### PR TITLE
Added support for command interception

### DIFF
--- a/Source/Source/Yamo/DbContext.vb
+++ b/Source/Source/Yamo/DbContext.vb
@@ -1,3 +1,4 @@
+Imports System.Data.Common
 Imports Yamo.Expressions
 Imports Yamo.Infrastructure
 Imports Yamo.Internal
@@ -58,10 +59,17 @@ Public Class DbContext
     m_Database = New DatabaseFacade(Me)
   End Sub
 
+  Friend Sub NotifyCommandExecution(command As DbCommand)
+    OnCommandExecuting(command)
+  End Sub
+
   Protected Overridable Sub OnConfiguring(optionsBuilder As DbContextOptionsBuilder)
   End Sub
 
   Protected Overridable Sub OnModelCreating(modelBuilder As ModelBuilder)
+  End Sub
+
+  Protected Overridable Sub OnCommandExecuting(command As DbCommand)
   End Sub
 
   Public Function From(Of T)() As SelectSqlExpression(Of T)

--- a/Source/Source/Yamo/Internal/Query/QueryExecutor.vb
+++ b/Source/Source/Yamo/Internal/Query/QueryExecutor.vb
@@ -83,6 +83,8 @@ Namespace Internal.Query
         command.Parameters.Add(parameter)
       Next
 
+      m_DbContext.NotifyCommandExecution(command)
+
       Return command
     End Function
 

--- a/Source/Test/Yamo.SQLite.Test/SQLiteTestDbContext.vb
+++ b/Source/Test/Yamo.SQLite.Test/SQLiteTestDbContext.vb
@@ -1,4 +1,5 @@
-﻿Imports Microsoft.Data.Sqlite
+﻿Imports System.Data.Common
+Imports Microsoft.Data.Sqlite
 Imports Yamo.Test
 
 Public Class SQLiteTestDbContext
@@ -12,6 +13,10 @@ Public Class SQLiteTestDbContext
 
   Protected Overrides Sub OnConfiguring(optionsBuilder As DbContextOptionsBuilder)
     optionsBuilder.UseSQLite(m_Connection)
+  End Sub
+
+  Protected Overrides Sub OnCommandExecuting(command As DbCommand)
+
   End Sub
 
 End Class

--- a/Source/Test/Yamo.SqlServer.Test/SqlServerTestDbContext.vb
+++ b/Source/Test/Yamo.SqlServer.Test/SqlServerTestDbContext.vb
@@ -1,4 +1,5 @@
-﻿Imports System.Data.SqlClient
+﻿Imports System.Data.Common
+Imports System.Data.SqlClient
 Imports Yamo.Test
 
 Public Class SqlServerTestDbContext
@@ -12,6 +13,10 @@ Public Class SqlServerTestDbContext
 
   Protected Overrides Sub OnConfiguring(optionsBuilder As DbContextOptionsBuilder)
     optionsBuilder.UseSqlServer(m_Connection)
+  End Sub
+
+  Protected Overrides Sub OnCommandExecuting(command As DbCommand)
+
   End Sub
 
 End Class


### PR DESCRIPTION
To intercept command, override `OnCommandExecuting` method in `DbContext`.