### PR TITLE
Added support to force update all fields of IHasDbPropertyModifiedTracking object

### DIFF
--- a/Source/Source/Yamo/DbContext.vb
+++ b/Source/Source/Yamo/DbContext.vb
@@ -241,9 +241,10 @@ Public Class DbContext
   ''' <typeparam name="T"></typeparam>
   ''' <param name="obj"></param>
   ''' <param name="setAutoFields"></param>
+  ''' <param name="forceUpdateAllFields"></param>
   ''' <returns></returns>
-  Public Function Update(Of T)(obj As T, Optional setAutoFields As Boolean = True) As Int32
-    Return (New UpdateSqlExpression(Of T)(Me)).Execute(obj, setAutoFields)
+  Public Function Update(Of T)(obj As T, Optional setAutoFields As Boolean = True, Optional forceUpdateAllFields As Boolean = False) As Int32
+    Return (New UpdateSqlExpression(Of T)(Me)).Execute(obj, setAutoFields, forceUpdateAllFields)
   End Function
 
   ''' <summary>

--- a/Source/Source/Yamo/Expressions/Builders/UpdateSqlExpressionBuilder.vb
+++ b/Source/Source/Yamo/Expressions/Builders/UpdateSqlExpressionBuilder.vb
@@ -202,8 +202,9 @@ Namespace Expressions.Builders
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
     ''' <param name="obj"></param>
+    ''' <param name="forceUpdateAllFields"></param>
     ''' <returns></returns>
-    Public Function CreateQuery(obj As Object) As Query
+    Public Function CreateQuery(obj As Object, forceUpdateAllFields As Boolean) As Query
       Dim table As String
 
       If m_TableNameOverride Is Nothing Then
@@ -214,7 +215,7 @@ Namespace Expressions.Builders
       End If
 
       Dim provider = EntitySqlStringProviderCache.GetUpdateProvider(Me, obj.GetType())
-      Dim sqlString = provider(obj, table)
+      Dim sqlString = provider(obj, table, forceUpdateAllFields)
 
       Return New Query(sqlString)
     End Function

--- a/Source/Source/Yamo/Expressions/UpdateSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/UpdateSqlExpression.vb
@@ -93,9 +93,10 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="obj"></param>
     ''' <param name="setAutoFields"></param>
+    ''' <param name="forceUpdateAllFields"></param>
     ''' <returns></returns>
-    Public Function Execute(obj As T, Optional setAutoFields As Boolean = True) As Int32
-      If SkipUpdate(obj) Then
+    Public Function Execute(obj As T, Optional setAutoFields As Boolean = True, Optional forceUpdateAllFields As Boolean = False) As Int32
+      If Not forceUpdateAllFields And SkipUpdate(obj) Then
         Return 0
       End If
 
@@ -104,7 +105,7 @@ Namespace Expressions
         setter(obj, Me.DbContext)
       End If
 
-      Dim query = Me.Builder.CreateQuery(obj)
+      Dim query = Me.Builder.CreateQuery(obj, forceUpdateAllFields)
       Dim affectedRows = Me.Executor.Execute(query)
       ResetDbPropertyModifiedTracking(obj)
       Return affectedRows

--- a/Source/Source/Yamo/Internal/EntitySqlStringProviderCache.vb
+++ b/Source/Source/Yamo/Internal/EntitySqlStringProviderCache.vb
@@ -24,7 +24,7 @@ Namespace Internal
     ''' <summary>
     ''' Stores cached update provider instances.
     ''' </summary>
-    Private m_UpdateProviders As Dictionary(Of Type, Func(Of Object, String, SqlString))
+    Private m_UpdateProviders As Dictionary(Of Type, Func(Of Object, String, Boolean, SqlString))
 
     ''' <summary>
     ''' Stores cached delete provider instances.
@@ -53,7 +53,7 @@ Namespace Internal
     ''' </summary>
     Private Sub New()
       m_InsertProviders = New Dictionary(Of Type, Func(Of Object, String, Boolean, CreateInsertSqlStringResult))
-      m_UpdateProviders = New Dictionary(Of Type, Func(Of Object, String, SqlString))
+      m_UpdateProviders = New Dictionary(Of Type, Func(Of Object, String, Boolean, SqlString))
       m_DeleteProviders = New Dictionary(Of Type, Func(Of Object, String, SqlString))
       m_SoftDeleteProviders = New Dictionary(Of Type, Func(Of Object, String, SqlString))
       m_SoftDeleteWithoutConditionProviders = New Dictionary(Of Type, Func(Of String, Object(), SqlString))
@@ -77,7 +77,7 @@ Namespace Internal
     ''' <param name="builder"></param>
     ''' <param name="type"></param>
     ''' <returns></returns>
-    Public Shared Function GetUpdateProvider(builder As UpdateSqlExpressionBuilder, type As Type) As Func(Of Object, String, SqlString)
+    Public Shared Function GetUpdateProvider(builder As UpdateSqlExpressionBuilder, type As Type) As Func(Of Object, String, Boolean, SqlString)
       Return GetInstance(builder.DialectProvider, builder.DbContext.Model).GetOrCreateUpdateProvider(builder, type)
     End Function
 
@@ -167,8 +167,8 @@ Namespace Internal
     ''' <param name="builder"></param>
     ''' <param name="type"></param>
     ''' <returns></returns>
-    Private Function GetOrCreateUpdateProvider(builder As UpdateSqlExpressionBuilder, type As Type) As Func(Of Object, String, SqlString)
-      Dim provider As Func(Of Object, String, SqlString) = Nothing
+    Private Function GetOrCreateUpdateProvider(builder As UpdateSqlExpressionBuilder, type As Type) As Func(Of Object, String, Boolean, SqlString)
+      Dim provider As Func(Of Object, String, Boolean, SqlString) = Nothing
 
       SyncLock m_UpdateProviders
         m_UpdateProviders.TryGetValue(type, provider)

--- a/Source/Test/Yamo.Test/Tests/PropertyModifiedTrackingTests.vb
+++ b/Source/Test/Yamo.Test/Tests/PropertyModifiedTrackingTests.vb
@@ -100,6 +100,102 @@ Namespace Tests
     End Sub
 
     <TestMethod()>
+    Public Overridable Sub UpdateRecordWithPropertyModifiedTrackingUsingForceUpdateAllFields()
+      Dim item = Me.ModelFactory.CreateItemWithPropertyModifiedTracking()
+      item.Description = "foo"
+      item.IntValue = 42
+
+      Using db = CreateDbContext()
+        db.Insert(item)
+
+        db.Update(Of ItemWithPropertyModifiedTracking).
+           Set(Sub(x) x.Description = "boo").
+           Set(Sub(x) x.IntValue = 10).
+           Execute()
+
+        Dim result = db.From(Of ItemWithPropertyModifiedTracking).SelectAll().FirstOrDefault()
+        Assert.AreNotEqual(item, result)
+        Assert.AreEqual(item.Id, result.Id)
+        Assert.AreEqual("boo", result.Description)
+        Assert.AreEqual(10, result.IntValue)
+      End Using
+
+      Assert.IsFalse(item.IsAnyDbPropertyModified())
+
+      Using db = CreateDbContext()
+        Dim affectedRows = db.Update(item)
+        Assert.AreEqual(0, affectedRows)
+        Assert.IsFalse(item.IsAnyDbPropertyModified())
+
+        Dim result = db.From(Of ItemWithPropertyModifiedTracking).SelectAll().FirstOrDefault()
+        Assert.AreNotEqual(item, result)
+        Assert.AreEqual(item.Id, result.Id)
+        Assert.AreEqual("boo", result.Description)
+        Assert.AreEqual(10, result.IntValue)
+      End Using
+
+      Using db = CreateDbContext()
+        Dim affectedRows = db.Update(item, forceUpdateAllFields:=True)
+        Assert.AreEqual(1, affectedRows)
+        Assert.IsFalse(item.IsAnyDbPropertyModified())
+
+        Dim result = db.From(Of ItemWithPropertyModifiedTracking).SelectAll().FirstOrDefault()
+        Assert.AreEqual(item, result)
+        Assert.AreEqual(item.Id, result.Id)
+        Assert.AreEqual("foo", result.Description)
+        Assert.AreEqual(42, result.IntValue)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub UpdateRecordWithPropertyModifiedTrackingWithSpecifiedTableNameUsingForceUpdateAllFields()
+      Dim item = Me.ModelFactory.CreateItemWithPropertyModifiedTracking()
+      item.Description = "foo"
+      item.IntValue = 42
+
+      InsertItemsToArchive(ItemWithPropertyModifiedTrackingArchiveTableName, item)
+
+      Using db = CreateDbContext()
+        db.Update(Of ItemWithPropertyModifiedTracking)(ItemWithPropertyModifiedTrackingArchiveTableName).
+           Set(Sub(x) x.Description = "boo").
+           Set(Sub(x) x.IntValue = 10).
+           Execute()
+
+        Dim result = db.From(Of ItemWithPropertyModifiedTracking)(ItemWithPropertyModifiedTrackingArchiveTableName).SelectAll().FirstOrDefault()
+        Assert.AreNotEqual(item, result)
+        Assert.AreEqual(item.Id, result.Id)
+        Assert.AreEqual("boo", result.Description)
+        Assert.AreEqual(10, result.IntValue)
+      End Using
+
+      Assert.IsFalse(item.IsAnyDbPropertyModified())
+
+      Using db = CreateDbContext()
+        Dim affectedRows = db.Update(Of ItemWithPropertyModifiedTracking)(ItemWithPropertyModifiedTrackingArchiveTableName).Execute(item)
+        Assert.AreEqual(0, affectedRows)
+        Assert.IsFalse(item.IsAnyDbPropertyModified())
+
+        Dim result = db.From(Of ItemWithPropertyModifiedTracking)(ItemWithPropertyModifiedTrackingArchiveTableName).SelectAll().FirstOrDefault()
+        Assert.AreNotEqual(item, result)
+        Assert.AreEqual(item.Id, result.Id)
+        Assert.AreEqual("boo", result.Description)
+        Assert.AreEqual(10, result.IntValue)
+      End Using
+
+      Using db = CreateDbContext()
+        Dim affectedRows = db.Update(Of ItemWithPropertyModifiedTracking)(ItemWithPropertyModifiedTrackingArchiveTableName).Execute(item, forceUpdateAllFields:=True)
+        Assert.AreEqual(1, affectedRows)
+        Assert.IsFalse(item.IsAnyDbPropertyModified())
+
+        Dim result = db.From(Of ItemWithPropertyModifiedTracking)(ItemWithPropertyModifiedTrackingArchiveTableName).SelectAll().FirstOrDefault()
+        Assert.AreEqual(item, result)
+        Assert.AreEqual(item.Id, result.Id)
+        Assert.AreEqual("foo", result.Description)
+        Assert.AreEqual(42, result.IntValue)
+      End Using
+    End Sub
+
+    <TestMethod()>
     Public Overridable Sub SelectRecordWithPropertyModifiedTracking()
       Dim item1 = Me.ModelFactory.CreateItemWithPropertyModifiedTracking()
       Dim item2 = Me.ModelFactory.CreateItemWithPropertyModifiedTracking()


### PR DESCRIPTION
There is now a possibility to force update all fields of `IHasDbPropertyModifiedTracking` object, not only its changed properties.

To do so, use new parameter `forceUpdateAllFields`:

```cs
using (var db = CreateContext())
{
    // Foo and Boo implement IHasDbPropertyModifiedTracking
    db.Update<Foo>Execute(foo, forceUpdateAllFields: true);
    db.Update<Boo>(tableName).Execute(boo, forceUpdateAllFields: true);
}
```

Parameter has no effect on objects that don't implement `IHasDbPropertyModifiedTracking` interface.

This resolves #18.