### PR TITLE
Added model related SQL helper methods

### DIFF
--- a/Source/Samples/Yamo.PlaygroundCS/Program.cs
+++ b/Source/Samples/Yamo.PlaygroundCS/Program.cs
@@ -646,7 +646,7 @@ namespace Yamo.PlaygroundCS
         {
             using (var db = CreateContext())
             {
-                var articles = db.Query<Article>($"SELECT {Yamo.Sql.Model.Columns<Article>()} FROM Article");
+                var articles = db.Query<Article>($"SELECT {Yamo.Sql.Model.Columns<Article>()} FROM {Yamo.Sql.Model.Table<Article>()}");
 
                 var data = db.QueryFirstOrDefault<(decimal, Label, Label)?>($@"
                     SELECT a.Price,

--- a/Source/Source/Yamo/Expressions/Builders/SqlExpressionBuilderBase.vb
+++ b/Source/Source/Yamo/Expressions/Builders/SqlExpressionBuilderBase.vb
@@ -75,9 +75,15 @@ Namespace Expressions.Builders
       For i = 0 To args.Length - 1
         Dim value = args(i)
 
-        If TypeOf value Is ModelInfo Then
-          Dim mi = DirectCast(value, ModelInfo)
-          formatArgs(i) = CreateColumnsString(mi.Model, mi.TableAlias)
+        If TypeOf value Is ColumnsModelInfo Then
+          Dim cmi = DirectCast(value, ColumnsModelInfo)
+          formatArgs(i) = CreateColumnsString(cmi.Model, cmi.TableAlias)
+        ElseIf TypeOf value Is ColumnModelInfo Then
+          Dim cmi = DirectCast(value, ColumnModelInfo)
+          formatArgs(i) = CreateColumnString(cmi.Model, cmi.TableAlias, cmi.PropertyName)
+        ElseIf TypeOf value Is TableModelInfo Then
+          Dim tmi = DirectCast(value, TableModelInfo)
+          formatArgs(i) = CreateTableString(tmi.Model)
         ElseIf TypeOf value Is RawSqlString Then
           Dim s = DirectCast(value, RawSqlString)
           formatArgs(i) = s.Value
@@ -124,6 +130,36 @@ Namespace Expressions.Builders
       Next
 
       Return sql.ToString()
+    End Function
+
+    ''' <summary>
+    ''' Creates string containing column.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <param name="model"></param>
+    ''' <param name="tableAlias"></param>
+    ''' <param name="propertyName"></param>
+    ''' <returns></returns>
+    Private Function CreateColumnString(model As Type, tableAlias As String, propertyName As String) As String
+      Dim entity = Me.DbContext.Model.GetEntity(model)
+      Dim prop = entity.GetProperty(propertyName)
+
+      If String.IsNullOrWhiteSpace(tableAlias) Then
+        Return Me.DialectProvider.Formatter.CreateIdentifier(prop.ColumnName)
+      Else
+        Return tableAlias & "." & Me.DialectProvider.Formatter.CreateIdentifier(prop.ColumnName)
+      End If
+    End Function
+
+    ''' <summary>
+    ''' Creates string containing table.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <param name="model"></param>
+    ''' <returns></returns>
+    Private Function CreateTableString(model As Type) As String
+      Dim entity = Me.DbContext.Model.GetEntity(model)
+      Return Me.DialectProvider.Formatter.CreateIdentifier(entity.TableName, entity.Schema)
     End Function
 
   End Class

--- a/Source/Source/Yamo/Sql/ColumnModelInfo.vb
+++ b/Source/Source/Yamo/Sql/ColumnModelInfo.vb
@@ -1,0 +1,40 @@
+﻿Namespace Sql
+
+  ''' <summary>
+  ''' Stores info about column of a model.<br/>
+  ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+  ''' </summary>
+  Public Structure ColumnModelInfo
+
+    ''' <summary>
+    ''' Type of model entity (table).
+    ''' </summary>
+    ''' <returns></returns>
+    Public ReadOnly Property Model As Type
+
+    ''' <summary>
+    ''' Entity property name.
+    ''' </summary>
+    ''' <returns></returns>
+    Public ReadOnly Property PropertyName As String
+
+    ''' <summary>
+    ''' Table alias used in SQL expression.
+    ''' </summary>
+    ''' <returns></returns>
+    Public ReadOnly Property TableAlias As String
+
+    ''' <summary>
+    ''' Creates new instance of <see cref="ColumnModelInfo"/>.
+    ''' </summary>
+    ''' <param name="model"></param>
+    ''' <param name="propertyName"></param>
+    ''' <param name="tableAlias"></param>
+    Public Sub New(model As Type, propertyName As String, tableAlias As String)
+      Me.Model = model
+      Me.TableAlias = tableAlias
+      Me.PropertyName = propertyName
+    End Sub
+
+  End Structure
+End Namespace

--- a/Source/Source/Yamo/Sql/ColumnsModelInfo.vb
+++ b/Source/Source/Yamo/Sql/ColumnsModelInfo.vb
@@ -1,10 +1,10 @@
 ﻿Namespace Sql
 
   ''' <summary>
-  ''' Stores info about model and its alias.<br/>
+  ''' Stores info about columns of a model.<br/>
   ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
   ''' </summary>
-  Public Structure ModelInfo
+  Public Structure ColumnsModelInfo
 
     ''' <summary>
     ''' Type of model entity (table).
@@ -19,7 +19,7 @@
     Public ReadOnly Property TableAlias As String
 
     ''' <summary>
-    ''' Creates new instance of <see cref="ModelInfo"/>.
+    ''' Creates new instance of <see cref="ColumnsModelInfo"/>.
     ''' </summary>
     ''' <param name="model"></param>
     ''' <param name="tableAlias"></param>

--- a/Source/Source/Yamo/Sql/Model.vb
+++ b/Source/Source/Yamo/Sql/Model.vb
@@ -17,8 +17,30 @@ Namespace Sql
     ''' <typeparam name="T"></typeparam>
     ''' <param name="tableAlias"></param>
     ''' <returns></returns>
-    Public Shared Function Columns(Of T)(Optional tableAlias As String = Nothing) As ModelInfo
-      Return New ModelInfo(GetType(T), tableAlias)
+    Public Shared Function Columns(Of T)(Optional tableAlias As String = Nothing) As ColumnsModelInfo
+      Return New ColumnsModelInfo(GetType(T), tableAlias)
+    End Function
+
+    ''' <summary>
+    ''' Translates to SQL expression that contains column of defined entity (table).<br/>
+    ''' This method is not intended to be called directly. Use it only as a part of the query expression.
+    ''' </summary>
+    ''' <typeparam name="T"></typeparam>
+    ''' <param name="propertyName"></param>
+    ''' <param name="tableAlias"></param>
+    ''' <returns></returns>
+    Public Shared Function Column(Of T)(propertyName As String, Optional tableAlias As String = Nothing) As ColumnModelInfo
+      Return New ColumnModelInfo(GetType(T), propertyName, tableAlias)
+    End Function
+
+    ''' <summary>
+    ''' Translates to SQL expression that contains table name of defined entity.<br/>
+    ''' This method is not intended to be called directly. Use it only as a part of the query expression.
+    ''' </summary>
+    ''' <typeparam name="T"></typeparam>
+    ''' <returns></returns>
+    Public Shared Function Table(Of T)() As TableModelInfo
+      Return New TableModelInfo(GetType(T))
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Sql/TableModelInfo.vb
+++ b/Source/Source/Yamo/Sql/TableModelInfo.vb
@@ -1,0 +1,24 @@
+﻿Namespace Sql
+
+  ''' <summary>
+  ''' Stores info about table of a model.<br/>
+  ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+  ''' </summary>
+  Public Structure TableModelInfo
+
+    ''' <summary>
+    ''' Type of model entity (table).
+    ''' </summary>
+    ''' <returns></returns>
+    Public ReadOnly Property Model As Type
+
+    ''' <summary>
+    ''' Creates new instance of <see cref="TableModelInfo"/>.
+    ''' </summary>
+    ''' <param name="model"></param>
+    Public Sub New(model As Type)
+      Me.Model = model
+    End Sub
+
+  End Structure
+End Namespace

--- a/Source/Test/Yamo.SQLite.Test/Tests/SqlHelperModelTests.vb
+++ b/Source/Test/Yamo.SQLite.Test/Tests/SqlHelperModelTests.vb
@@ -1,0 +1,14 @@
+﻿Imports Yamo.Test
+
+Namespace Tests
+
+  <TestClass()>
+  Public Class SqlHelperModelTests
+    Inherits Yamo.Test.Tests.SqlHelperModelTests
+
+    Protected Overrides Function CreateTestEnvironment() As ITestEnvironment
+      Return SQLiteTestEnvironment.Create()
+    End Function
+
+  End Class
+End Namespace

--- a/Source/Test/Yamo.SQLite.Test/Yamo.SQLite.Test.vbproj
+++ b/Source/Test/Yamo.SQLite.Test/Yamo.SQLite.Test.vbproj
@@ -107,6 +107,7 @@
     <Compile Include="Tests\CustomSelectTests.vb" />
     <Compile Include="Tests\SelectTests.vb" />
     <Compile Include="Tests\SelectWithLimitTests.vb" />
+    <Compile Include="Tests\SqlHelperModelTests.vb" />
     <Compile Include="Tests\SqlHelperExpTests.vb" />
     <Compile Include="Tests\SqlHelperAggregateTests.vb" />
     <Compile Include="Tests\SqlHelperDateTimeTests.vb" />

--- a/Source/Test/Yamo.SqlServer.Test/Tests/SqlHelperModelTests.vb
+++ b/Source/Test/Yamo.SqlServer.Test/Tests/SqlHelperModelTests.vb
@@ -1,0 +1,14 @@
+﻿Imports Yamo.Test
+
+Namespace Tests
+
+  <TestClass()>
+  Public Class SqlHelperModelTests
+    Inherits Yamo.Test.Tests.SqlHelperModelTests
+
+    Protected Overrides Function CreateTestEnvironment() As ITestEnvironment
+      Return SqlServerTestEnvironment.Create()
+    End Function
+
+  End Class
+End Namespace

--- a/Source/Test/Yamo.SqlServer.Test/Yamo.SqlServer.Test.vbproj
+++ b/Source/Test/Yamo.SqlServer.Test/Yamo.SqlServer.Test.vbproj
@@ -88,6 +88,7 @@
     <Compile Include="Tests\CustomSelectTests.vb" />
     <Compile Include="Tests\SelectTests.vb" />
     <Compile Include="Tests\SelectWithLimitTests.vb" />
+    <Compile Include="Tests\SqlHelperModelTests.vb" />
     <Compile Include="Tests\SqlHelperExpTests.vb" />
     <Compile Include="Tests\SqlHelperAggregateTests.vb" />
     <Compile Include="Tests\SqlHelperDateTimeTests.vb" />

--- a/Source/Test/Yamo.Test/Tests/SelectWithTableSourceTests.vb
+++ b/Source/Test/Yamo.Test/Tests/SelectWithTableSourceTests.vb
@@ -58,8 +58,7 @@ Namespace Tests
       InsertItemsToArchive(ArticleArchiveTableName, article1, article2, article3)
 
       Using db = CreateDbContext()
-        ' order of columns in SELECT clause is important!
-        Dim result = db.From(Of Article)("(SELECT Id, Price FROM ArticleArchive WHERE Id < {0})", 3).
+        Dim result = db.From(Of Article)("(SELECT {0} FROM ArticleArchive WHERE Id < {1})", Sql.Model.Columns(Of Article), 3).
                         SelectAll().ToList()
 
         CollectionAssert.AreEquivalent({article1, article2}, result)
@@ -131,9 +130,8 @@ Namespace Tests
       InsertItemsToArchive(LabelArchiveTableName, label1En, label3En, label3De)
 
       Using db = CreateDbContext()
-        ' order of columns in SELECT clause is important!
         Dim result = db.From(Of Article).
-                        Join(Of Label)("(SELECT TableId, Id, Language, Description FROM LabelArchive WHERE Language = {0})", English).
+                        Join(Of Label)("(SELECT {0} FROM LabelArchive WHERE Language = {1})", Sql.Model.Columns(Of Label), English).
                         On(Function(a, l) a.Id = l.Id).
                         SelectAll().ToList()
 
@@ -210,9 +208,8 @@ Namespace Tests
       InsertItemsToArchive(LabelArchiveTableName, label1En, label3En, label3De)
 
       Using db = CreateDbContext()
-        ' order of columns in SELECT clause is important!
         Dim result = db.From(Of Article).
-                        LeftJoin(Of Label)("(SELECT TableId, Id, Language, Description FROM LabelArchive WHERE Language = {0})", English).
+                        LeftJoin(Of Label)("(SELECT {0} FROM LabelArchive WHERE Language = {1})", Sql.Model.Columns(Of Label), English).
                         On(Function(a, l) a.Id = l.Id).
                         SelectAll().ToList()
 
@@ -288,9 +285,8 @@ Namespace Tests
       InsertItemsToArchive(LabelArchiveTableName, label1En, label3En, label3De)
 
       Using db = CreateDbContext()
-        ' order of columns in SELECT clause is important!
         Dim result = db.From(Of Article).
-                        RightJoin(Of Label)("(SELECT TableId, Id, Language, Description FROM LabelArchive WHERE Language = {0})", English).
+                        RightJoin(Of Label)("(SELECT {0} FROM LabelArchive WHERE Language = {1})", Sql.Model.Columns(Of Label), English).
                         On(Function(a, l) a.Id = l.Id).
                         SelectAll().ToList()
 
@@ -367,9 +363,8 @@ Namespace Tests
       InsertItemsToArchive(LabelArchiveTableName, label1En, label3En, label3De)
 
       Using db = CreateDbContext()
-        ' order of columns in SELECT clause is important!
         Dim result = db.From(Of Article).
-                        FullJoin(Of Label)("(SELECT TableId, Id, Language, Description FROM LabelArchive WHERE Language = {0})", English).
+                        FullJoin(Of Label)("(SELECT {0} FROM LabelArchive WHERE Language = {1})", Sql.Model.Columns(Of Label), English).
                         On(Function(a, l) a.Id = l.Id).
                         SelectAll().ToList()
 
@@ -453,9 +448,8 @@ Namespace Tests
       InsertItemsToArchive(LabelArchiveTableName, label1En, label3En, label3De)
 
       Using db = CreateDbContext()
-        ' order of columns in SELECT clause is important!
         Dim result = db.From(Of Article).
-                        CrossJoin(Of Label)("(SELECT TableId, Id, Language, Description FROM LabelArchive WHERE Language = {0})", English).
+                        CrossJoin(Of Label)("(SELECT {0} FROM LabelArchive WHERE Language = {1})", Sql.Model.Columns(Of Label), English).
                         SelectAll().ToList()
 
         Assert.AreEqual(6, result.Count)

--- a/Source/Test/Yamo.Test/Tests/SqlHelperModelTests.vb
+++ b/Source/Test/Yamo.Test/Tests/SqlHelperModelTests.vb
@@ -1,0 +1,101 @@
+﻿Imports Yamo.Test.Model
+
+Namespace Tests
+
+  Public MustInherit Class SqlHelperModelTests
+    Inherits BaseIntegrationTests
+
+    <TestMethod()>
+    Public Overridable Sub QueryUsingColumns()
+      Dim items = CreateItems()
+
+      InsertItems(items)
+
+      Using db = CreateDbContext()
+        Dim result = db.Query(Of ItemWithAllSupportedValues)($"SELECT {Sql.Model.Columns(Of ItemWithAllSupportedValues)} FROM ItemWithAllSupportedValues")
+        CollectionAssert.AreEquivalent(items, result)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub QueryUsingColumnsWithAlias()
+      Dim items = CreateItems()
+
+      InsertItems(items)
+
+      Using db = CreateDbContext()
+        Dim result = db.Query(Of ItemWithAllSupportedValues)($"SELECT {Sql.Model.Columns(Of ItemWithAllSupportedValues)("t")} FROM ItemWithAllSupportedValues t")
+        CollectionAssert.AreEquivalent(items, result)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub QueryUsingColumn()
+      Dim items = CreateItems()
+      items(0).IntColumn = 1
+      items(1).IntColumn = 2
+      items(2).IntColumn = 3
+      items(3).IntColumn = 4
+      items(4).IntColumn = 5
+
+      InsertItems(items)
+
+      Using db = CreateDbContext()
+        Dim result = db.Query(Of Int32)($"SELECT {Sql.Model.Column(Of ItemWithAllSupportedValues)(NameOf(ItemWithAllSupportedValues.IntColumn))} FROM ItemWithAllSupportedValues")
+        CollectionAssert.AreEquivalent({1, 2, 3, 4, 5}, result)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub QueryUsingColumnWithAlias()
+      Dim items = CreateItems()
+      items(0).IntColumn = 1
+      items(1).IntColumn = 2
+      items(2).IntColumn = 3
+      items(3).IntColumn = 4
+      items(4).IntColumn = 5
+
+      InsertItems(items)
+
+      Using db = CreateDbContext()
+        Dim result = db.Query(Of Int32)($"SELECT {Sql.Model.Column(Of ItemWithAllSupportedValues)(NameOf(ItemWithAllSupportedValues.IntColumn), "t")} FROM ItemWithAllSupportedValues t")
+        CollectionAssert.AreEquivalent({1, 2, 3, 4, 5}, result)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub QueryUsingTable()
+      Dim items = CreateItems()
+
+      InsertItems(items)
+
+      Using db = CreateDbContext()
+        Dim result = db.Query(Of ItemWithAllSupportedValues)($"SELECT {Sql.Model.Columns(Of ItemWithAllSupportedValues)} FROM {Sql.Model.Table(Of ItemWithAllSupportedValues)}")
+        CollectionAssert.AreEquivalent(items, result)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub QueryUsingRawSqlString()
+      Dim items = CreateItems()
+
+      InsertItems(items)
+
+      Using db = CreateDbContext()
+        Dim result = db.Query(Of ItemWithAllSupportedValues)("SELECT {0} FROM {1}", Sql.Model.Columns(Of ItemWithAllSupportedValues), Sql.Model.Table(Of ItemWithAllSupportedValues))
+        CollectionAssert.AreEquivalent(items, result)
+      End Using
+    End Sub
+
+    Protected Overridable Function CreateItems() As List(Of ItemWithAllSupportedValues)
+      Return New List(Of ItemWithAllSupportedValues) From {
+        Me.ModelFactory.CreateItemWithAllSupportedValuesWithEmptyValues(),
+        Me.ModelFactory.CreateItemWithAllSupportedValuesWithEmptyValues(),
+        Me.ModelFactory.CreateItemWithAllSupportedValuesWithEmptyValues(),
+        Me.ModelFactory.CreateItemWithAllSupportedValuesWithEmptyValues(),
+        Me.ModelFactory.CreateItemWithAllSupportedValuesWithEmptyValues()
+      }
+    End Function
+
+  End Class
+End Namespace

--- a/Source/Test/Yamo.Test/Yamo.Test.vbproj
+++ b/Source/Test/Yamo.Test/Yamo.Test.vbproj
@@ -89,6 +89,7 @@
     <Compile Include="Tests\SelectWithTableSourceTests.vb" />
     <Compile Include="Tests\SelectWithConditionTests.vb" />
     <Compile Include="Tests\SelectWithLimitTests.vb" />
+    <Compile Include="Tests\SqlHelperModelTests.vb" />
     <Compile Include="Tests\SqlHelperExpTests.vb" />
     <Compile Include="UnitTestDbContextOptionsExtensions.vb" />
     <Compile Include="UnitTestDialectProvider.vb" />


### PR DESCRIPTION
Added new SQL helper methods `Column` and `Table`:
```cs
using (var db = CreateContext())
{
    var articles = db.Query<Article>($"SELECT {Yamo.Sql.Model.Columns<Article>()} FROM {Yamo.Sql.Model.Table<Article>()}");
    var ids = db.Query<int>($"SELECT {Yamo.Sql.Model.Column<Article>(nameof(Article.Id))} FROM {Yamo.Sql.Model.Table<Article>()}");
}
```