### PR TITLE
Added support for parameters if raw SQL string is used

### DIFF
--- a/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.Having.And.vb
+++ b/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.Having.And.vb
@@ -113,13 +113,13 @@
 
     Protected Sub GenerateHavingAndWithString(builder As CodeBuilder, entityCount As Int32)
       Dim comment = "Adds AND condition to HAVING clause."
-      Dim params = {"predicate"}
+      Dim params = {"predicate", "parameters"}
       AddComment(builder, comment, params:=params, returns:="")
 
       Dim generics = String.Join(", ", GetGenericNames(entityCount))
 
-      builder.Indent().AppendLine($"Public Function [And](predicate As String) As HavingSelectSqlExpression(Of {generics})").PushIndent()
-      builder.Indent().AppendLine("Me.Builder.AddHaving(predicate)")
+      builder.Indent().AppendLine($"Public Function [And](predicate As String, ParamArray parameters() As Object) As HavingSelectSqlExpression(Of {generics})").PushIndent()
+      builder.Indent().AppendLine("Me.Builder.AddHaving(predicate, parameters)")
       builder.Indent().AppendLine("Return Me").PopIndent()
       builder.Indent().AppendLine("End Function")
     End Sub

--- a/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.Having.vb
+++ b/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.Having.vb
@@ -116,13 +116,13 @@
 
     Protected Sub GenerateHavingWithString(builder As CodeBuilder, entityCount As Int32)
       Dim comment = "Adds HAVING clause."
-      Dim params = {"predicate"}
+      Dim params = {"predicate", "parameters"}
       AddComment(builder, comment, params:=params, returns:="")
 
       Dim generics = String.Join(", ", GetGenericNames(entityCount))
 
-      builder.Indent().AppendLine($"Public Function Having(predicate As String) As HavingSelectSqlExpression(Of {generics})").PushIndent()
-      builder.Indent().AppendLine("Me.Builder.AddHaving(predicate)")
+      builder.Indent().AppendLine($"Public Function Having(predicate As String, ParamArray parameters() As Object) As HavingSelectSqlExpression(Of {generics})").PushIndent()
+      builder.Indent().AppendLine("Me.Builder.AddHaving(predicate, parameters)")
       builder.Indent().AppendLine($"Return New HavingSelectSqlExpression(Of {generics})(Me.Builder, Me.Executor)").PopIndent()
       builder.Indent().AppendLine("End Function")
     End Sub

--- a/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.Where.And.vb
+++ b/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.Where.And.vb
@@ -113,13 +113,13 @@
 
     Protected Sub GenerateWhereAndWithString(builder As CodeBuilder, entityCount As Int32)
       Dim comment = "Adds AND condition to WHERE clause."
-      Dim params = {"predicate"}
+      Dim params = {"predicate", "parameters"}
       AddComment(builder, comment, params:=params, returns:="")
 
       Dim generics = String.Join(", ", GetGenericNames(entityCount))
 
-      builder.Indent().AppendLine($"Public Function [And](predicate As String) As FilteredSelectSqlExpression(Of {generics})").PushIndent()
-      builder.Indent().AppendLine("Me.Builder.AddWhere(predicate)")
+      builder.Indent().AppendLine($"Public Function [And](predicate As String, ParamArray parameters() As Object) As FilteredSelectSqlExpression(Of {generics})").PushIndent()
+      builder.Indent().AppendLine("Me.Builder.AddWhere(predicate, parameters)")
       builder.Indent().AppendLine("Return Me").PopIndent()
       builder.Indent().AppendLine("End Function")
     End Sub

--- a/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.Where.vb
+++ b/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.Where.vb
@@ -116,13 +116,13 @@
 
     Protected Sub GenerateWhereWithString(builder As CodeBuilder, entityCount As Int32)
       Dim comment = "Adds WHERE clause."
-      Dim params = {"predicate"}
+      Dim params = {"predicate", "parameters"}
       AddComment(builder, comment, params:=params, returns:="")
 
       Dim generics = String.Join(", ", GetGenericNames(entityCount))
 
-      builder.Indent().AppendLine($"Public Function Where(predicate As String) As FilteredSelectSqlExpression(Of {generics})").PushIndent()
-      builder.Indent().AppendLine("Me.Builder.AddWhere(predicate)")
+      builder.Indent().AppendLine($"Public Function Where(predicate As String, ParamArray parameters() As Object) As FilteredSelectSqlExpression(Of {generics})").PushIndent()
+      builder.Indent().AppendLine("Me.Builder.AddWhere(predicate, parameters)")
       builder.Indent().AppendLine($"Return New FilteredSelectSqlExpression(Of {generics})(Me.Builder, Me.Executor)").PopIndent()
       builder.Indent().AppendLine("End Function")
     End Sub

--- a/Source/Source/Yamo/DbContext.vb
+++ b/Source/Source/Yamo/DbContext.vb
@@ -144,9 +144,10 @@ Public Class DbContext
   ''' Executes SQL query and returns the number of affected rows.
   ''' </summary>
   ''' <param name="sql"></param>
+  ''' <param name="parameters"></param>
   ''' <returns></returns>
-  Public Function Execute(sql As RawSqlString) As Int32
-    Return (New SqlExpression(Me)).Execute(sql)
+  Public Function Execute(sql As RawSqlString, ParamArray parameters() As Object) As Int32
+    Return (New SqlExpression(Me)).Execute(sql, parameters)
   End Function
 
   ''' <summary>
@@ -164,9 +165,10 @@ Public Class DbContext
   ''' </summary>
   ''' <typeparam name="T"></typeparam>
   ''' <param name="sql"></param>
+  ''' <param name="parameters"></param>
   ''' <returns></returns>
-  Public Function QueryFirstOrDefault(Of T)(sql As RawSqlString) As T
-    Return (New SqlExpression(Me)).QueryFirstOrDefault(Of T)(sql)
+  Public Function QueryFirstOrDefault(Of T)(sql As RawSqlString, ParamArray parameters() As Object) As T
+    Return (New SqlExpression(Me)).QueryFirstOrDefault(Of T)(sql, parameters)
   End Function
 
   ''' <summary>
@@ -184,9 +186,10 @@ Public Class DbContext
   ''' </summary>
   ''' <typeparam name="T"></typeparam>
   ''' <param name="sql"></param>
+  ''' <param name="parameters"></param>
   ''' <returns></returns>
-  Public Function Query(Of T)(sql As RawSqlString) As List(Of T)
-    Return (New SqlExpression(Me)).Query(Of T)(sql)
+  Public Function Query(Of T)(sql As RawSqlString, ParamArray parameters() As Object) As List(Of T)
+    Return (New SqlExpression(Me)).Query(Of T)(sql, parameters)
   End Function
 
   ''' <summary>

--- a/Source/Source/Yamo/Expressions/Builders/DeleteSqlExpressionBuilder.vb
+++ b/Source/Source/Yamo/Expressions/Builders/DeleteSqlExpressionBuilder.vb
@@ -92,8 +92,15 @@ Namespace Expressions.Builders
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
     ''' <param name="predicate"></param>
-    Public Sub AddWhere(predicate As String)
-      m_WhereExpressions.Add(predicate)
+    ''' <param name="parameters"></param>
+    Public Sub AddWhere(predicate As String, ParamArray parameters() As Object)
+      If parameters Is Nothing OrElse parameters.Length = 0 Then
+        m_WhereExpressions.Add(predicate)
+      Else
+        Dim sql = ConvertToSqlString(predicate, parameters, m_Parameters.Count)
+        m_WhereExpressions.Add(sql.Sql)
+        m_Parameters.AddRange(sql.Parameters)
+      End If
     End Sub
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/Builders/SelectSqlExpressionBuilder.vb
+++ b/Source/Source/Yamo/Expressions/Builders/SelectSqlExpressionBuilder.vb
@@ -388,7 +388,8 @@ Namespace Expressions.Builders
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
     ''' <param name="predicate"></param>
-    Public Sub AddWhere(predicate As String)
+    ''' <param name="parameters"></param>
+    Public Sub AddWhere(predicate As String, ParamArray parameters() As Object)
       If IsInConditionalIgnoreMode() Then
         Exit Sub
       End If
@@ -397,7 +398,13 @@ Namespace Expressions.Builders
         m_WhereExpressions = New List(Of String)
       End If
 
-      m_WhereExpressions.Add(predicate)
+      If parameters Is Nothing OrElse parameters.Length = 0 Then
+        m_WhereExpressions.Add(predicate)
+      Else
+        Dim sql = ConvertToSqlString(predicate, parameters, m_Parameters.Count)
+        m_WhereExpressions.Add(sql.Sql)
+        m_Parameters.AddRange(sql.Parameters)
+      End If
     End Sub
 
     ''' <summary>
@@ -447,7 +454,8 @@ Namespace Expressions.Builders
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
     ''' <param name="predicate"></param>
-    Public Sub AddHaving(predicate As String)
+    ''' <param name="parameters"></param>
+    Public Sub AddHaving(predicate As String, ParamArray parameters() As Object)
       If IsInConditionalIgnoreMode() Then
         Exit Sub
       End If
@@ -456,7 +464,13 @@ Namespace Expressions.Builders
         m_HavingExpressions = New List(Of String)
       End If
 
-      m_HavingExpressions.Add(predicate)
+      If parameters Is Nothing OrElse parameters.Length = 0 Then
+        m_HavingExpressions.Add(predicate)
+      Else
+        Dim sql = ConvertToSqlString(predicate, parameters, m_Parameters.Count)
+        m_HavingExpressions.Add(sql.Sql)
+        m_Parameters.AddRange(sql.Parameters)
+      End If
     End Sub
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/Builders/SqlExpressionBuilder.vb
+++ b/Source/Source/Yamo/Expressions/Builders/SqlExpressionBuilder.vb
@@ -33,9 +33,14 @@ Namespace Expressions.Builders
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
     ''' <param name="sql"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function CreateQuery(sql As RawSqlString) As Query
-      Return New Query(New SqlString(sql.Value))
+    Public Function CreateQuery(sql As RawSqlString, ParamArray parameters() As Object) As Query
+      If parameters Is Nothing OrElse parameters.Length = 0 Then
+        Return New Query(New SqlString(sql.Value))
+      Else
+        Return New Query(ConvertToSqlString(sql.Value, parameters, 0))
+      End If
     End Function
 
   End Class

--- a/Source/Source/Yamo/Expressions/Builders/SqlExpressionBuilderBase.vb
+++ b/Source/Source/Yamo/Expressions/Builders/SqlExpressionBuilderBase.vb
@@ -69,7 +69,7 @@ Namespace Expressions.Builders
     ''' <param name="parameterIndex"></param>
     ''' <returns></returns>
     Public Function ConvertToSqlString(format As String, args() As Object, parameterIndex As Int32) As SqlString
-      Dim paramNames = New String(args.Length - 1) {}
+      Dim formatArgs = New String(args.Length - 1) {}
       Dim parameters = New List(Of SqlParameter)(args.Length)
 
       For i = 0 To args.Length - 1
@@ -77,15 +77,18 @@ Namespace Expressions.Builders
 
         If TypeOf value Is ModelInfo Then
           Dim mi = DirectCast(value, ModelInfo)
-          paramNames(i) = CreateColumnsString(mi.Model, mi.TableAlias)
+          formatArgs(i) = CreateColumnsString(mi.Model, mi.TableAlias)
+        ElseIf TypeOf value Is RawSqlString Then
+          Dim s = DirectCast(value, RawSqlString)
+          formatArgs(i) = s.Value
         Else
           Dim paramName = CreateParameter(parameterIndex + i)
-          paramNames(i) = paramName
+          formatArgs(i) = paramName
           parameters.Add(New SqlParameter(paramName, value))
         End If
       Next
 
-      Dim sqlString = String.Format(format, paramNames)
+      Dim sqlString = String.Format(format, formatArgs)
 
       Return New SqlString(sqlString, parameters)
     End Function

--- a/Source/Source/Yamo/Expressions/Builders/SqlExpressionBuilderBase.vb
+++ b/Source/Source/Yamo/Expressions/Builders/SqlExpressionBuilderBase.vb
@@ -53,6 +53,22 @@ Namespace Expressions.Builders
     Public Function ConvertToSqlString(sql As FormattableString, parameterIndex As Int32) As SqlString
       Dim args = sql.GetArguments()
 
+      If args.Length = 0 Then
+        Return New SqlString(sql.Format)
+      Else
+        Return ConvertToSqlString(sql.Format, args, parameterIndex)
+      End If
+    End Function
+
+    ''' <summary>
+    ''' Converts string format to <see cref="SqlString"/>.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <param name="format"></param>
+    ''' <param name="args"></param>
+    ''' <param name="parameterIndex"></param>
+    ''' <returns></returns>
+    Public Function ConvertToSqlString(format As String, args() As Object, parameterIndex As Int32) As SqlString
       Dim paramNames = New String(args.Length - 1) {}
       Dim parameters = New List(Of SqlParameter)(args.Length)
 
@@ -69,7 +85,7 @@ Namespace Expressions.Builders
         End If
       Next
 
-      Dim sqlString = String.Format(sql.Format, paramNames)
+      Dim sqlString = String.Format(format, paramNames)
 
       Return New SqlString(sqlString, parameters)
     End Function

--- a/Source/Source/Yamo/Expressions/Builders/UpdateSqlExpressionBuilder.vb
+++ b/Source/Source/Yamo/Expressions/Builders/UpdateSqlExpressionBuilder.vb
@@ -118,8 +118,15 @@ Namespace Expressions.Builders
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
     ''' <param name="predicate"></param>
-    Public Sub AddSet(predicate As String)
-      m_SetExpressions.Add(predicate)
+    ''' <param name="parameters"></param>
+    Public Sub AddSet(predicate As String, ParamArray parameters() As Object)
+      If parameters Is Nothing OrElse parameters.Length = 0 Then
+        m_SetExpressions.Add(predicate)
+      Else
+        Dim sql = ConvertToSqlString(predicate, parameters, m_Parameters.Count)
+        m_SetExpressions.Add(sql.Sql)
+        m_Parameters.AddRange(sql.Parameters)
+      End If
     End Sub
 
     ''' <summary>
@@ -142,8 +149,15 @@ Namespace Expressions.Builders
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
     ''' <param name="predicate"></param>
-    Public Sub AddWhere(predicate As String)
-      m_WhereExpressions.Add(predicate)
+    ''' <param name="parameters"></param>
+    Public Sub AddWhere(predicate As String, ParamArray parameters() As Object)
+      If parameters Is Nothing OrElse parameters.Length = 0 Then
+        m_WhereExpressions.Add(predicate)
+      Else
+        Dim sql = ConvertToSqlString(predicate, parameters, m_Parameters.Count)
+        m_WhereExpressions.Add(sql.Sql)
+        m_Parameters.AddRange(sql.Parameters)
+      End If
     End Sub
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/DeleteSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/DeleteSqlExpression.vb
@@ -46,9 +46,10 @@ Namespace Expressions
     ''' Adds WHERE clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function Where(predicate As String) As FilteredDeleteSqlExpression(Of T)
-      Me.Builder.AddWhere(predicate)
+    Public Function Where(predicate As String, ParamArray parameters() As Object) As FilteredDeleteSqlExpression(Of T)
+      Me.Builder.AddWhere(predicate, parameters)
       Return New FilteredDeleteSqlExpression(Of T)(Me.DbContext, Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpression.vb
@@ -42,9 +42,10 @@ Namespace Expressions
     ''' Adds AND condition to WHERE clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function [And](predicate As String) As FilteredSelectSqlExpression(Of T)
-      Me.Builder.AddWhere(predicate)
+    Public Function [And](predicate As String, ParamArray parameters() As Object) As FilteredSelectSqlExpression(Of T)
+      Me.Builder.AddWhere(predicate, parameters)
       Return Me
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2.vb
@@ -97,9 +97,10 @@ Namespace Expressions
     ''' Adds AND condition to WHERE clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function [And](predicate As String) As FilteredSelectSqlExpression(Of T1, T2)
-      Me.Builder.AddWhere(predicate)
+    Public Function [And](predicate As String, ParamArray parameters() As Object) As FilteredSelectSqlExpression(Of T1, T2)
+      Me.Builder.AddWhere(predicate, parameters)
       Return Me
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3.vb
@@ -116,9 +116,10 @@ Namespace Expressions
     ''' Adds AND condition to WHERE clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function [And](predicate As String) As FilteredSelectSqlExpression(Of T1, T2, T3)
-      Me.Builder.AddWhere(predicate)
+    Public Function [And](predicate As String, ParamArray parameters() As Object) As FilteredSelectSqlExpression(Of T1, T2, T3)
+      Me.Builder.AddWhere(predicate, parameters)
       Return Me
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4.vb
@@ -117,9 +117,10 @@ Namespace Expressions
     ''' Adds AND condition to WHERE clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function [And](predicate As String) As FilteredSelectSqlExpression(Of T1, T2, T3, T4)
-      Me.Builder.AddWhere(predicate)
+    Public Function [And](predicate As String, ParamArray parameters() As Object) As FilteredSelectSqlExpression(Of T1, T2, T3, T4)
+      Me.Builder.AddWhere(predicate, parameters)
       Return Me
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5.vb
@@ -136,9 +136,10 @@ Namespace Expressions
     ''' Adds AND condition to WHERE clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function [And](predicate As String) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Me.Builder.AddWhere(predicate)
+    Public Function [And](predicate As String, ParamArray parameters() As Object) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Me.Builder.AddWhere(predicate, parameters)
       Return Me
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6.vb
@@ -155,9 +155,10 @@ Namespace Expressions
     ''' Adds AND condition to WHERE clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function [And](predicate As String) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Me.Builder.AddWhere(predicate)
+    Public Function [And](predicate As String, ParamArray parameters() As Object) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Me.Builder.AddWhere(predicate, parameters)
       Return Me
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
@@ -174,9 +174,10 @@ Namespace Expressions
     ''' Adds AND condition to WHERE clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function [And](predicate As String) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Me.Builder.AddWhere(predicate)
+    Public Function [And](predicate As String, ParamArray parameters() As Object) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Me.Builder.AddWhere(predicate, parameters)
       Return Me
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
@@ -49,9 +49,10 @@ Namespace Expressions
     ''' Adds AND condition to WHERE clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function [And](predicate As String) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Me.Builder.AddWhere(predicate)
+    Public Function [And](predicate As String, ParamArray parameters() As Object) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Me.Builder.AddWhere(predicate, parameters)
       Return Me
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
@@ -50,9 +50,10 @@ Namespace Expressions
     ''' Adds AND condition to WHERE clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function [And](predicate As String) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Me.Builder.AddWhere(predicate)
+    Public Function [And](predicate As String, ParamArray parameters() As Object) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Me.Builder.AddWhere(predicate, parameters)
       Return Me
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
@@ -51,9 +51,10 @@ Namespace Expressions
     ''' Adds AND condition to WHERE clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function [And](predicate As String) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Me.Builder.AddWhere(predicate)
+    Public Function [And](predicate As String, ParamArray parameters() As Object) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Me.Builder.AddWhere(predicate, parameters)
       Return Me
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
@@ -52,9 +52,10 @@ Namespace Expressions
     ''' Adds AND condition to WHERE clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function [And](predicate As String) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Me.Builder.AddWhere(predicate)
+    Public Function [And](predicate As String, ParamArray parameters() As Object) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Me.Builder.AddWhere(predicate, parameters)
       Return Me
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
@@ -53,9 +53,10 @@ Namespace Expressions
     ''' Adds AND condition to WHERE clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function [And](predicate As String) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Me.Builder.AddWhere(predicate)
+    Public Function [And](predicate As String, ParamArray parameters() As Object) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Me.Builder.AddWhere(predicate, parameters)
       Return Me
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
@@ -54,9 +54,10 @@ Namespace Expressions
     ''' Adds AND condition to WHERE clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function [And](predicate As String) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Me.Builder.AddWhere(predicate)
+    Public Function [And](predicate As String, ParamArray parameters() As Object) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Me.Builder.AddWhere(predicate, parameters)
       Return Me
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
@@ -55,9 +55,10 @@ Namespace Expressions
     ''' Adds AND condition to WHERE clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function [And](predicate As String) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Me.Builder.AddWhere(predicate)
+    Public Function [And](predicate As String, ParamArray parameters() As Object) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Me.Builder.AddWhere(predicate, parameters)
       Return Me
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
@@ -56,9 +56,10 @@ Namespace Expressions
     ''' Adds AND condition to WHERE clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function [And](predicate As String) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Me.Builder.AddWhere(predicate)
+    Public Function [And](predicate As String, ParamArray parameters() As Object) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Me.Builder.AddWhere(predicate, parameters)
       Return Me
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpression.vb
@@ -42,9 +42,10 @@ Namespace Expressions
     ''' Adds HAVING clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function Having(predicate As String) As HavingSelectSqlExpression(Of T)
-      Me.Builder.AddHaving(predicate)
+    Public Function Having(predicate As String, ParamArray parameters() As Object) As HavingSelectSqlExpression(Of T)
+      Me.Builder.AddHaving(predicate, parameters)
       Return New HavingSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2.vb
@@ -97,9 +97,10 @@ Namespace Expressions
     ''' Adds HAVING clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function Having(predicate As String) As HavingSelectSqlExpression(Of T1, T2)
-      Me.Builder.AddHaving(predicate)
+    Public Function Having(predicate As String, ParamArray parameters() As Object) As HavingSelectSqlExpression(Of T1, T2)
+      Me.Builder.AddHaving(predicate, parameters)
       Return New HavingSelectSqlExpression(Of T1, T2)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3.vb
@@ -116,9 +116,10 @@ Namespace Expressions
     ''' Adds HAVING clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function Having(predicate As String) As HavingSelectSqlExpression(Of T1, T2, T3)
-      Me.Builder.AddHaving(predicate)
+    Public Function Having(predicate As String, ParamArray parameters() As Object) As HavingSelectSqlExpression(Of T1, T2, T3)
+      Me.Builder.AddHaving(predicate, parameters)
       Return New HavingSelectSqlExpression(Of T1, T2, T3)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4.vb
@@ -117,9 +117,10 @@ Namespace Expressions
     ''' Adds HAVING clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function Having(predicate As String) As HavingSelectSqlExpression(Of T1, T2, T3, T4)
-      Me.Builder.AddHaving(predicate)
+    Public Function Having(predicate As String, ParamArray parameters() As Object) As HavingSelectSqlExpression(Of T1, T2, T3, T4)
+      Me.Builder.AddHaving(predicate, parameters)
       Return New HavingSelectSqlExpression(Of T1, T2, T3, T4)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5.vb
@@ -136,9 +136,10 @@ Namespace Expressions
     ''' Adds HAVING clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function Having(predicate As String) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Me.Builder.AddHaving(predicate)
+    Public Function Having(predicate As String, ParamArray parameters() As Object) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Me.Builder.AddHaving(predicate, parameters)
       Return New HavingSelectSqlExpression(Of T1, T2, T3, T4, T5)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6.vb
@@ -155,9 +155,10 @@ Namespace Expressions
     ''' Adds HAVING clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function Having(predicate As String) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Me.Builder.AddHaving(predicate)
+    Public Function Having(predicate As String, ParamArray parameters() As Object) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Me.Builder.AddHaving(predicate, parameters)
       Return New HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
@@ -174,9 +174,10 @@ Namespace Expressions
     ''' Adds HAVING clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function Having(predicate As String) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Me.Builder.AddHaving(predicate)
+    Public Function Having(predicate As String, ParamArray parameters() As Object) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Me.Builder.AddHaving(predicate, parameters)
       Return New HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
@@ -49,9 +49,10 @@ Namespace Expressions
     ''' Adds HAVING clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function Having(predicate As String) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Me.Builder.AddHaving(predicate)
+    Public Function Having(predicate As String, ParamArray parameters() As Object) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Me.Builder.AddHaving(predicate, parameters)
       Return New HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
@@ -50,9 +50,10 @@ Namespace Expressions
     ''' Adds HAVING clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function Having(predicate As String) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Me.Builder.AddHaving(predicate)
+    Public Function Having(predicate As String, ParamArray parameters() As Object) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Me.Builder.AddHaving(predicate, parameters)
       Return New HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
@@ -51,9 +51,10 @@ Namespace Expressions
     ''' Adds HAVING clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function Having(predicate As String) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Me.Builder.AddHaving(predicate)
+    Public Function Having(predicate As String, ParamArray parameters() As Object) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Me.Builder.AddHaving(predicate, parameters)
       Return New HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
@@ -52,9 +52,10 @@ Namespace Expressions
     ''' Adds HAVING clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function Having(predicate As String) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Me.Builder.AddHaving(predicate)
+    Public Function Having(predicate As String, ParamArray parameters() As Object) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Me.Builder.AddHaving(predicate, parameters)
       Return New HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
@@ -53,9 +53,10 @@ Namespace Expressions
     ''' Adds HAVING clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function Having(predicate As String) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Me.Builder.AddHaving(predicate)
+    Public Function Having(predicate As String, ParamArray parameters() As Object) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Me.Builder.AddHaving(predicate, parameters)
       Return New HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
@@ -54,9 +54,10 @@ Namespace Expressions
     ''' Adds HAVING clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function Having(predicate As String) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Me.Builder.AddHaving(predicate)
+    Public Function Having(predicate As String, ParamArray parameters() As Object) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Me.Builder.AddHaving(predicate, parameters)
       Return New HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
@@ -55,9 +55,10 @@ Namespace Expressions
     ''' Adds HAVING clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function Having(predicate As String) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Me.Builder.AddHaving(predicate)
+    Public Function Having(predicate As String, ParamArray parameters() As Object) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Me.Builder.AddHaving(predicate, parameters)
       Return New HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
@@ -56,9 +56,10 @@ Namespace Expressions
     ''' Adds HAVING clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function Having(predicate As String) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Me.Builder.AddHaving(predicate)
+    Public Function Having(predicate As String, ParamArray parameters() As Object) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Me.Builder.AddHaving(predicate, parameters)
       Return New HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpression.vb
@@ -42,9 +42,10 @@ Namespace Expressions
     ''' Adds AND condition to HAVING clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function [And](predicate As String) As HavingSelectSqlExpression(Of T)
-      Me.Builder.AddHaving(predicate)
+    Public Function [And](predicate As String, ParamArray parameters() As Object) As HavingSelectSqlExpression(Of T)
+      Me.Builder.AddHaving(predicate, parameters)
       Return Me
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2.vb
@@ -97,9 +97,10 @@ Namespace Expressions
     ''' Adds AND condition to HAVING clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function [And](predicate As String) As HavingSelectSqlExpression(Of T1, T2)
-      Me.Builder.AddHaving(predicate)
+    Public Function [And](predicate As String, ParamArray parameters() As Object) As HavingSelectSqlExpression(Of T1, T2)
+      Me.Builder.AddHaving(predicate, parameters)
       Return Me
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3.vb
@@ -116,9 +116,10 @@ Namespace Expressions
     ''' Adds AND condition to HAVING clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function [And](predicate As String) As HavingSelectSqlExpression(Of T1, T2, T3)
-      Me.Builder.AddHaving(predicate)
+    Public Function [And](predicate As String, ParamArray parameters() As Object) As HavingSelectSqlExpression(Of T1, T2, T3)
+      Me.Builder.AddHaving(predicate, parameters)
       Return Me
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4.vb
@@ -117,9 +117,10 @@ Namespace Expressions
     ''' Adds AND condition to HAVING clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function [And](predicate As String) As HavingSelectSqlExpression(Of T1, T2, T3, T4)
-      Me.Builder.AddHaving(predicate)
+    Public Function [And](predicate As String, ParamArray parameters() As Object) As HavingSelectSqlExpression(Of T1, T2, T3, T4)
+      Me.Builder.AddHaving(predicate, parameters)
       Return Me
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5.vb
@@ -136,9 +136,10 @@ Namespace Expressions
     ''' Adds AND condition to HAVING clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function [And](predicate As String) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Me.Builder.AddHaving(predicate)
+    Public Function [And](predicate As String, ParamArray parameters() As Object) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Me.Builder.AddHaving(predicate, parameters)
       Return Me
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6.vb
@@ -155,9 +155,10 @@ Namespace Expressions
     ''' Adds AND condition to HAVING clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function [And](predicate As String) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Me.Builder.AddHaving(predicate)
+    Public Function [And](predicate As String, ParamArray parameters() As Object) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Me.Builder.AddHaving(predicate, parameters)
       Return Me
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
@@ -174,9 +174,10 @@ Namespace Expressions
     ''' Adds AND condition to HAVING clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function [And](predicate As String) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Me.Builder.AddHaving(predicate)
+    Public Function [And](predicate As String, ParamArray parameters() As Object) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Me.Builder.AddHaving(predicate, parameters)
       Return Me
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
@@ -49,9 +49,10 @@ Namespace Expressions
     ''' Adds AND condition to HAVING clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function [And](predicate As String) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Me.Builder.AddHaving(predicate)
+    Public Function [And](predicate As String, ParamArray parameters() As Object) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Me.Builder.AddHaving(predicate, parameters)
       Return Me
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
@@ -50,9 +50,10 @@ Namespace Expressions
     ''' Adds AND condition to HAVING clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function [And](predicate As String) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Me.Builder.AddHaving(predicate)
+    Public Function [And](predicate As String, ParamArray parameters() As Object) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Me.Builder.AddHaving(predicate, parameters)
       Return Me
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
@@ -51,9 +51,10 @@ Namespace Expressions
     ''' Adds AND condition to HAVING clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function [And](predicate As String) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Me.Builder.AddHaving(predicate)
+    Public Function [And](predicate As String, ParamArray parameters() As Object) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Me.Builder.AddHaving(predicate, parameters)
       Return Me
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
@@ -52,9 +52,10 @@ Namespace Expressions
     ''' Adds AND condition to HAVING clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function [And](predicate As String) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Me.Builder.AddHaving(predicate)
+    Public Function [And](predicate As String, ParamArray parameters() As Object) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Me.Builder.AddHaving(predicate, parameters)
       Return Me
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
@@ -53,9 +53,10 @@ Namespace Expressions
     ''' Adds AND condition to HAVING clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function [And](predicate As String) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Me.Builder.AddHaving(predicate)
+    Public Function [And](predicate As String, ParamArray parameters() As Object) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Me.Builder.AddHaving(predicate, parameters)
       Return Me
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
@@ -54,9 +54,10 @@ Namespace Expressions
     ''' Adds AND condition to HAVING clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function [And](predicate As String) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Me.Builder.AddHaving(predicate)
+    Public Function [And](predicate As String, ParamArray parameters() As Object) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Me.Builder.AddHaving(predicate, parameters)
       Return Me
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
@@ -55,9 +55,10 @@ Namespace Expressions
     ''' Adds AND condition to HAVING clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function [And](predicate As String) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Me.Builder.AddHaving(predicate)
+    Public Function [And](predicate As String, ParamArray parameters() As Object) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Me.Builder.AddHaving(predicate, parameters)
       Return Me
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
@@ -56,9 +56,10 @@ Namespace Expressions
     ''' Adds AND condition to HAVING clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function [And](predicate As String) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Me.Builder.AddHaving(predicate)
+    Public Function [And](predicate As String, ParamArray parameters() As Object) As HavingSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Me.Builder.AddHaving(predicate, parameters)
       Return Me
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpression.vb
@@ -145,9 +145,10 @@ Namespace Expressions
     ''' Adds WHERE clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function Where(predicate As String) As FilteredSelectSqlExpression(Of T)
-      Me.Builder.AddWhere(predicate)
+    Public Function Where(predicate As String, ParamArray parameters() As Object) As FilteredSelectSqlExpression(Of T)
+      Me.Builder.AddWhere(predicate, parameters)
       Return New FilteredSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2.vb
@@ -280,9 +280,10 @@ Namespace Expressions
     ''' Adds WHERE clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function Where(predicate As String) As FilteredSelectSqlExpression(Of T1, T2)
-      Me.Builder.AddWhere(predicate)
+    Public Function Where(predicate As String, ParamArray parameters() As Object) As FilteredSelectSqlExpression(Of T1, T2)
+      Me.Builder.AddWhere(predicate, parameters)
       Return New FilteredSelectSqlExpression(Of T1, T2)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3.vb
@@ -299,9 +299,10 @@ Namespace Expressions
     ''' Adds WHERE clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function Where(predicate As String) As FilteredSelectSqlExpression(Of T1, T2, T3)
-      Me.Builder.AddWhere(predicate)
+    Public Function Where(predicate As String, ParamArray parameters() As Object) As FilteredSelectSqlExpression(Of T1, T2, T3)
+      Me.Builder.AddWhere(predicate, parameters)
       Return New FilteredSelectSqlExpression(Of T1, T2, T3)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4.vb
@@ -340,9 +340,10 @@ Namespace Expressions
     ''' Adds WHERE clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function Where(predicate As String) As FilteredSelectSqlExpression(Of T1, T2, T3, T4)
-      Me.Builder.AddWhere(predicate)
+    Public Function Where(predicate As String, ParamArray parameters() As Object) As FilteredSelectSqlExpression(Of T1, T2, T3, T4)
+      Me.Builder.AddWhere(predicate, parameters)
       Return New FilteredSelectSqlExpression(Of T1, T2, T3, T4)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5.vb
@@ -399,9 +399,10 @@ Namespace Expressions
     ''' Adds WHERE clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function Where(predicate As String) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Me.Builder.AddWhere(predicate)
+    Public Function Where(predicate As String, ParamArray parameters() As Object) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Me.Builder.AddWhere(predicate, parameters)
       Return New FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6.vb
@@ -458,9 +458,10 @@ Namespace Expressions
     ''' Adds WHERE clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function Where(predicate As String) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Me.Builder.AddWhere(predicate)
+    Public Function Where(predicate As String, ParamArray parameters() As Object) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Me.Builder.AddWhere(predicate, parameters)
       Return New FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7.vb
@@ -237,9 +237,10 @@ Namespace Expressions
     ''' Adds WHERE clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function Where(predicate As String) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Me.Builder.AddWhere(predicate)
+    Public Function Where(predicate As String, ParamArray parameters() As Object) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Me.Builder.AddWhere(predicate, parameters)
       Return New FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
@@ -112,9 +112,10 @@ Namespace Expressions
     ''' Adds WHERE clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function Where(predicate As String) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Me.Builder.AddWhere(predicate)
+    Public Function Where(predicate As String, ParamArray parameters() As Object) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Me.Builder.AddWhere(predicate, parameters)
       Return New FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
@@ -113,9 +113,10 @@ Namespace Expressions
     ''' Adds WHERE clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function Where(predicate As String) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Me.Builder.AddWhere(predicate)
+    Public Function Where(predicate As String, ParamArray parameters() As Object) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Me.Builder.AddWhere(predicate, parameters)
       Return New FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
@@ -114,9 +114,10 @@ Namespace Expressions
     ''' Adds WHERE clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function Where(predicate As String) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Me.Builder.AddWhere(predicate)
+    Public Function Where(predicate As String, ParamArray parameters() As Object) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Me.Builder.AddWhere(predicate, parameters)
       Return New FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
@@ -115,9 +115,10 @@ Namespace Expressions
     ''' Adds WHERE clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function Where(predicate As String) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Me.Builder.AddWhere(predicate)
+    Public Function Where(predicate As String, ParamArray parameters() As Object) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Me.Builder.AddWhere(predicate, parameters)
       Return New FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
@@ -116,9 +116,10 @@ Namespace Expressions
     ''' Adds WHERE clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function Where(predicate As String) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Me.Builder.AddWhere(predicate)
+    Public Function Where(predicate As String, ParamArray parameters() As Object) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Me.Builder.AddWhere(predicate, parameters)
       Return New FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
@@ -117,9 +117,10 @@ Namespace Expressions
     ''' Adds WHERE clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function Where(predicate As String) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Me.Builder.AddWhere(predicate)
+    Public Function Where(predicate As String, ParamArray parameters() As Object) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Me.Builder.AddWhere(predicate, parameters)
       Return New FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
@@ -118,9 +118,10 @@ Namespace Expressions
     ''' Adds WHERE clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function Where(predicate As String) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Me.Builder.AddWhere(predicate)
+    Public Function Where(predicate As String, ParamArray parameters() As Object) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Me.Builder.AddWhere(predicate, parameters)
       Return New FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
@@ -57,9 +57,10 @@ Namespace Expressions
     ''' Adds WHERE clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function Where(predicate As String) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Me.Builder.AddWhere(predicate)
+    Public Function Where(predicate As String, ParamArray parameters() As Object) As FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Me.Builder.AddWhere(predicate, parameters)
       Return New FilteredSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SetUpdateSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/SetUpdateSqlExpression.vb
@@ -69,9 +69,10 @@ Namespace Expressions
     ''' Adds SET clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function [Set](predicate As String) As SetUpdateSqlExpression(Of T)
-      Me.Builder.AddSet(predicate)
+    Public Function [Set](predicate As String, ParamArray parameters() As Object) As SetUpdateSqlExpression(Of T)
+      Me.Builder.AddSet(predicate, parameters)
       Return Me
     End Function
 
@@ -110,9 +111,10 @@ Namespace Expressions
     ''' Adds WHERE clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function Where(predicate As String) As FilteredUpdateSqlExpression(Of T)
-      Me.Builder.AddWhere(predicate)
+    Public Function Where(predicate As String, ParamArray parameters() As Object) As FilteredUpdateSqlExpression(Of T)
+      Me.Builder.AddWhere(predicate, parameters)
       Return New FilteredUpdateSqlExpression(Of T)(Me.DbContext, Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/SqlExpression.vb
@@ -48,9 +48,10 @@ Namespace Expressions
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
     ''' <param name="sql"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function Execute(sql As RawSqlString) As Int32
-      Dim query = Me.Builder.CreateQuery(sql)
+    Public Function Execute(sql As RawSqlString, ParamArray parameters() As Object) As Int32
+      Dim query = Me.Builder.CreateQuery(sql, parameters)
       Return Me.Executor.Execute(query)
     End Function
 
@@ -72,9 +73,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="T"></typeparam>
     ''' <param name="sql"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function QueryFirstOrDefault(Of T)(sql As RawSqlString) As T
-      Dim query = Me.Builder.CreateQuery(sql)
+    Public Function QueryFirstOrDefault(Of T)(sql As RawSqlString, ParamArray parameters() As Object) As T
+      Dim query = Me.Builder.CreateQuery(sql, parameters)
       Return Me.Executor.QueryFirstOrDefault(Of T)(query)
     End Function
 
@@ -96,9 +98,10 @@ Namespace Expressions
     ''' </summary>
     ''' <typeparam name="T"></typeparam>
     ''' <param name="sql"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function Query(Of T)(sql As RawSqlString) As List(Of T)
-      Dim q = Me.Builder.CreateQuery(sql)
+    Public Function Query(Of T)(sql As RawSqlString, ParamArray parameters() As Object) As List(Of T)
+      Dim q = Me.Builder.CreateQuery(sql, parameters)
       Return Me.Executor.QueryList(Of T)(q)
     End Function
 

--- a/Source/Source/Yamo/Expressions/UpdateSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/UpdateSqlExpression.vb
@@ -76,9 +76,10 @@ Namespace Expressions
     ''' Adds SET clause.
     ''' </summary>
     ''' <param name="predicate"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function [Set](predicate As String) As SetUpdateSqlExpression(Of T)
-      Me.Builder.AddSet(predicate)
+    Public Function [Set](predicate As String, ParamArray parameters() As Object) As SetUpdateSqlExpression(Of T)
+      Me.Builder.AddSet(predicate, parameters)
       Return New SetUpdateSqlExpression(Of T)(Me.DbContext, Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Internal/SqlExpressionVisitor.vb
+++ b/Source/Source/Yamo/Internal/SqlExpressionVisitor.vb
@@ -221,6 +221,10 @@ Namespace Internal
         If GetType(SqlHelper).IsAssignableFrom(node.Method.DeclaringType) Then
           Return VisitSqlHelperMethodCall(node)
         End If
+
+        If node.Method.DeclaringType Is GetType(RawSqlString) Then
+          Return VisitRawSqlStringCreateCall(node)
+        End If
       End If
 
       If node.Method.DeclaringType Is GetType(Enumerable) Then
@@ -409,6 +413,16 @@ Namespace Internal
 
       m_Sql.AppendFormat(sqlFormat.Format, args)
 
+      Return node
+    End Function
+
+    ''' <summary>
+    ''' Visits <see cref="RawSqlString.Create(String)"/> method call.
+    ''' </summary>
+    ''' <param name="node"></param>
+    ''' <returns></returns>
+    Private Function VisitRawSqlStringCreateCall(node As MethodCallExpression) As Expression
+      m_Sql.Append(Evaluate(node.Arguments(0)))
       Return node
     End Function
 
@@ -833,6 +847,9 @@ Namespace Internal
         Return VisitValueTupleOrAnonymousType(node, True)
       ElseIf IsAnonymousType(node.Type) Then
         Return VisitValueTupleOrAnonymousType(node, False)
+      ElseIf node.Type Is GetType(RawSqlString) Then
+        m_Sql.Append(Evaluate(node.Arguments(0)))
+        Return node
       Else
         Return VisitAndEvaluate(node)
       End If

--- a/Source/Source/Yamo/RawSqlString.vb
+++ b/Source/Source/Yamo/RawSqlString.vb
@@ -1,5 +1,5 @@
 ﻿''' <summary>
-''' Helper structure that enables to pass raw SQL string to SQL expression builder methods.
+''' Helper structure that enables to pass raw SQL string to SQL expression builder methods or as a formatting argument.
 ''' </summary>
 Public Structure RawSqlString
 
@@ -12,7 +12,7 @@ Public Structure RawSqlString
   ''' Creates new instance of <see cref="RawSqlString"/>.
   ''' </summary>
   ''' <param name="value"></param>
-  Sub New(value As String)
+  Public Sub New(value As String)
     Me.Value = value
   End Sub
 
@@ -33,5 +33,14 @@ Public Structure RawSqlString
   Public Shared Widening Operator CType(s As FormattableString) As RawSqlString
     Return Nothing
   End Operator
+
+  ''' <summary>
+  ''' Creates new instance of <see cref="RawSqlString"/>.
+  ''' </summary>
+  ''' <param name="value"></param>
+  ''' <returns></returns>
+  Public Shared Function Create(value As String) As RawSqlString
+    Return New RawSqlString(value)
+  End Function
 
 End Structure

--- a/Source/Source/Yamo/Sql/Exp.vb
+++ b/Source/Source/Yamo/Sql/Exp.vb
@@ -39,8 +39,9 @@ Namespace Sql
     ''' This method is not intended to be called directly. Use it only as a part of the query expression.
     ''' </summary>
     ''' <param name="expression"></param>
+    ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Shared Function Raw(Of T)(expression As RawSqlString) As T
+    Public Shared Function Raw(Of T)(expression As RawSqlString, ParamArray parameters() As Object) As T
       Throw New Exception("This method is not intended to be called directly.")
     End Function
 
@@ -137,7 +138,7 @@ Namespace Sql
     End Function
 
     ''' <summary>
-    ''' Returns SQL format string for <see cref="Raw(Of T)(FormattableString)"/> and <see cref="Raw(Of T)(RawSqlString)"/> methods.
+    ''' Returns SQL format string for <see cref="Raw(Of T)(FormattableString)"/> and <see cref="Raw(Of T)(RawSqlString, Object())"/> methods.
     ''' </summary>
     ''' <param name="method"></param>
     ''' <returns></returns>
@@ -167,7 +168,12 @@ Namespace Sql
 
         If stringConstantExp.NodeType = ExpressionType.Constant Then
           Dim format = DirectCast(DirectCast(stringConstantExp, ConstantExpression).Value, String)
-          Return New SqlFormat(format, {})
+
+          If method.Arguments.Count = 2 AndAlso method.Arguments(1).NodeType = ExpressionType.NewArrayInit Then
+            Return New SqlFormat(format, DirectCast(method.Arguments(1), NewArrayExpression).Expressions)
+          Else
+            Return New SqlFormat(format, {})
+          End If
         End If
       End If
 

--- a/Source/Test/Yamo.Test/Tests/DeleteTests.vb
+++ b/Source/Test/Yamo.Test/Tests/DeleteTests.vb
@@ -130,7 +130,9 @@ Namespace Tests
       InsertItems(item1, item2, item3)
 
       Using db = CreateDbContext()
-        Dim affectedRows = db.Delete(Of ItemWithAllSupportedValues).Where("Nvarchar50Column = {0}", "d").Execute()
+        Dim column = db.Model.GetEntity(GetType(ItemWithAllSupportedValues)).GetProperty(NameOf(ItemWithAllSupportedValues.Nvarchar50Column)).ColumnName
+
+        Dim affectedRows = db.Delete(Of ItemWithAllSupportedValues).Where("{0} = {1}", RawSqlString.Create(column), "d").Execute()
         Assert.AreEqual(2, affectedRows)
 
         Dim item = db.From(Of ItemWithAllSupportedValues).Where(Function(x) x.Id = item2.Id).SelectAll().FirstOrDefault()

--- a/Source/Test/Yamo.Test/Tests/DeleteTests.vb
+++ b/Source/Test/Yamo.Test/Tests/DeleteTests.vb
@@ -116,5 +116,27 @@ Namespace Tests
       End Using
     End Sub
 
+    <TestMethod()>
+    Public Overridable Sub DeleteRecordsWithRawSqlStringWithparameters()
+      Dim item1 = Me.ModelFactory.CreateItemWithAllSupportedValuesWithEmptyValues()
+      item1.Nvarchar50Column = "d"
+
+      Dim item2 = Me.ModelFactory.CreateItemWithAllSupportedValuesWithEmptyValues()
+      item2.Nvarchar50Column = ""
+
+      Dim item3 = Me.ModelFactory.CreateItemWithAllSupportedValuesWithEmptyValues()
+      item3.Nvarchar50Column = "d"
+
+      InsertItems(item1, item2, item3)
+
+      Using db = CreateDbContext()
+        Dim affectedRows = db.Delete(Of ItemWithAllSupportedValues).Where("Nvarchar50Column = {0}", "d").Execute()
+        Assert.AreEqual(2, affectedRows)
+
+        Dim item = db.From(Of ItemWithAllSupportedValues).Where(Function(x) x.Id = item2.Id).SelectAll().FirstOrDefault()
+        Assert.IsNotNull(item)
+      End Using
+    End Sub
+
   End Class
 End Namespace

--- a/Source/Test/Yamo.Test/Tests/ExecuteTests.vb
+++ b/Source/Test/Yamo.Test/Tests/ExecuteTests.vb
@@ -17,7 +17,10 @@ Namespace Tests
       InsertItems(label1En, label2En)
 
       Using db = CreateDbContext()
-        Dim result = db.Execute($"UPDATE Label SET Language = {German}")
+        Dim table = db.Model.GetEntity(GetType(Label)).TableName
+        Dim column = db.Model.GetEntity(GetType(Label)).GetProperty(NameOf(Label.Language)).ColumnName
+
+        Dim result = db.Execute($"UPDATE {RawSqlString.Create(table)} SET {RawSqlString.Create(column)} = {German}")
         Assert.AreEqual(2, result)
 
         result = db.From(Of Label).Where(Function(o) o.Language = German).SelectCount()
@@ -49,12 +52,17 @@ Namespace Tests
       InsertItems(label1En, label2En)
 
       Using db = CreateDbContext()
-        Dim result = db.Execute("UPDATE Label SET Language = {0}", German)
+        Dim table = db.Model.GetEntity(GetType(Label)).TableName
+        Dim column = db.Model.GetEntity(GetType(Label)).GetProperty(NameOf(Label.Language)).ColumnName
+
+        Dim result = db.Execute("UPDATE {0} SET {1} = {2}", RawSqlString.Create(table), RawSqlString.Create(column), German)
         Assert.AreEqual(2, result)
 
         result = db.From(Of Label).Where(Function(o) o.Language = German).SelectCount()
         Assert.AreEqual(2, result)
       End Using
+
+      Dim a = New RawSqlString()
     End Sub
 
   End Class

--- a/Source/Test/Yamo.Test/Tests/ExecuteTests.vb
+++ b/Source/Test/Yamo.Test/Tests/ExecuteTests.vb
@@ -10,7 +10,23 @@ Namespace Tests
     Protected Const German As String = "de"
 
     <TestMethod()>
-    Public Overridable Sub ExecuteUsingString()
+    Public Overridable Sub ExecuteUsingFormattableString()
+      Dim label1En = Me.ModelFactory.CreateLabel("", 1, English)
+      Dim label2En = Me.ModelFactory.CreateLabel("", 2, English)
+
+      InsertItems(label1En, label2En)
+
+      Using db = CreateDbContext()
+        Dim result = db.Execute($"UPDATE Label SET Language = {German}")
+        Assert.AreEqual(2, result)
+
+        result = db.From(Of Label).Where(Function(o) o.Language = German).SelectCount()
+        Assert.AreEqual(2, result)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub ExecuteUsingRawSqlString()
       Dim label1En = Me.ModelFactory.CreateLabel("", 1, English)
       Dim label2En = Me.ModelFactory.CreateLabel("", 2, English)
 
@@ -26,14 +42,14 @@ Namespace Tests
     End Sub
 
     <TestMethod()>
-    Public Overridable Sub ExecuteUsingFormattableString()
+    Public Overridable Sub ExecuteUsingRawSqlStringWithParameters()
       Dim label1En = Me.ModelFactory.CreateLabel("", 1, English)
       Dim label2En = Me.ModelFactory.CreateLabel("", 2, English)
 
       InsertItems(label1En, label2En)
 
       Using db = CreateDbContext()
-        Dim result = db.Execute($"UPDATE Label SET Language = {German}")
+        Dim result = db.Execute("UPDATE Label SET Language = {0}", German)
         Assert.AreEqual(2, result)
 
         result = db.From(Of Label).Where(Function(o) o.Language = German).SelectCount()

--- a/Source/Test/Yamo.Test/Tests/QueryFirstOrDefaultTests.vb
+++ b/Source/Test/Yamo.Test/Tests/QueryFirstOrDefaultTests.vb
@@ -11,6 +11,72 @@ Namespace Tests
     Protected Const German As String = "de"
 
     <TestMethod()>
+    Public Overridable Sub QueryFirstOrDefaultUsingFormattableString()
+      Dim item1 = Me.ModelFactory.CreateItemWithAllSupportedValuesWithEmptyValues()
+      item1.IntColumn = 10
+      item1.Nvarchar50Column = "lorem"
+
+      Dim item2 = Me.ModelFactory.CreateItemWithAllSupportedValuesWithEmptyValues()
+      item2.IntColumn = 20
+      item2.Nvarchar50Column = "ipsum"
+
+      Dim item3 = Me.ModelFactory.CreateItemWithAllSupportedValuesWithEmptyValues()
+      item3.IntColumn = 30
+      item3.Nvarchar50Column = "dolor"
+
+      InsertItems(item1, item2, item3)
+
+      Using db = CreateDbContext()
+        Dim result = db.QueryFirstOrDefault(Of Int32)($"SELECT IntColumn FROM ItemWithAllSupportedValues WHERE Nvarchar50Column = {item2.Nvarchar50Column}")
+        Assert.AreEqual(item2.IntColumn, result)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub QueryFirstOrDefaultUsingRawSqlString()
+      Dim item1 = Me.ModelFactory.CreateItemWithAllSupportedValuesWithEmptyValues()
+      item1.IntColumn = 10
+      item1.Nvarchar50Column = "lorem"
+
+      Dim item2 = Me.ModelFactory.CreateItemWithAllSupportedValuesWithEmptyValues()
+      item2.IntColumn = 20
+      item2.Nvarchar50Column = "ipsum"
+
+      Dim item3 = Me.ModelFactory.CreateItemWithAllSupportedValuesWithEmptyValues()
+      item3.IntColumn = 30
+      item3.Nvarchar50Column = "dolor"
+
+      InsertItems(item1, item2, item3)
+
+      Using db = CreateDbContext()
+        Dim result = db.QueryFirstOrDefault(Of Int32)("SELECT IntColumn FROM ItemWithAllSupportedValues WHERE Nvarchar50Column = 'ipsum'")
+        Assert.AreEqual(item2.IntColumn, result)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub QueryFirstOrDefaultUsingRawSqlStringWithParameters()
+      Dim item1 = Me.ModelFactory.CreateItemWithAllSupportedValuesWithEmptyValues()
+      item1.IntColumn = 10
+      item1.Nvarchar50Column = "lorem"
+
+      Dim item2 = Me.ModelFactory.CreateItemWithAllSupportedValuesWithEmptyValues()
+      item2.IntColumn = 20
+      item2.Nvarchar50Column = "ipsum"
+
+      Dim item3 = Me.ModelFactory.CreateItemWithAllSupportedValuesWithEmptyValues()
+      item3.IntColumn = 30
+      item3.Nvarchar50Column = "dolor"
+
+      InsertItems(item1, item2, item3)
+
+      Using db = CreateDbContext()
+        Dim result = db.QueryFirstOrDefault(Of Int32)("SELECT IntColumn FROM ItemWithAllSupportedValues WHERE Nvarchar50Column = {0}", "ipsum")
+        Assert.AreEqual(item2.IntColumn, result)
+      End Using
+    End Sub
+
+    <TestMethod()>
     Public Overridable Sub QueryFirstOrDefaultOfGuid()
       Dim item1 = Me.ModelFactory.CreateItemWithAllSupportedValuesWithEmptyValues()
       item1.UniqueidentifierColumn = Guid.Empty

--- a/Source/Test/Yamo.Test/Tests/QueryFirstOrDefaultTests.vb
+++ b/Source/Test/Yamo.Test/Tests/QueryFirstOrDefaultTests.vb
@@ -27,7 +27,10 @@ Namespace Tests
       InsertItems(item1, item2, item3)
 
       Using db = CreateDbContext()
-        Dim result = db.QueryFirstOrDefault(Of Int32)($"SELECT IntColumn FROM ItemWithAllSupportedValues WHERE Nvarchar50Column = {item2.Nvarchar50Column}")
+        Dim table = db.Model.GetEntity(GetType(ItemWithAllSupportedValues)).TableName
+        Dim column = db.Model.GetEntity(GetType(ItemWithAllSupportedValues)).GetProperty(NameOf(ItemWithAllSupportedValues.Nvarchar50Column)).ColumnName
+
+        Dim result = db.QueryFirstOrDefault(Of Int32)($"SELECT IntColumn FROM {RawSqlString.Create(table)} WHERE {RawSqlString.Create(column)} = {item2.Nvarchar50Column}")
         Assert.AreEqual(item2.IntColumn, result)
       End Using
     End Sub
@@ -71,7 +74,10 @@ Namespace Tests
       InsertItems(item1, item2, item3)
 
       Using db = CreateDbContext()
-        Dim result = db.QueryFirstOrDefault(Of Int32)("SELECT IntColumn FROM ItemWithAllSupportedValues WHERE Nvarchar50Column = {0}", "ipsum")
+        Dim table = db.Model.GetEntity(GetType(ItemWithAllSupportedValues)).TableName
+        Dim column = db.Model.GetEntity(GetType(ItemWithAllSupportedValues)).GetProperty(NameOf(ItemWithAllSupportedValues.Nvarchar50Column)).ColumnName
+
+        Dim result = db.QueryFirstOrDefault(Of Int32)("SELECT IntColumn FROM {0} WHERE {1} = {2}", RawSqlString.Create(table), RawSqlString.Create(column), "ipsum")
         Assert.AreEqual(item2.IntColumn, result)
       End Using
     End Sub

--- a/Source/Test/Yamo.Test/Tests/QueryTests.vb
+++ b/Source/Test/Yamo.Test/Tests/QueryTests.vb
@@ -10,6 +10,78 @@ Namespace Tests
     Protected Const German As String = "de"
 
     <TestMethod()>
+    Public Overridable Sub QueryUsingFormattableString()
+      Dim item1 = Me.ModelFactory.CreateItemWithAllSupportedValuesWithEmptyValues()
+      item1.IntColumn = 10
+      item1.Nvarchar50Column = "lorem"
+
+      Dim item2 = Me.ModelFactory.CreateItemWithAllSupportedValuesWithEmptyValues()
+      item2.IntColumn = 20
+      item2.Nvarchar50Column = "ipsum"
+
+      Dim item3 = Me.ModelFactory.CreateItemWithAllSupportedValuesWithEmptyValues()
+      item3.IntColumn = 30
+      item3.Nvarchar50Column = "dolor"
+
+      InsertItems(item1, item2, item3)
+
+      Using db = CreateDbContext()
+        Dim result = db.Query(Of Int32)($"SELECT IntColumn FROM ItemWithAllSupportedValues WHERE NOT Nvarchar50Column = {item2.Nvarchar50Column} ORDER BY IntColumn")
+        Assert.AreEqual(2, result.Count)
+        Assert.AreEqual(item1.IntColumn, result(0))
+        Assert.AreEqual(item3.IntColumn, result(1))
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub QueryUsingRawSqlString()
+      Dim item1 = Me.ModelFactory.CreateItemWithAllSupportedValuesWithEmptyValues()
+      item1.IntColumn = 10
+      item1.Nvarchar50Column = "lorem"
+
+      Dim item2 = Me.ModelFactory.CreateItemWithAllSupportedValuesWithEmptyValues()
+      item2.IntColumn = 20
+      item2.Nvarchar50Column = "ipsum"
+
+      Dim item3 = Me.ModelFactory.CreateItemWithAllSupportedValuesWithEmptyValues()
+      item3.IntColumn = 30
+      item3.Nvarchar50Column = "dolor"
+
+      InsertItems(item1, item2, item3)
+
+      Using db = CreateDbContext()
+        Dim result = db.Query(Of Int32)("SELECT IntColumn FROM ItemWithAllSupportedValues WHERE NOT Nvarchar50Column = 'ipsum' ORDER BY IntColumn")
+        Assert.AreEqual(2, result.Count)
+        Assert.AreEqual(item1.IntColumn, result(0))
+        Assert.AreEqual(item3.IntColumn, result(1))
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub QueryUsingRawSqlStringWithParameters()
+      Dim item1 = Me.ModelFactory.CreateItemWithAllSupportedValuesWithEmptyValues()
+      item1.IntColumn = 10
+      item1.Nvarchar50Column = "lorem"
+
+      Dim item2 = Me.ModelFactory.CreateItemWithAllSupportedValuesWithEmptyValues()
+      item2.IntColumn = 20
+      item2.Nvarchar50Column = "ipsum"
+
+      Dim item3 = Me.ModelFactory.CreateItemWithAllSupportedValuesWithEmptyValues()
+      item3.IntColumn = 30
+      item3.Nvarchar50Column = "dolor"
+
+      InsertItems(item1, item2, item3)
+
+      Using db = CreateDbContext()
+        Dim result = db.Query(Of Int32)("SELECT IntColumn FROM ItemWithAllSupportedValues WHERE NOT Nvarchar50Column = {0} ORDER BY IntColumn", "ipsum")
+        Assert.AreEqual(2, result.Count)
+        Assert.AreEqual(item1.IntColumn, result(0))
+        Assert.AreEqual(item3.IntColumn, result(1))
+      End Using
+    End Sub
+
+    <TestMethod()>
     Public Overridable Sub QueryOfGuid()
       Dim item1 = Me.ModelFactory.CreateItemWithAllSupportedValuesWithEmptyValues()
       item1.IntColumn = 1

--- a/Source/Test/Yamo.Test/Tests/QueryTests.vb
+++ b/Source/Test/Yamo.Test/Tests/QueryTests.vb
@@ -26,7 +26,10 @@ Namespace Tests
       InsertItems(item1, item2, item3)
 
       Using db = CreateDbContext()
-        Dim result = db.Query(Of Int32)($"SELECT IntColumn FROM ItemWithAllSupportedValues WHERE NOT Nvarchar50Column = {item2.Nvarchar50Column} ORDER BY IntColumn")
+        Dim table = db.Model.GetEntity(GetType(ItemWithAllSupportedValues)).TableName
+        Dim column = db.Model.GetEntity(GetType(ItemWithAllSupportedValues)).GetProperty(NameOf(ItemWithAllSupportedValues.Nvarchar50Column)).ColumnName
+
+        Dim result = db.Query(Of Int32)($"SELECT IntColumn FROM {RawSqlString.Create(table)} WHERE NOT {RawSqlString.Create(column)} = {item2.Nvarchar50Column} ORDER BY IntColumn")
         Assert.AreEqual(2, result.Count)
         Assert.AreEqual(item1.IntColumn, result(0))
         Assert.AreEqual(item3.IntColumn, result(1))
@@ -74,7 +77,10 @@ Namespace Tests
       InsertItems(item1, item2, item3)
 
       Using db = CreateDbContext()
-        Dim result = db.Query(Of Int32)("SELECT IntColumn FROM ItemWithAllSupportedValues WHERE NOT Nvarchar50Column = {0} ORDER BY IntColumn", "ipsum")
+        Dim table = db.Model.GetEntity(GetType(ItemWithAllSupportedValues)).TableName
+        Dim column = db.Model.GetEntity(GetType(ItemWithAllSupportedValues)).GetProperty(NameOf(ItemWithAllSupportedValues.Nvarchar50Column)).ColumnName
+
+        Dim result = db.Query(Of Int32)("SELECT IntColumn FROM {0} WHERE NOT {1} = {2} ORDER BY IntColumn", RawSqlString.Create(table), RawSqlString.Create(column), "ipsum")
         Assert.AreEqual(2, result.Count)
         Assert.AreEqual(item1.IntColumn, result(0))
         Assert.AreEqual(item3.IntColumn, result(1))

--- a/Source/Test/Yamo.Test/Tests/SelectWithHavingTests.vb
+++ b/Source/Test/Yamo.Test/Tests/SelectWithHavingTests.vb
@@ -68,11 +68,11 @@ Namespace Tests
 
       Using db = CreateDbContext()
         Dim result1 = db.From(Of ItemWithAllSupportedValues).
-                        GroupBy(Function(x) New With {x.Nvarchar50Column, x.IntColumn}).
-                        Having(Function(x) x.Nvarchar50Column = "Lorem").
-                        And(Function(x) x.IntColumn < 42).
-                        Select(Function(x) (x.Nvarchar50Column, x.IntColumn)).
-                        ToList()
+                         GroupBy(Function(x) New With {x.Nvarchar50Column, x.IntColumn}).
+                         Having(Function(x) x.Nvarchar50Column = "Lorem").
+                         And(Function(x) x.IntColumn < 42).
+                         Select(Function(x) (x.Nvarchar50Column, x.IntColumn)).
+                         ToList()
 
         CollectionAssert.AreEquivalent({("Lorem", 6), ("Lorem", 9)}, result1)
 
@@ -85,6 +85,105 @@ Namespace Tests
                          ToList()
 
         CollectionAssert.AreEquivalent({("Lorem", 6), ("Lorem", 9)}, result2)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithFormattableSqlStringHavingCondition()
+      Dim items = CreateItems()
+
+      items(0).Nvarchar50Column = "Lorem"
+      items(0).IntColumn = 42
+
+      items(1).Nvarchar50Column = "Ipsum"
+      items(1).IntColumn = 6
+
+      items(2).Nvarchar50Column = "Lorem"
+      items(2).IntColumn = 6
+
+      items(3).Nvarchar50Column = "Ipsum"
+      items(3).IntColumn = 6
+
+      items(4).Nvarchar50Column = "Lorem"
+      items(4).IntColumn = 9
+
+      InsertItems(items)
+
+      Using db = CreateDbContext()
+        Dim v1 = "Lorem"
+        Dim v2 = 42
+
+        Dim result = db.From(Of ItemWithAllSupportedValues).
+                        GroupBy(Function(x) New With {x.Nvarchar50Column, x.IntColumn}).
+                        Having(Function(x) DirectCast($"Nvarchar50Column = {v1} AND IntColumn < {v2}", FormattableString)).
+                        Select(Function(x) (x.Nvarchar50Column, x.IntColumn)).
+                        ToList()
+
+        CollectionAssert.AreEquivalent({("Lorem", 6), ("Lorem", 9)}, result)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithRawSqlStringHavingCondition()
+      Dim items = CreateItems()
+
+      items(0).Nvarchar50Column = "Lorem"
+      items(0).IntColumn = 42
+
+      items(1).Nvarchar50Column = "Ipsum"
+      items(1).IntColumn = 6
+
+      items(2).Nvarchar50Column = "Lorem"
+      items(2).IntColumn = 6
+
+      items(3).Nvarchar50Column = "Ipsum"
+      items(3).IntColumn = 6
+
+      items(4).Nvarchar50Column = "Lorem"
+      items(4).IntColumn = 9
+
+      InsertItems(items)
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of ItemWithAllSupportedValues).
+                        GroupBy(Function(x) New With {x.Nvarchar50Column, x.IntColumn}).
+                        Having("Nvarchar50Column = 'Lorem' AND IntColumn < 42").
+                        Select(Function(x) (x.Nvarchar50Column, x.IntColumn)).
+                        ToList()
+
+        CollectionAssert.AreEquivalent({("Lorem", 6), ("Lorem", 9)}, result)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithRawSqlStringHavingConditionWithParameters()
+      Dim items = CreateItems()
+
+      items(0).Nvarchar50Column = "Lorem"
+      items(0).IntColumn = 42
+
+      items(1).Nvarchar50Column = "Ipsum"
+      items(1).IntColumn = 6
+
+      items(2).Nvarchar50Column = "Lorem"
+      items(2).IntColumn = 6
+
+      items(3).Nvarchar50Column = "Ipsum"
+      items(3).IntColumn = 6
+
+      items(4).Nvarchar50Column = "Lorem"
+      items(4).IntColumn = 9
+
+      InsertItems(items)
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of ItemWithAllSupportedValues).
+                        GroupBy(Function(x) New With {x.Nvarchar50Column, x.IntColumn}).
+                        Having("Nvarchar50Column = {0} AND IntColumn < {1}", "Lorem", 42).
+                        Select(Function(x) (x.Nvarchar50Column, x.IntColumn)).
+                        ToList()
+
+        CollectionAssert.AreEquivalent({("Lorem", 6), ("Lorem", 9)}, result)
       End Using
     End Sub
 

--- a/Source/Test/Yamo.Test/Tests/SelectWithHavingTests.vb
+++ b/Source/Test/Yamo.Test/Tests/SelectWithHavingTests.vb
@@ -177,9 +177,12 @@ Namespace Tests
       InsertItems(items)
 
       Using db = CreateDbContext()
+        Dim column1 = db.Model.GetEntity(GetType(ItemWithAllSupportedValues)).GetProperty(NameOf(ItemWithAllSupportedValues.Nvarchar50Column)).ColumnName
+        Dim column2 = db.Model.GetEntity(GetType(ItemWithAllSupportedValues)).GetProperty(NameOf(ItemWithAllSupportedValues.IntColumn)).ColumnName
+
         Dim result = db.From(Of ItemWithAllSupportedValues).
                         GroupBy(Function(x) New With {x.Nvarchar50Column, x.IntColumn}).
-                        Having("Nvarchar50Column = {0} AND IntColumn < {1}", "Lorem", 42).
+                        Having("{0} = {1} AND {2} < {3}", RawSqlString.Create(column1), "Lorem", RawSqlString.Create(column2), 42).
                         Select(Function(x) (x.Nvarchar50Column, x.IntColumn)).
                         ToList()
 

--- a/Source/Test/Yamo.Test/Tests/SelectWithSqlStringWhereTests.vb
+++ b/Source/Test/Yamo.Test/Tests/SelectWithSqlStringWhereTests.vb
@@ -45,6 +45,25 @@ Namespace Tests
       End Using
     End Sub
 
+    <TestMethod()>
+    Public Overridable Sub SelectRecordByRawSqlStringWithParameters()
+      Dim items = CreateItems()
+
+      items(0).Nvarchar50Column = "lorem ipsum"
+      items(1).Nvarchar50Column = "dolor sit"
+      items(2).Nvarchar50Column = "amet"
+      items(3).Nvarchar50Column = "lorem ipsum dolor sit amet"
+      items(4).Nvarchar50Column = ""
+
+      InsertItems(items)
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of ItemWithAllSupportedValues).Where("Nvarchar50Column = {0}", "amet").SelectAll().ToList()
+        Assert.AreEqual(1, result.Count)
+        Assert.AreEqual(items(2), result(0))
+      End Using
+    End Sub
+
     Protected Overridable Function CreateItems() As List(Of ItemWithAllSupportedValues)
       Return New List(Of ItemWithAllSupportedValues) From {
         Me.ModelFactory.CreateItemWithAllSupportedValuesWithEmptyValues(),

--- a/Source/Test/Yamo.Test/Tests/SelectWithSqlStringWhereTests.vb
+++ b/Source/Test/Yamo.Test/Tests/SelectWithSqlStringWhereTests.vb
@@ -18,11 +18,21 @@ Namespace Tests
       InsertItems(items)
 
       Using db = CreateDbContext()
+        Dim column = db.Model.GetEntity(GetType(ItemWithAllSupportedValues)).GetProperty(NameOf(ItemWithAllSupportedValues.Nvarchar50Column)).ColumnName
         Dim value = "amet"
+
         ' NOTE: DirectCast is needed (VB.NET compiler bug/feature?)
-        Dim result = db.From(Of ItemWithAllSupportedValues).Where(Function(x) DirectCast($"{x.Nvarchar50Column} = {value}", FormattableString)).SelectAll().ToList()
-        Assert.AreEqual(1, result.Count)
-        Assert.AreEqual(items(2), result(0))
+        Dim result1 = db.From(Of ItemWithAllSupportedValues).Where(Function(x) DirectCast($"{x.Nvarchar50Column} = {value}", FormattableString)).SelectAll().ToList()
+        Assert.AreEqual(1, result1.Count)
+        Assert.AreEqual(items(2), result1(0))
+
+        Dim result2 = db.From(Of ItemWithAllSupportedValues).Where(Function(x) DirectCast($"{RawSqlString.Create(column)} = {value}", FormattableString)).SelectAll().ToList()
+        Assert.AreEqual(1, result2.Count)
+        Assert.AreEqual(items(2), result2(0))
+
+        Dim result3 = db.From(Of ItemWithAllSupportedValues).Where(Function(x) DirectCast($"{New RawSqlString(column)} = {value}", FormattableString)).SelectAll().ToList()
+        Assert.AreEqual(1, result3.Count)
+        Assert.AreEqual(items(2), result3(0))
       End Using
     End Sub
 
@@ -58,7 +68,9 @@ Namespace Tests
       InsertItems(items)
 
       Using db = CreateDbContext()
-        Dim result = db.From(Of ItemWithAllSupportedValues).Where("Nvarchar50Column = {0}", "amet").SelectAll().ToList()
+        Dim column = db.Model.GetEntity(GetType(ItemWithAllSupportedValues)).GetProperty(NameOf(ItemWithAllSupportedValues.Nvarchar50Column)).ColumnName
+
+        Dim result = db.From(Of ItemWithAllSupportedValues).Where("{0} = {1}", RawSqlString.Create(column), "amet").SelectAll().ToList()
         Assert.AreEqual(1, result.Count)
         Assert.AreEqual(items(2), result(0))
       End Using

--- a/Source/Test/Yamo.Test/Tests/SqlHelperExpTests.vb
+++ b/Source/Test/Yamo.Test/Tests/SqlHelperExpTests.vb
@@ -64,7 +64,9 @@ Namespace Tests
 
       InsertItems(items)
 
+
       Using db = CreateDbContext()
+        Dim column = db.Model.GetEntity(GetType(ItemWithAllSupportedValues)).GetProperty(NameOf(ItemWithAllSupportedValues.IntColumn)).ColumnName
         Dim one = 1
         Dim two = 2
 
@@ -77,52 +79,79 @@ Namespace Tests
 
         Dim result2 = db.From(Of ItemWithAllSupportedValues).
                          OrderBy(Function(x) x.IntColumn).
+                         Select(Function(x) Sql.Exp.Raw(Of Int32)($"{RawSqlString.Create(column)} + 1 + {one}")).
+                         ToList()
+
+        CollectionAssert.AreEqual({3, 4, 5, 6, 7}, result2)
+
+        Dim result3 = db.From(Of ItemWithAllSupportedValues).
+                         OrderBy(Function(x) x.IntColumn).
+                         Select(Function(x) Sql.Exp.Raw(Of Int32)($"{New RawSqlString(column)} + 1 + {one}")).
+                         ToList()
+
+        CollectionAssert.AreEqual({3, 4, 5, 6, 7}, result3)
+
+        Dim result4 = db.From(Of ItemWithAllSupportedValues).
+                         OrderBy(Function(x) x.IntColumn).
                          Select(Function(x) Sql.Exp.Raw(Of Int32?)($"{x.IntColumnNull} + 1")).
                          ToList()
 
-        CollectionAssert.AreEqual({New Int32?(2), New Int32?(3), New Int32?(), New Int32?(5), New Int32?()}, result2)
+        CollectionAssert.AreEqual({New Int32?(2), New Int32?(3), New Int32?(), New Int32?(5), New Int32?()}, result4)
 
-        Dim result3 = db.From(Of ItemWithAllSupportedValues).
+        Dim result5 = db.From(Of ItemWithAllSupportedValues).
                          OrderBy(Function(x) x.IntColumn).
                          Select(Function(x) Sql.Exp.Raw(Of Int32)($"1 + 2")).
                          ToList()
 
-        CollectionAssert.AreEqual({3, 3, 3, 3, 3}, result3)
+        CollectionAssert.AreEqual({3, 3, 3, 3, 3}, result5)
 
-        Dim result4 = db.From(Of ItemWithAllSupportedValues).
+        Dim result6 = db.From(Of ItemWithAllSupportedValues).
                          OrderBy(Function(x) x.IntColumn).
                          Select(Function(x) Sql.Exp.Raw(Of String)($"'foo'")).
                          ToList()
 
-        CollectionAssert.AreEqual({"foo", "foo", "foo", "foo", "foo"}, result4)
+        CollectionAssert.AreEqual({"foo", "foo", "foo", "foo", "foo"}, result6)
+      End Using
 
-        Dim result5 = db.From(Of ItemWithAllSupportedValues).
+      Using db = CreateDbContext()
+        Dim column = db.Model.GetEntity(GetType(ItemWithAllSupportedValues)).GetProperty(NameOf(ItemWithAllSupportedValues.IntColumn)).ColumnName
+        Dim one = 1
+        Dim two = 2
+
+        Dim result1 = db.From(Of ItemWithAllSupportedValues).
                          OrderBy(Function(x) x.IntColumn).
-                         Select(Function(x) Sql.Exp.Raw(Of Int32)("IntColumn + 1 + 1")).
+                         Select(Function(x) Sql.Exp.Raw(Of Int32)("IntColumn + 1 + {0}", one)).
                          ToList()
 
-        CollectionAssert.AreEqual({3, 4, 5, 6, 7}, result5)
+        CollectionAssert.AreEqual({3, 4, 5, 6, 7}, result1)
 
-        Dim result6 = db.From(Of ItemWithAllSupportedValues).
+        Dim result2 = db.From(Of ItemWithAllSupportedValues).
+                         OrderBy(Function(x) x.IntColumn).
+                         Select(Function(x) Sql.Exp.Raw(Of Int32)("{0} + 1 + {1}", RawSqlString.Create(column), one)).
+                         ToList()
+
+        CollectionAssert.AreEqual({3, 4, 5, 6, 7}, result2)
+
+        Dim result3 = db.From(Of ItemWithAllSupportedValues).
+                         OrderBy(Function(x) x.IntColumn).
+                         Select(Function(x) Sql.Exp.Raw(Of Int32?)("IntColumnNull + 1")).
+                         ToList()
+
+        CollectionAssert.AreEqual({New Int32?(2), New Int32?(3), New Int32?(), New Int32?(5), New Int32?()}, result3)
+
+        Dim result4 = db.From(Of ItemWithAllSupportedValues).
                          OrderBy(Function(x) x.IntColumn).
                          Select(Function(x) Sql.Exp.Raw(Of Int32)("1 + 2")).
                          ToList()
 
-        CollectionAssert.AreEqual({3, 3, 3, 3, 3}, result6)
+        CollectionAssert.AreEqual({3, 3, 3, 3, 3}, result4)
 
-        Dim result7 = db.From(Of ItemWithAllSupportedValues).
+        Dim result5 = db.From(Of ItemWithAllSupportedValues).
                          OrderBy(Function(x) x.IntColumn).
                          Select(Function(x) Sql.Exp.Raw(Of String)("'foo'")).
                          ToList()
 
-        CollectionAssert.AreEqual({"foo", "foo", "foo", "foo", "foo"}, result7)
-
-        Dim result8 = db.From(Of ItemWithAllSupportedValues).
-                         OrderBy(Function(x) x.IntColumn).
-                         Select(Function(x) Sql.Exp.Raw(Of Int32)("{0} + {1}", one, two)).
-                         ToList()
-
-        CollectionAssert.AreEqual({3, 3, 3, 3, 3}, result8)
+        CollectionAssert.AreEqual({"foo", "foo", "foo", "foo", "foo"}, result5)
       End Using
     End Sub
 

--- a/Source/Test/Yamo.Test/Tests/SqlHelperExpTests.vb
+++ b/Source/Test/Yamo.Test/Tests/SqlHelperExpTests.vb
@@ -65,9 +65,12 @@ Namespace Tests
       InsertItems(items)
 
       Using db = CreateDbContext()
+        Dim one = 1
+        Dim two = 2
+
         Dim result1 = db.From(Of ItemWithAllSupportedValues).
                          OrderBy(Function(x) x.IntColumn).
-                         Select(Function(x) Sql.Exp.Raw(Of Int32)($"{x.IntColumn} + 1 + {1}")).
+                         Select(Function(x) Sql.Exp.Raw(Of Int32)($"{x.IntColumn} + 1 + {one}")).
                          ToList()
 
         CollectionAssert.AreEqual({3, 4, 5, 6, 7}, result1)
@@ -95,17 +98,31 @@ Namespace Tests
 
         Dim result5 = db.From(Of ItemWithAllSupportedValues).
                          OrderBy(Function(x) x.IntColumn).
+                         Select(Function(x) Sql.Exp.Raw(Of Int32)("IntColumn + 1 + 1")).
+                         ToList()
+
+        CollectionAssert.AreEqual({3, 4, 5, 6, 7}, result5)
+
+        Dim result6 = db.From(Of ItemWithAllSupportedValues).
+                         OrderBy(Function(x) x.IntColumn).
                          Select(Function(x) Sql.Exp.Raw(Of Int32)("1 + 2")).
                          ToList()
 
-        CollectionAssert.AreEqual({3, 3, 3, 3, 3}, result5)
+        CollectionAssert.AreEqual({3, 3, 3, 3, 3}, result6)
 
-        Dim result6 = db.From(Of ItemWithAllSupportedValues).
+        Dim result7 = db.From(Of ItemWithAllSupportedValues).
                          OrderBy(Function(x) x.IntColumn).
                          Select(Function(x) Sql.Exp.Raw(Of String)("'foo'")).
                          ToList()
 
-        CollectionAssert.AreEqual({"foo", "foo", "foo", "foo", "foo"}, result6)
+        CollectionAssert.AreEqual({"foo", "foo", "foo", "foo", "foo"}, result7)
+
+        Dim result8 = db.From(Of ItemWithAllSupportedValues).
+                         OrderBy(Function(x) x.IntColumn).
+                         Select(Function(x) Sql.Exp.Raw(Of Int32)("{0} + {1}", one, two)).
+                         ToList()
+
+        CollectionAssert.AreEqual({3, 3, 3, 3, 3}, result8)
       End Using
     End Sub
 

--- a/Source/Test/Yamo.Test/Tests/UpdateTests.vb
+++ b/Source/Test/Yamo.Test/Tests/UpdateTests.vb
@@ -507,9 +507,12 @@ Namespace Tests
 
       ' set value directly
       Using db = CreateDbContext()
+        Dim column1 = db.Model.GetEntity(GetType(ItemWithAllSupportedValues)).GetProperty(NameOf(ItemWithAllSupportedValues.Nvarchar50Column)).ColumnName
+        Dim column2 = db.Model.GetEntity(GetType(ItemWithAllSupportedValues)).GetProperty(NameOf(ItemWithAllSupportedValues.IntColumn)).ColumnName
+
         Dim affectedRows = db.Update(Of ItemWithAllSupportedValues).
-                              Set("Nvarchar50Column = {0}", "lorem").
-                              Set("IntColumn = {0}", 42).
+                              Set("{0} = {1}", RawSqlString.Create(column1), "lorem").
+                              Set("{0} = {1}", RawSqlString.Create(column2), 42).
                               Execute()
         Assert.AreEqual(3, affectedRows)
 
@@ -631,9 +634,11 @@ Namespace Tests
       InsertItems(item1, item2, item3)
 
       Using db = CreateDbContext()
+        Dim column = db.Model.GetEntity(GetType(ItemWithAllSupportedValues)).GetProperty(NameOf(ItemWithAllSupportedValues.IntColumn)).ColumnName
+
         Dim affectedRows = db.Update(Of ItemWithAllSupportedValues).
                               Set(Sub(x) x.Nvarchar50Column = "lorem").
-                              Where("IntColumn < {0}", 3).
+                              Where("{0} < {1}", RawSqlString.Create(column), 3).
                               Execute()
         Assert.AreEqual(2, affectedRows)
 

--- a/Source/Test/Yamo.Test/Tests/UpdateTests.vb
+++ b/Source/Test/Yamo.Test/Tests/UpdateTests.vb
@@ -498,6 +498,36 @@ Namespace Tests
     End Sub
 
     <TestMethod()>
+    Public Overridable Sub UpdateRecordsWithRawSqlStringWithParameters()
+      Dim item1 = Me.ModelFactory.CreateItemWithAllSupportedValuesWithEmptyValues()
+      Dim item2 = Me.ModelFactory.CreateItemWithAllSupportedValuesWithEmptyValues()
+      Dim item3 = Me.ModelFactory.CreateItemWithAllSupportedValuesWithEmptyValues()
+
+      InsertItems(item1, item2, item3)
+
+      ' set value directly
+      Using db = CreateDbContext()
+        Dim affectedRows = db.Update(Of ItemWithAllSupportedValues).
+                              Set("Nvarchar50Column = {0}", "lorem").
+                              Set("IntColumn = {0}", 42).
+                              Execute()
+        Assert.AreEqual(3, affectedRows)
+
+        Dim result = db.From(Of ItemWithAllSupportedValues).SelectAll().ToList()
+
+        item1.Nvarchar50Column = "lorem"
+        item1.IntColumn = 42
+        item2.Nvarchar50Column = "lorem"
+        item2.IntColumn = 42
+        item3.Nvarchar50Column = "lorem"
+        item3.IntColumn = 42
+
+        Assert.AreEqual(3, result.Count)
+        CollectionAssert.AreEquivalent({item1, item2, item3}, result)
+      End Using
+    End Sub
+
+    <TestMethod()>
     Public Overridable Sub UpdateRecordsWithCondition()
       Dim item1 = Me.ModelFactory.CreateItemWithAllSupportedValuesWithEmptyValues()
       item1.IntColumn = 1
@@ -574,6 +604,36 @@ Namespace Tests
         Dim affectedRows = db.Update(Of ItemWithAllSupportedValues).
                               Set(Sub(x) x.Nvarchar50Column = "lorem").
                               Where("IntColumn < 3").
+                              Execute()
+        Assert.AreEqual(2, affectedRows)
+
+        Dim result = db.From(Of ItemWithAllSupportedValues).SelectAll().ToList()
+
+        item1.Nvarchar50Column = "lorem"
+        item2.Nvarchar50Column = "lorem"
+
+        Assert.AreEqual(3, result.Count)
+        CollectionAssert.AreEquivalent({item1, item2, item3}, result)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub UpdateRecordsWithRawSqlStringConditionWithParameters()
+      Dim item1 = Me.ModelFactory.CreateItemWithAllSupportedValuesWithEmptyValues()
+      item1.IntColumn = 1
+
+      Dim item2 = Me.ModelFactory.CreateItemWithAllSupportedValuesWithEmptyValues()
+      item2.IntColumn = 2
+
+      Dim item3 = Me.ModelFactory.CreateItemWithAllSupportedValuesWithEmptyValues()
+      item3.IntColumn = 3
+
+      InsertItems(item1, item2, item3)
+
+      Using db = CreateDbContext()
+        Dim affectedRows = db.Update(Of ItemWithAllSupportedValues).
+                              Set(Sub(x) x.Nvarchar50Column = "lorem").
+                              Where("IntColumn < {0}", 3).
                               Execute()
         Assert.AreEqual(2, affectedRows)
 


### PR DESCRIPTION
Previously, the only way how to safely pass a value to a SQL command was via string interpolation and methods accepting `FormattableString`. Overloads with string parameter (`RawSqlString` to be precise) did not support parameters. This is now supported.

Example:
```cs
var value = "lorem ipsum";
// translates to: ...WHERE Bar = @p0
var result = db.From<Foo>().Where("Bar = {0}", value).SelectAll().ToList();
```

Additionally, there is an option to embed chunks of raw SQL without converting them to SQL parameters. Just pass instance of `RawSqlString` and it will be embedded as simple string. It can be used everywhere, where "normal" value would be converted to SQL parameter (in `FormattableString`, in `Expression`, ...).

Example:
```cs
var column = db.Model.GetEntity(typeof(Foo)).GetProperty(nameof(Foo.Bar)).ColumnName;
var value = "lorem ipsum";
// both translate to: ...WHERE Bar = @p0
var result1 = db.From<Foo>().Where("{0} = {1}", RawSqlString.Create(column), value).SelectAll().ToList();
var result2 = db.From<Foo>().Where($"{RawSqlString.Create(column)} = {value}").SelectAll().ToList();
// but this is still preferred:
var result3 = db.From<Foo>().Where(x => x.Bar == value).SelectAll().ToList();
```
As always with "dangerous" features like this, it should be used wisely and never for passing unsanitized user inputs!

This resolves #64.