### PR TITLE
Added support for limiting rows returned by the query

### DIFF
--- a/Source/Samples/Yamo.PlaygroundCS/Program.cs
+++ b/Source/Samples/Yamo.PlaygroundCS/Program.cs
@@ -53,6 +53,7 @@ namespace Yamo.PlaygroundCS
             //Test32();
             //Test33();
             //Test34();
+            //Test35();
         }
 
         public static MyContext CreateContext()
@@ -647,6 +648,26 @@ namespace Yamo.PlaygroundCS
                     LEFT JOIN Label AS le ON a.Id = le.Id AND le.Language = 'en'
                     LEFT JOIN Label AS lg ON a.Id = lg.Id AND lg.Language = 'ger'
                     WHERE a.Id = 1");
+            }
+        }
+
+        public static void Test35()
+        {
+            using (var db = CreateContext())
+            {
+                // get 3 most expensive articles
+                var articles = db.From<Article>()
+                                 .OrderByDescending(a => a.Price)
+                                 .Limit(3)
+                                 .SelectAll()
+                                 .ToList();
+
+                // get second and third cheapest article
+                var article = db.From<Article>()
+                                .OrderBy(a => a.Price)
+                                .Limit(1, 2)
+                                .SelectAll()
+                                .ToList();
             }
         }
 

--- a/Source/Samples/Yamo.PlaygroundCS/Program.cs
+++ b/Source/Samples/Yamo.PlaygroundCS/Program.cs
@@ -656,18 +656,18 @@ namespace Yamo.PlaygroundCS
             using (var db = CreateContext())
             {
                 // get 3 most expensive articles
-                var articles = db.From<Article>()
+                var articles1 = db.From<Article>()
                                  .OrderByDescending(a => a.Price)
                                  .Limit(3)
                                  .SelectAll()
                                  .ToList();
 
                 // get second and third cheapest article
-                var article = db.From<Article>()
-                                .OrderBy(a => a.Price)
-                                .Limit(1, 2)
-                                .SelectAll()
-                                .ToList();
+                var articles2 = db.From<Article>()
+                                  .OrderBy(a => a.Price)
+                                  .Limit(1, 2)
+                                  .SelectAll()
+                                  .ToList();
             }
         }
 

--- a/Source/Source/Yamo.SQLite/Infrastructure/SQLiteDialectProvider.vb
+++ b/Source/Source/Yamo.SQLite/Infrastructure/SQLiteDialectProvider.vb
@@ -25,6 +25,7 @@ Namespace Infrastructure
       Me.ValueTypeReaderFactory = New ValueTypeReaderFactory
       Me.EntityReaderFactory = New EntityReaderFactory
       Me.DbValueConversion = New SQLiteDbValueConversion
+      Me.SupportedLimitType = LimitType.Limit
       RegisterInternalSqlHelper(New Sql.InternalDateDiff)
     End Sub
 

--- a/Source/Source/Yamo.SqlServer/Infrastructure/SqlServerDialectProvider.vb
+++ b/Source/Source/Yamo.SqlServer/Infrastructure/SqlServerDialectProvider.vb
@@ -25,6 +25,7 @@ Namespace Infrastructure
       Me.ValueTypeReaderFactory = New ValueTypeReaderFactory
       Me.EntityReaderFactory = New EntityReaderFactory
       Me.DbValueConversion = New DbValueConversion
+      Me.SupportedLimitType = LimitType.Top Or LimitType.OffsetFetch
       RegisterInternalSqlHelper(New Sql.InternalDateDiff)
     End Sub
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpression.vb
@@ -114,6 +114,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of the table (entity).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2.vb
@@ -240,6 +240,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3.vb
@@ -289,6 +289,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4.vb
@@ -320,6 +320,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5.vb
@@ -369,6 +369,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6.vb
@@ -418,6 +418,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
@@ -467,6 +467,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
@@ -122,6 +122,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
@@ -123,6 +123,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
@@ -124,6 +124,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
@@ -125,6 +125,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
@@ -126,6 +126,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
@@ -127,6 +127,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
@@ -128,6 +128,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
@@ -129,6 +129,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpression.vb
@@ -101,6 +101,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of the table (entity).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2.vb
@@ -197,6 +197,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3.vb
@@ -236,6 +236,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4.vb
@@ -257,6 +257,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5.vb
@@ -296,6 +296,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6.vb
@@ -335,6 +335,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
@@ -373,6 +373,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
@@ -108,6 +108,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
@@ -109,6 +109,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
@@ -110,6 +110,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
@@ -111,6 +111,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
@@ -112,6 +112,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
@@ -113,6 +113,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
@@ -114,6 +114,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
@@ -115,6 +115,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpression.vb
@@ -92,6 +92,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of the table (entity).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2.vb
@@ -188,6 +188,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3.vb
@@ -227,6 +227,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4.vb
@@ -248,6 +248,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5.vb
@@ -287,6 +287,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6.vb
@@ -326,6 +326,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
@@ -365,6 +365,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
@@ -100,6 +100,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
@@ -101,6 +101,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
@@ -102,6 +102,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
@@ -103,6 +103,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
@@ -104,6 +104,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
@@ -105,6 +105,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
@@ -106,6 +106,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
@@ -107,6 +107,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpression.vb
@@ -1,0 +1,74 @@
+﻿Imports System.Linq.Expressions
+Imports Yamo.Expressions.Builders
+Imports Yamo.Internal.Query
+
+Namespace Expressions
+
+  ''' <summary>
+  ''' Represents LIMIT/TOP/OFFSET FETCH clause in SQL SELECT statement.
+  ''' </summary>
+  ''' <typeparam name="T"></typeparam>
+  Public Class LimitedSelectSqlExpression(Of T)
+    Inherits SelectSqlExpressionBase
+
+    ''' <summary>
+    ''' Creates new instance of <see cref="LimitedSelectSqlExpression(Of T)"/>.
+    ''' </summary>
+    ''' <param name="builder"></param>
+    ''' <param name="executor"></param>
+    Friend Sub New(builder As SelectSqlExpressionBuilder, executor As QueryExecutor)
+      MyBase.New(builder, executor)
+    End Sub
+
+    ''' <summary>
+    ''' Adds SELECT clause with all columns of the table (entity).
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function SelectAll() As SelectedSelectSqlExpression(Of T)
+      Me.Builder.AddSelectAll(GetType(T))
+      Return New SelectedSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT COUNT(*) clause, executes SQL query and returns the result.
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function SelectCount() As Int32
+      Me.Builder.AddSelectCount()
+      Dim query = Me.Builder.CreateQuery()
+      Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Executes SQL query and returns first record or a default value.
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function FirstOrDefault() As T
+      Dim query = Me.Builder.CreateQuery()
+      Return Me.Executor.ReadFirstOrDefault(Of T)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <param name="entityIndexHints"></param>
+    ''' <returns></returns>
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints)
+      Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
+    End Function
+
+  End Class
+End Namespace

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2.vb
@@ -1,0 +1,96 @@
+﻿Imports System.Linq.Expressions
+Imports Yamo.Expressions.Builders
+Imports Yamo.Internal.Query
+
+Namespace Expressions
+
+  ''' <summary>
+  ''' Represents LIMIT/TOP/OFFSET FETCH clause in SQL SELECT statement.
+  ''' </summary>
+  ''' <typeparam name="T1"></typeparam>
+  ''' <typeparam name="T2"></typeparam>
+  Public Class LimitedSelectSqlExpression(Of T1, T2)
+    Inherits SelectSqlExpressionBase
+
+    ''' <summary>
+    ''' Creates new instance of <see cref="LimitedSelectSqlExpression(Of T1, T2)"/>.
+    ''' </summary>
+    ''' <param name="builder"></param>
+    ''' <param name="executor"></param>
+    Friend Sub New(builder As SelectSqlExpressionBuilder, executor As QueryExecutor)
+      MyBase.New(builder, executor)
+    End Sub
+
+    ''' <summary>
+    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2)
+      Me.Builder.AddSelectAll(GetType(T1), GetType(T2))
+      Return New SelectedSelectSqlExpression(Of T1, T2)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT COUNT(*) clause, executes SQL query and returns the result.
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function SelectCount() As Int32
+      Me.Builder.AddSelectCount()
+      Dim query = Me.Builder.CreateQuery()
+      Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0, 1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of Join(Of T1, T2), TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <param name="entityIndexHints"></param>
+    ''' <returns></returns>
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints)
+      Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
+    End Function
+
+  End Class
+End Namespace

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3.vb
@@ -1,0 +1,107 @@
+﻿Imports System.Linq.Expressions
+Imports Yamo.Expressions.Builders
+Imports Yamo.Internal.Query
+
+Namespace Expressions
+
+  ''' <summary>
+  ''' Represents LIMIT/TOP/OFFSET FETCH clause in SQL SELECT statement.
+  ''' </summary>
+  ''' <typeparam name="T1"></typeparam>
+  ''' <typeparam name="T2"></typeparam>
+  ''' <typeparam name="T3"></typeparam>
+  Public Class LimitedSelectSqlExpression(Of T1, T2, T3)
+    Inherits SelectSqlExpressionBase
+
+    ''' <summary>
+    ''' Creates new instance of <see cref="LimitedSelectSqlExpression(Of T1, T2, T3)"/>.
+    ''' </summary>
+    ''' <param name="builder"></param>
+    ''' <param name="executor"></param>
+    Friend Sub New(builder As SelectSqlExpressionBuilder, executor As QueryExecutor)
+      MyBase.New(builder, executor)
+    End Sub
+
+    ''' <summary>
+    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3)
+      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3))
+      Return New SelectedSelectSqlExpression(Of T1, T2, T3)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT COUNT(*) clause, executes SQL query and returns the result.
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function SelectCount() As Int32
+      Me.Builder.AddSelectCount()
+      Dim query = Me.Builder.CreateQuery()
+      Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, T2, T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0, 1, 2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of Join(Of T1, T2, T3), TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <param name="entityIndexHints"></param>
+    ''' <returns></returns>
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints)
+      Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
+    End Function
+
+  End Class
+End Namespace

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4.vb
@@ -1,0 +1,118 @@
+﻿Imports System.Linq.Expressions
+Imports Yamo.Expressions.Builders
+Imports Yamo.Internal.Query
+
+Namespace Expressions
+
+  ''' <summary>
+  ''' Represents LIMIT/TOP/OFFSET FETCH clause in SQL SELECT statement.
+  ''' </summary>
+  ''' <typeparam name="T1"></typeparam>
+  ''' <typeparam name="T2"></typeparam>
+  ''' <typeparam name="T3"></typeparam>
+  ''' <typeparam name="T4"></typeparam>
+  Public Class LimitedSelectSqlExpression(Of T1, T2, T3, T4)
+    Inherits SelectSqlExpressionBase
+
+    ''' <summary>
+    ''' Creates new instance of <see cref="LimitedSelectSqlExpression(Of T1, T2, T3, T4)"/>.
+    ''' </summary>
+    ''' <param name="builder"></param>
+    ''' <param name="executor"></param>
+    Friend Sub New(builder As SelectSqlExpressionBuilder, executor As QueryExecutor)
+      MyBase.New(builder, executor)
+    End Sub
+
+    ''' <summary>
+    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
+      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4))
+      Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT COUNT(*) clause, executes SQL query and returns the result.
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function SelectCount() As Int32
+      Me.Builder.AddSelectCount()
+      Dim query = Me.Builder.CreateQuery()
+      Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, T2, T3, T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0, 1, 2, 3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4), TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <param name="entityIndexHints"></param>
+    ''' <returns></returns>
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints)
+      Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
+    End Function
+
+  End Class
+End Namespace

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5.vb
@@ -1,0 +1,129 @@
+﻿Imports System.Linq.Expressions
+Imports Yamo.Expressions.Builders
+Imports Yamo.Internal.Query
+
+Namespace Expressions
+
+  ''' <summary>
+  ''' Represents LIMIT/TOP/OFFSET FETCH clause in SQL SELECT statement.
+  ''' </summary>
+  ''' <typeparam name="T1"></typeparam>
+  ''' <typeparam name="T2"></typeparam>
+  ''' <typeparam name="T3"></typeparam>
+  ''' <typeparam name="T4"></typeparam>
+  ''' <typeparam name="T5"></typeparam>
+  Public Class LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+    Inherits SelectSqlExpressionBase
+
+    ''' <summary>
+    ''' Creates new instance of <see cref="LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5)"/>.
+    ''' </summary>
+    ''' <param name="builder"></param>
+    ''' <param name="executor"></param>
+    Friend Sub New(builder As SelectSqlExpressionBuilder, executor As QueryExecutor)
+      MyBase.New(builder, executor)
+    End Sub
+
+    ''' <summary>
+    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5))
+      Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT COUNT(*) clause, executes SQL query and returns the result.
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function SelectCount() As Int32
+      Me.Builder.AddSelectCount()
+      Dim query = Me.Builder.CreateQuery()
+      Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, T2, T3, T4, T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0, 1, 2, 3, 4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5), TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <param name="entityIndexHints"></param>
+    ''' <returns></returns>
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints)
+      Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
+    End Function
+
+  End Class
+End Namespace

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6.vb
@@ -1,0 +1,140 @@
+﻿Imports System.Linq.Expressions
+Imports Yamo.Expressions.Builders
+Imports Yamo.Internal.Query
+
+Namespace Expressions
+
+  ''' <summary>
+  ''' Represents LIMIT/TOP/OFFSET FETCH clause in SQL SELECT statement.
+  ''' </summary>
+  ''' <typeparam name="T1"></typeparam>
+  ''' <typeparam name="T2"></typeparam>
+  ''' <typeparam name="T3"></typeparam>
+  ''' <typeparam name="T4"></typeparam>
+  ''' <typeparam name="T5"></typeparam>
+  ''' <typeparam name="T6"></typeparam>
+  Public Class LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+    Inherits SelectSqlExpressionBase
+
+    ''' <summary>
+    ''' Creates new instance of <see cref="LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)"/>.
+    ''' </summary>
+    ''' <param name="builder"></param>
+    ''' <param name="executor"></param>
+    Friend Sub New(builder As SelectSqlExpressionBuilder, executor As QueryExecutor)
+      MyBase.New(builder, executor)
+    End Sub
+
+    ''' <summary>
+    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6))
+      Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT COUNT(*) clause, executes SQL query and returns the result.
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function SelectCount() As Int32
+      Me.Builder.AddSelectCount()
+      Dim query = Me.Builder.CreateQuery()
+      Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, T2, T3, T4, T5, T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0, 1, 2, 3, 4, 5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6), TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <param name="entityIndexHints"></param>
+    ''' <returns></returns>
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints)
+      Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
+    End Function
+
+  End Class
+End Namespace

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
@@ -1,0 +1,151 @@
+﻿Imports System.Linq.Expressions
+Imports Yamo.Expressions.Builders
+Imports Yamo.Internal.Query
+
+Namespace Expressions
+
+  ''' <summary>
+  ''' Represents LIMIT/TOP/OFFSET FETCH clause in SQL SELECT statement.
+  ''' </summary>
+  ''' <typeparam name="T1"></typeparam>
+  ''' <typeparam name="T2"></typeparam>
+  ''' <typeparam name="T3"></typeparam>
+  ''' <typeparam name="T4"></typeparam>
+  ''' <typeparam name="T5"></typeparam>
+  ''' <typeparam name="T6"></typeparam>
+  ''' <typeparam name="T7"></typeparam>
+  Public Class LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+    Inherits SelectSqlExpressionBase
+
+    ''' <summary>
+    ''' Creates new instance of <see cref="LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)"/>.
+    ''' </summary>
+    ''' <param name="builder"></param>
+    ''' <param name="executor"></param>
+    Friend Sub New(builder As SelectSqlExpressionBuilder, executor As QueryExecutor)
+      MyBase.New(builder, executor)
+    End Sub
+
+    ''' <summary>
+    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7))
+      Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT COUNT(*) clause, executes SQL query and returns the result.
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function SelectCount() As Int32
+      Me.Builder.AddSelectCount()
+      Dim query = Me.Builder.CreateQuery()
+      Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T2, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {1})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T3, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {2})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T4, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {3})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T5, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {4})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T6, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {5})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of T1, T2, T3, T4, T5, T6, T7, TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, {0, 1, 2, 3, 4, 5, 6})
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7), TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <param name="entityIndexHints"></param>
+    ''' <returns></returns>
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints)
+      Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
+    End Function
+
+  End Class
+End Namespace

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
@@ -1,0 +1,72 @@
+﻿Imports System.Linq.Expressions
+Imports Yamo.Expressions.Builders
+Imports Yamo.Internal.Query
+
+Namespace Expressions
+
+  ''' <summary>
+  ''' Represents LIMIT/TOP/OFFSET FETCH clause in SQL SELECT statement.
+  ''' </summary>
+  ''' <typeparam name="T1"></typeparam>
+  ''' <typeparam name="T2"></typeparam>
+  ''' <typeparam name="T3"></typeparam>
+  ''' <typeparam name="T4"></typeparam>
+  ''' <typeparam name="T5"></typeparam>
+  ''' <typeparam name="T6"></typeparam>
+  ''' <typeparam name="T7"></typeparam>
+  ''' <typeparam name="T8"></typeparam>
+  Public Class LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+    Inherits SelectSqlExpressionBase
+
+    ''' <summary>
+    ''' Creates new instance of <see cref="LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)"/>.
+    ''' </summary>
+    ''' <param name="builder"></param>
+    ''' <param name="executor"></param>
+    Friend Sub New(builder As SelectSqlExpressionBuilder, executor As QueryExecutor)
+      MyBase.New(builder, executor)
+    End Sub
+
+    ''' <summary>
+    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8))
+      Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT COUNT(*) clause, executes SQL query and returns the result.
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function SelectCount() As Int32
+      Me.Builder.AddSelectCount()
+      Dim query = Me.Builder.CreateQuery()
+      Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8), TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <param name="entityIndexHints"></param>
+    ''' <returns></returns>
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints)
+      Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
+    End Function
+
+  End Class
+End Namespace

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
@@ -1,0 +1,73 @@
+﻿Imports System.Linq.Expressions
+Imports Yamo.Expressions.Builders
+Imports Yamo.Internal.Query
+
+Namespace Expressions
+
+  ''' <summary>
+  ''' Represents LIMIT/TOP/OFFSET FETCH clause in SQL SELECT statement.
+  ''' </summary>
+  ''' <typeparam name="T1"></typeparam>
+  ''' <typeparam name="T2"></typeparam>
+  ''' <typeparam name="T3"></typeparam>
+  ''' <typeparam name="T4"></typeparam>
+  ''' <typeparam name="T5"></typeparam>
+  ''' <typeparam name="T6"></typeparam>
+  ''' <typeparam name="T7"></typeparam>
+  ''' <typeparam name="T8"></typeparam>
+  ''' <typeparam name="T9"></typeparam>
+  Public Class LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+    Inherits SelectSqlExpressionBase
+
+    ''' <summary>
+    ''' Creates new instance of <see cref="LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)"/>.
+    ''' </summary>
+    ''' <param name="builder"></param>
+    ''' <param name="executor"></param>
+    Friend Sub New(builder As SelectSqlExpressionBuilder, executor As QueryExecutor)
+      MyBase.New(builder, executor)
+    End Sub
+
+    ''' <summary>
+    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9))
+      Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT COUNT(*) clause, executes SQL query and returns the result.
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function SelectCount() As Int32
+      Me.Builder.AddSelectCount()
+      Dim query = Me.Builder.CreateQuery()
+      Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9), TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <param name="entityIndexHints"></param>
+    ''' <returns></returns>
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints)
+      Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
+    End Function
+
+  End Class
+End Namespace

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
@@ -1,0 +1,74 @@
+﻿Imports System.Linq.Expressions
+Imports Yamo.Expressions.Builders
+Imports Yamo.Internal.Query
+
+Namespace Expressions
+
+  ''' <summary>
+  ''' Represents LIMIT/TOP/OFFSET FETCH clause in SQL SELECT statement.
+  ''' </summary>
+  ''' <typeparam name="T1"></typeparam>
+  ''' <typeparam name="T2"></typeparam>
+  ''' <typeparam name="T3"></typeparam>
+  ''' <typeparam name="T4"></typeparam>
+  ''' <typeparam name="T5"></typeparam>
+  ''' <typeparam name="T6"></typeparam>
+  ''' <typeparam name="T7"></typeparam>
+  ''' <typeparam name="T8"></typeparam>
+  ''' <typeparam name="T9"></typeparam>
+  ''' <typeparam name="T10"></typeparam>
+  Public Class LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+    Inherits SelectSqlExpressionBase
+
+    ''' <summary>
+    ''' Creates new instance of <see cref="LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)"/>.
+    ''' </summary>
+    ''' <param name="builder"></param>
+    ''' <param name="executor"></param>
+    Friend Sub New(builder As SelectSqlExpressionBuilder, executor As QueryExecutor)
+      MyBase.New(builder, executor)
+    End Sub
+
+    ''' <summary>
+    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10))
+      Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT COUNT(*) clause, executes SQL query and returns the result.
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function SelectCount() As Int32
+      Me.Builder.AddSelectCount()
+      Dim query = Me.Builder.CreateQuery()
+      Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10), TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <param name="entityIndexHints"></param>
+    ''' <returns></returns>
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints)
+      Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
+    End Function
+
+  End Class
+End Namespace

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
@@ -1,0 +1,75 @@
+﻿Imports System.Linq.Expressions
+Imports Yamo.Expressions.Builders
+Imports Yamo.Internal.Query
+
+Namespace Expressions
+
+  ''' <summary>
+  ''' Represents LIMIT/TOP/OFFSET FETCH clause in SQL SELECT statement.
+  ''' </summary>
+  ''' <typeparam name="T1"></typeparam>
+  ''' <typeparam name="T2"></typeparam>
+  ''' <typeparam name="T3"></typeparam>
+  ''' <typeparam name="T4"></typeparam>
+  ''' <typeparam name="T5"></typeparam>
+  ''' <typeparam name="T6"></typeparam>
+  ''' <typeparam name="T7"></typeparam>
+  ''' <typeparam name="T8"></typeparam>
+  ''' <typeparam name="T9"></typeparam>
+  ''' <typeparam name="T10"></typeparam>
+  ''' <typeparam name="T11"></typeparam>
+  Public Class LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+    Inherits SelectSqlExpressionBase
+
+    ''' <summary>
+    ''' Creates new instance of <see cref="LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)"/>.
+    ''' </summary>
+    ''' <param name="builder"></param>
+    ''' <param name="executor"></param>
+    Friend Sub New(builder As SelectSqlExpressionBuilder, executor As QueryExecutor)
+      MyBase.New(builder, executor)
+    End Sub
+
+    ''' <summary>
+    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11))
+      Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT COUNT(*) clause, executes SQL query and returns the result.
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function SelectCount() As Int32
+      Me.Builder.AddSelectCount()
+      Dim query = Me.Builder.CreateQuery()
+      Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11), TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <param name="entityIndexHints"></param>
+    ''' <returns></returns>
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints)
+      Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
+    End Function
+
+  End Class
+End Namespace

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
@@ -1,0 +1,76 @@
+﻿Imports System.Linq.Expressions
+Imports Yamo.Expressions.Builders
+Imports Yamo.Internal.Query
+
+Namespace Expressions
+
+  ''' <summary>
+  ''' Represents LIMIT/TOP/OFFSET FETCH clause in SQL SELECT statement.
+  ''' </summary>
+  ''' <typeparam name="T1"></typeparam>
+  ''' <typeparam name="T2"></typeparam>
+  ''' <typeparam name="T3"></typeparam>
+  ''' <typeparam name="T4"></typeparam>
+  ''' <typeparam name="T5"></typeparam>
+  ''' <typeparam name="T6"></typeparam>
+  ''' <typeparam name="T7"></typeparam>
+  ''' <typeparam name="T8"></typeparam>
+  ''' <typeparam name="T9"></typeparam>
+  ''' <typeparam name="T10"></typeparam>
+  ''' <typeparam name="T11"></typeparam>
+  ''' <typeparam name="T12"></typeparam>
+  Public Class LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+    Inherits SelectSqlExpressionBase
+
+    ''' <summary>
+    ''' Creates new instance of <see cref="LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)"/>.
+    ''' </summary>
+    ''' <param name="builder"></param>
+    ''' <param name="executor"></param>
+    Friend Sub New(builder As SelectSqlExpressionBuilder, executor As QueryExecutor)
+      MyBase.New(builder, executor)
+    End Sub
+
+    ''' <summary>
+    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12))
+      Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT COUNT(*) clause, executes SQL query and returns the result.
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function SelectCount() As Int32
+      Me.Builder.AddSelectCount()
+      Dim query = Me.Builder.CreateQuery()
+      Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12), TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <param name="entityIndexHints"></param>
+    ''' <returns></returns>
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints)
+      Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
+    End Function
+
+  End Class
+End Namespace

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
@@ -1,0 +1,77 @@
+﻿Imports System.Linq.Expressions
+Imports Yamo.Expressions.Builders
+Imports Yamo.Internal.Query
+
+Namespace Expressions
+
+  ''' <summary>
+  ''' Represents LIMIT/TOP/OFFSET FETCH clause in SQL SELECT statement.
+  ''' </summary>
+  ''' <typeparam name="T1"></typeparam>
+  ''' <typeparam name="T2"></typeparam>
+  ''' <typeparam name="T3"></typeparam>
+  ''' <typeparam name="T4"></typeparam>
+  ''' <typeparam name="T5"></typeparam>
+  ''' <typeparam name="T6"></typeparam>
+  ''' <typeparam name="T7"></typeparam>
+  ''' <typeparam name="T8"></typeparam>
+  ''' <typeparam name="T9"></typeparam>
+  ''' <typeparam name="T10"></typeparam>
+  ''' <typeparam name="T11"></typeparam>
+  ''' <typeparam name="T12"></typeparam>
+  ''' <typeparam name="T13"></typeparam>
+  Public Class LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+    Inherits SelectSqlExpressionBase
+
+    ''' <summary>
+    ''' Creates new instance of <see cref="LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)"/>.
+    ''' </summary>
+    ''' <param name="builder"></param>
+    ''' <param name="executor"></param>
+    Friend Sub New(builder As SelectSqlExpressionBuilder, executor As QueryExecutor)
+      MyBase.New(builder, executor)
+    End Sub
+
+    ''' <summary>
+    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13))
+      Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT COUNT(*) clause, executes SQL query and returns the result.
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function SelectCount() As Int32
+      Me.Builder.AddSelectCount()
+      Dim query = Me.Builder.CreateQuery()
+      Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13), TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <param name="entityIndexHints"></param>
+    ''' <returns></returns>
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints)
+      Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
+    End Function
+
+  End Class
+End Namespace

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
@@ -1,0 +1,78 @@
+﻿Imports System.Linq.Expressions
+Imports Yamo.Expressions.Builders
+Imports Yamo.Internal.Query
+
+Namespace Expressions
+
+  ''' <summary>
+  ''' Represents LIMIT/TOP/OFFSET FETCH clause in SQL SELECT statement.
+  ''' </summary>
+  ''' <typeparam name="T1"></typeparam>
+  ''' <typeparam name="T2"></typeparam>
+  ''' <typeparam name="T3"></typeparam>
+  ''' <typeparam name="T4"></typeparam>
+  ''' <typeparam name="T5"></typeparam>
+  ''' <typeparam name="T6"></typeparam>
+  ''' <typeparam name="T7"></typeparam>
+  ''' <typeparam name="T8"></typeparam>
+  ''' <typeparam name="T9"></typeparam>
+  ''' <typeparam name="T10"></typeparam>
+  ''' <typeparam name="T11"></typeparam>
+  ''' <typeparam name="T12"></typeparam>
+  ''' <typeparam name="T13"></typeparam>
+  ''' <typeparam name="T14"></typeparam>
+  Public Class LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+    Inherits SelectSqlExpressionBase
+
+    ''' <summary>
+    ''' Creates new instance of <see cref="LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)"/>.
+    ''' </summary>
+    ''' <param name="builder"></param>
+    ''' <param name="executor"></param>
+    Friend Sub New(builder As SelectSqlExpressionBuilder, executor As QueryExecutor)
+      MyBase.New(builder, executor)
+    End Sub
+
+    ''' <summary>
+    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14))
+      Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT COUNT(*) clause, executes SQL query and returns the result.
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function SelectCount() As Int32
+      Me.Builder.AddSelectCount()
+      Dim query = Me.Builder.CreateQuery()
+      Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14), TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <param name="entityIndexHints"></param>
+    ''' <returns></returns>
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints)
+      Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
+    End Function
+
+  End Class
+End Namespace

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
@@ -1,0 +1,79 @@
+﻿Imports System.Linq.Expressions
+Imports Yamo.Expressions.Builders
+Imports Yamo.Internal.Query
+
+Namespace Expressions
+
+  ''' <summary>
+  ''' Represents LIMIT/TOP/OFFSET FETCH clause in SQL SELECT statement.
+  ''' </summary>
+  ''' <typeparam name="T1"></typeparam>
+  ''' <typeparam name="T2"></typeparam>
+  ''' <typeparam name="T3"></typeparam>
+  ''' <typeparam name="T4"></typeparam>
+  ''' <typeparam name="T5"></typeparam>
+  ''' <typeparam name="T6"></typeparam>
+  ''' <typeparam name="T7"></typeparam>
+  ''' <typeparam name="T8"></typeparam>
+  ''' <typeparam name="T9"></typeparam>
+  ''' <typeparam name="T10"></typeparam>
+  ''' <typeparam name="T11"></typeparam>
+  ''' <typeparam name="T12"></typeparam>
+  ''' <typeparam name="T13"></typeparam>
+  ''' <typeparam name="T14"></typeparam>
+  ''' <typeparam name="T15"></typeparam>
+  Public Class LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+    Inherits SelectSqlExpressionBase
+
+    ''' <summary>
+    ''' Creates new instance of <see cref="LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)"/>.
+    ''' </summary>
+    ''' <param name="builder"></param>
+    ''' <param name="executor"></param>
+    Friend Sub New(builder As SelectSqlExpressionBuilder, executor As QueryExecutor)
+      MyBase.New(builder, executor)
+    End Sub
+
+    ''' <summary>
+    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15))
+      Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT COUNT(*) clause, executes SQL query and returns the result.
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function SelectCount() As Int32
+      Me.Builder.AddSelectCount()
+      Dim query = Me.Builder.CreateQuery()
+      Return Me.Executor.QueryFirstOrDefault(Of Int32)(query)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <returns></returns>
+    Public Function [Select](Of TResult)(selector As Expression(Of Func(Of Join(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15), TResult))) As CustomSelectSqlExpression(Of TResult)
+      Return InternalSelect(Of TResult)(selector, Nothing)
+    End Function
+
+    ''' <summary>
+    ''' Adds SELECT clause with custom columns selection.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="selector"></param>
+    ''' <param name="entityIndexHints"></param>
+    ''' <returns></returns>
+    Private Function InternalSelect(Of TResult)(selector As Expression, entityIndexHints As Int32()) As CustomSelectSqlExpression(Of TResult)
+      Me.Builder.AddSelect(selector, entityIndexHints)
+      Return New CustomSelectSqlExpression(Of TResult)(Me.Builder, Me.Executor)
+    End Function
+
+  End Class
+End Namespace

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpression.vb
@@ -53,6 +53,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of the table (entity).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2.vb
@@ -95,6 +95,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3.vb
@@ -116,6 +116,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4.vb
@@ -137,6 +137,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5.vb
@@ -158,6 +158,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6.vb
@@ -179,6 +179,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
@@ -200,6 +200,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
@@ -61,6 +61,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
@@ -62,6 +62,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
@@ -63,6 +63,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
@@ -64,6 +64,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
@@ -65,6 +65,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
@@ -66,6 +66,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
@@ -67,6 +67,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
@@ -68,6 +68,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/SelectSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpression.vb
@@ -225,6 +225,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of the table (entity).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2.vb
@@ -431,6 +431,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3.vb
@@ -480,6 +480,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4.vb
@@ -551,6 +551,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5.vb
@@ -640,6 +640,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6.vb
@@ -729,6 +729,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7.vb
@@ -538,6 +538,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
@@ -193,6 +193,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
@@ -194,6 +194,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
@@ -195,6 +195,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
@@ -196,6 +196,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
@@ -197,6 +197,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
@@ -198,6 +198,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
@@ -199,6 +199,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
@@ -137,6 +137,36 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalLimit(Nothing, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Public Function Limit(offset As Int32, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Return InternalLimit(offset, count)
+    End Function
+
+    ''' <summary>
+    ''' Adds clause to limit rows returned by the query. Depending on the database, LIMIT, TOP or OFFSET FETCH clause is used.
+    ''' </summary>
+    ''' <param name="offset"></param>
+    ''' <param name="count"></param>
+    ''' <returns></returns>
+    Private Function InternalLimit(offset As Int32?, count As Int32) As LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Me.Builder.AddLimit(offset, count)
+      Return New LimitedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Adds SELECT clause with all columns of all tables (entities).
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Infrastructure/LimitType.vb
+++ b/Source/Source/Yamo/Infrastructure/LimitType.vb
@@ -1,0 +1,14 @@
+﻿Namespace Infrastructure
+
+  ''' <summary>
+  ''' Supported limit clause type.<br/>
+  ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+  ''' </summary>
+  <Flags>
+  Public Enum LimitType
+    Limit = 1
+    Top = 2
+    OffsetFetch = 4
+  End Enum
+
+End Namespace

--- a/Source/Source/Yamo/Infrastructure/SqlDialectProvider.vb
+++ b/Source/Source/Yamo/Infrastructure/SqlDialectProvider.vb
@@ -83,6 +83,20 @@ Namespace Infrastructure
       End Set
     End Property
 
+    Private m_SupportedLimitType As LimitType
+    ''' <summary>
+    ''' Gets or sets supported limit clause type
+    ''' </summary>
+    ''' <returns></returns>
+    Public Property SupportedLimitType() As LimitType
+      Get
+        Return m_SupportedLimitType
+      End Get
+      Protected Set(ByVal value As LimitType)
+        m_SupportedLimitType = value
+      End Set
+    End Property
+
     ''' <summary>
     ''' Stores internal SQL helpers.
     ''' </summary>

--- a/Source/Test/Yamo.SQLite.Test/Tests/SelectWithLimitTests.vb
+++ b/Source/Test/Yamo.SQLite.Test/Tests/SelectWithLimitTests.vb
@@ -1,0 +1,14 @@
+﻿Imports Yamo.Test
+
+Namespace Tests
+
+  <TestClass()>
+  Public Class SelectWithLimitTests
+    Inherits Yamo.Test.Tests.SelectWithLimitTests
+
+    Protected Overrides Function CreateTestEnvironment() As ITestEnvironment
+      Return SQLiteTestEnvironment.Create()
+    End Function
+
+  End Class
+End Namespace

--- a/Source/Test/Yamo.SQLite.Test/Yamo.SQLite.Test.vbproj
+++ b/Source/Test/Yamo.SQLite.Test/Yamo.SQLite.Test.vbproj
@@ -104,6 +104,7 @@
     <Compile Include="Tests\ExecuteTests.vb" />
     <Compile Include="Tests\CustomSelectTests.vb" />
     <Compile Include="Tests\SelectTests.vb" />
+    <Compile Include="Tests\SelectWithLimitTests.vb" />
     <Compile Include="Tests\SqlHelperAggregateTests.vb" />
     <Compile Include="Tests\SqlHelperDateDiffTests.vb" />
     <Compile Include="Tests\SelectWithSqlStringConditionTests.vb" />

--- a/Source/Test/Yamo.SqlServer.Test/Tests/SelectWithLimitTests.vb
+++ b/Source/Test/Yamo.SqlServer.Test/Tests/SelectWithLimitTests.vb
@@ -1,0 +1,26 @@
+﻿Imports Yamo.Test
+
+Namespace Tests
+
+  <TestClass()>
+  Public Class SelectWithLimitTests
+    Inherits Yamo.Test.Tests.SelectWithLimitTests
+
+    Protected Overrides Function CreateTestEnvironment() As ITestEnvironment
+      Return SqlServerTestEnvironment.Create()
+    End Function
+
+    <TestMethod()>
+    Public Overrides Sub SelectUnorderedWithLimitAndOffset()
+      Try
+        MyBase.SelectUnorderedWithLimitAndOffset()
+        Assert.Fail()
+      Catch ex As Exception
+        If Not ex.Message.Contains("Incorrect syntax near 'OFFSET'.") Then
+          Assert.Fail(ex.Message)
+        End If
+      End Try
+    End Sub
+
+  End Class
+End Namespace

--- a/Source/Test/Yamo.SqlServer.Test/Yamo.SqlServer.Test.vbproj
+++ b/Source/Test/Yamo.SqlServer.Test/Yamo.SqlServer.Test.vbproj
@@ -85,6 +85,7 @@
     <Compile Include="Tests\SelectCountTests.vb" />
     <Compile Include="Tests\CustomSelectTests.vb" />
     <Compile Include="Tests\SelectTests.vb" />
+    <Compile Include="Tests\SelectWithLimitTests.vb" />
     <Compile Include="Tests\SqlHelperAggregateTests.vb" />
     <Compile Include="Tests\SqlHelperDateDiffTests.vb" />
     <Compile Include="Tests\SelectWithSqlStringConditionTests.vb" />

--- a/Source/Test/Yamo.Test/Model/ModelFactory.vb
+++ b/Source/Test/Yamo.Test/Model/ModelFactory.vb
@@ -9,6 +9,13 @@
       }
     End Function
 
+    Public Overridable Function CreateArticle(id As Int32, price As Decimal) As Article
+      Return New Article With {
+        .Id = id,
+        .Price = price
+      }
+    End Function
+
     Public Overridable Function CreateArticleCategory(articleId As Int32, categoryId As Int32) As ArticleCategory
       Return New ArticleCategory With {
         .ArticleId = articleId,

--- a/Source/Test/Yamo.Test/Tests/SelectWithLimitTests.vb
+++ b/Source/Test/Yamo.Test/Tests/SelectWithLimitTests.vb
@@ -1,0 +1,180 @@
+﻿Imports Yamo.Test.Model
+
+Namespace Tests
+
+  Public MustInherit Class SelectWithLimitTests
+    Inherits BaseIntegrationTests
+
+    Protected Const English As String = "en"
+
+    Protected Const German As String = "ger"
+
+    <TestMethod()>
+    Public Overridable Sub SelectOrderedWithLimit()
+      Dim article1 = Me.ModelFactory.CreateArticle(1, 10)
+      Dim article2 = Me.ModelFactory.CreateArticle(2, 20)
+      Dim article3 = Me.ModelFactory.CreateArticle(3, 30)
+      Dim article4 = Me.ModelFactory.CreateArticle(4, 40)
+      Dim article5 = Me.ModelFactory.CreateArticle(5, 50)
+      Dim article6 = Me.ModelFactory.CreateArticle(6, 60)
+      Dim article7 = Me.ModelFactory.CreateArticle(7, 70)
+
+      InsertItems(article1, article2, article3, article4, article5, article6, article7)
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        OrderBy(Function(x) x.Price).
+                        Limit(3).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(3, result.Count)
+        Assert.AreEqual(article1, result(0))
+        Assert.AreEqual(article2, result(1))
+        Assert.AreEqual(article3, result(2))
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectOrderedWithLimitAndOffset()
+      Dim article1 = Me.ModelFactory.CreateArticle(1, 10)
+      Dim article2 = Me.ModelFactory.CreateArticle(2, 20)
+      Dim article3 = Me.ModelFactory.CreateArticle(3, 30)
+      Dim article4 = Me.ModelFactory.CreateArticle(4, 40)
+      Dim article5 = Me.ModelFactory.CreateArticle(5, 50)
+      Dim article6 = Me.ModelFactory.CreateArticle(6, 60)
+      Dim article7 = Me.ModelFactory.CreateArticle(7, 70)
+
+      InsertItems(article1, article2, article3, article4, article5, article6, article7)
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        OrderBy(Function(x) x.Price).
+                        Limit(3, 2).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(2, result.Count)
+        Assert.AreEqual(article4, result(0))
+        Assert.AreEqual(article5, result(1))
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectUnorderedWithLimit()
+      Dim article1 = Me.ModelFactory.CreateArticle(1, 10)
+      Dim article2 = Me.ModelFactory.CreateArticle(2, 20)
+      Dim article3 = Me.ModelFactory.CreateArticle(3, 30)
+      Dim article4 = Me.ModelFactory.CreateArticle(4, 40)
+      Dim article5 = Me.ModelFactory.CreateArticle(5, 50)
+      Dim article6 = Me.ModelFactory.CreateArticle(6, 60)
+      Dim article7 = Me.ModelFactory.CreateArticle(7, 70)
+
+      InsertItems(article1, article2, article3, article4, article5, article6, article7)
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        Limit(3).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(3, result.Count)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectUnorderedWithLimitAndOffset()
+      Dim article1 = Me.ModelFactory.CreateArticle(1, 10)
+      Dim article2 = Me.ModelFactory.CreateArticle(2, 20)
+      Dim article3 = Me.ModelFactory.CreateArticle(3, 30)
+      Dim article4 = Me.ModelFactory.CreateArticle(4, 40)
+      Dim article5 = Me.ModelFactory.CreateArticle(5, 50)
+      Dim article6 = Me.ModelFactory.CreateArticle(6, 60)
+      Dim article7 = Me.ModelFactory.CreateArticle(7, 70)
+
+      InsertItems(article1, article2, article3, article4, article5, article6, article7)
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        Limit(3, 2).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(2, result.Count)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithLimitFromMultipleTables()
+      Dim article1 = Me.ModelFactory.CreateArticle(1, 10)
+      Dim article2 = Me.ModelFactory.CreateArticle(2, 20)
+      Dim article3 = Me.ModelFactory.CreateArticle(3, 30)
+      Dim article4 = Me.ModelFactory.CreateArticle(4, 40)
+      Dim article5 = Me.ModelFactory.CreateArticle(5, 50)
+
+      Dim label1En = Me.ModelFactory.CreateLabel("", 1, English, "a")
+      Dim label1Ger = Me.ModelFactory.CreateLabel("", 1, German, "b")
+      Dim label2En = Me.ModelFactory.CreateLabel("", 2, English, "c")
+      Dim label2Ger = Me.ModelFactory.CreateLabel("", 2, German, "d")
+      Dim label3En = Me.ModelFactory.CreateLabel("", 3, English, "e")
+      Dim label3Ger = Me.ModelFactory.CreateLabel("", 3, German, "f")
+      Dim label4En = Me.ModelFactory.CreateLabel("", 4, English, "g")
+      Dim label4Ger = Me.ModelFactory.CreateLabel("", 4, German, "h")
+      Dim label5En = Me.ModelFactory.CreateLabel("", 5, English, "i")
+      Dim label5Ger = Me.ModelFactory.CreateLabel("", 5, German, "j")
+
+      InsertItems(article1, article2, article3, article4, article5, label1En, label1Ger, label2En, label2Ger, label3En, label3Ger, label4En, label4Ger, label5En, label5Ger)
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        Join(Of Label)(Function(a, l) a.Id = l.Id).
+                        Where(Function(a, l) l.Language = English).
+                        OrderByDescending(Function(a) a.Price).
+                        Limit(3).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(3, result.Count)
+        Assert.AreEqual(article5, result(0))
+        Assert.AreEqual(label5En, result(0).Label)
+        Assert.AreEqual(article4, result(1))
+        Assert.AreEqual(label4En, result(1).Label)
+        Assert.AreEqual(article3, result(2))
+        Assert.AreEqual(label3En, result(2).Label)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithLimitAndOffsetFromMultipleTables()
+      Dim article1 = Me.ModelFactory.CreateArticle(1, 10)
+      Dim article2 = Me.ModelFactory.CreateArticle(2, 20)
+      Dim article3 = Me.ModelFactory.CreateArticle(3, 30)
+      Dim article4 = Me.ModelFactory.CreateArticle(4, 40)
+      Dim article5 = Me.ModelFactory.CreateArticle(5, 50)
+
+      Dim label1En = Me.ModelFactory.CreateLabel("", 1, English, "a")
+      Dim label1Ger = Me.ModelFactory.CreateLabel("", 1, German, "b")
+      Dim label2En = Me.ModelFactory.CreateLabel("", 2, English, "c")
+      Dim label2Ger = Me.ModelFactory.CreateLabel("", 2, German, "d")
+      Dim label3En = Me.ModelFactory.CreateLabel("", 3, English, "e")
+      Dim label3Ger = Me.ModelFactory.CreateLabel("", 3, German, "f")
+      Dim label4En = Me.ModelFactory.CreateLabel("", 4, English, "g")
+      Dim label4Ger = Me.ModelFactory.CreateLabel("", 4, German, "h")
+      Dim label5En = Me.ModelFactory.CreateLabel("", 5, English, "i")
+      Dim label5Ger = Me.ModelFactory.CreateLabel("", 5, German, "j")
+
+      InsertItems(article1, article2, article3, article4, article5, label1En, label1Ger, label2En, label2Ger, label3En, label3Ger, label4En, label4Ger, label5En, label5Ger)
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        Join(Of Label)(Function(a, l) a.Id = l.Id).
+                        Where(Function(a, l) l.Language = English).
+                        OrderByDescending(Function(a) a.Price).
+                        Limit(3, 2).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(2, result.Count)
+        Assert.AreEqual(article2, result(0))
+        Assert.AreEqual(label2En, result(0).Label)
+        Assert.AreEqual(article1, result(1))
+        Assert.AreEqual(label1En, result(1).Label)
+      End Using
+    End Sub
+
+  End Class
+End Namespace

--- a/Source/Test/Yamo.Test/Tests/SelectWithSortTests.vb
+++ b/Source/Test/Yamo.Test/Tests/SelectWithSortTests.vb
@@ -129,14 +129,11 @@ Namespace Tests
 
     <TestMethod()>
     Public Overridable Sub SelectWithOrderByColumnsFromMultipleTables()
-      Dim article1 = Me.ModelFactory.CreateArticle(1)
-      article1.Price = 30
+      Dim article1 = Me.ModelFactory.CreateArticle(1, 30)
 
-      Dim article2 = Me.ModelFactory.CreateArticle(2)
-      article2.Price = 10
+      Dim article2 = Me.ModelFactory.CreateArticle(2, 10)
 
-      Dim article3 = Me.ModelFactory.CreateArticle(3)
-      article3.Price = 20
+      Dim article3 = Me.ModelFactory.CreateArticle(3, 20)
 
       Dim label1En = Me.ModelFactory.CreateLabel("", 1, English, "a")
       Dim label1Ger = Me.ModelFactory.CreateLabel("", 1, German, "b")

--- a/Source/Test/Yamo.Test/UnitTestDialectProvider.vb
+++ b/Source/Test/Yamo.Test/UnitTestDialectProvider.vb
@@ -11,6 +11,7 @@ Public Class UnitTestDialectProvider
     Me.ValueTypeReaderFactory = New ValueTypeReaderFactory
     Me.EntityReaderFactory = New EntityReaderFactory
     Me.DbValueConversion = New DbValueConversion
+    Me.SupportedLimitType = LimitType.Top Or LimitType.OffsetFetch
   End Sub
 
 End Class

--- a/Source/Test/Yamo.Test/Yamo.Test.vbproj
+++ b/Source/Test/Yamo.Test/Yamo.Test.vbproj
@@ -75,6 +75,7 @@
   <ItemGroup>
     <Compile Include="Tests\QueryTests.vb" />
     <Compile Include="Tests\SelectDistinctTests.vb" />
+    <Compile Include="Tests\SelectWithLimitTests.vb" />
     <Compile Include="UnitTestDbContextOptionsExtensions.vb" />
     <Compile Include="UnitTestDialectProvider.vb" />
     <Compile Include="UnitTestDbContext.vb" />


### PR DESCRIPTION
Fixed #39

Example:
```cs
using (var db = CreateContext())
{
    // get 3 most expensive articles
    var articles1 = db.From<Article>()
                      .OrderByDescending(a => a.Price)
                      .Limit(3)
                      .SelectAll()
                      .ToList();

    // get second and third cheapest article
    var articles2 = db.From<Article>()
                      .OrderBy(a => a.Price)
                      .Limit(1, 2)
                      .SelectAll()
                      .ToList();
}
```
