### PR TITLE
Added support for querying large value tuples

### DIFF
--- a/Source/Source/Yamo/Internal/Helpers/CtorInfo.vb
+++ b/Source/Source/Yamo/Internal/Helpers/CtorInfo.vb
@@ -1,0 +1,37 @@
+﻿Imports System.Reflection
+
+Namespace Internal.Helpers
+
+  ''' <summary>
+  ''' Constructor info.<br/>
+  ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+  ''' </summary>
+  Public Structure CtorInfo
+
+    ''' <summary>
+    ''' Gets constructor info.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <returns></returns>
+    Public ReadOnly Property ConstructorInfo As ConstructorInfo
+
+    ''' <summary>
+    ''' Gets cached parameter count for <see cref="ConstructorInfo"/>.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <returns></returns>
+    Public ReadOnly Property ParameterCount As Int32
+
+    ''' <summary>
+    ''' Creates new instance of <see cref="CtorInfo"/>.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <param name="constructorInfo"></param>
+    ''' <param name="parameterCount"></param>
+    Public Sub New(constructorInfo As ConstructorInfo, parameterCount As Int32)
+      Me.ConstructorInfo = constructorInfo
+      Me.ParameterCount = parameterCount
+    End Sub
+
+  End Structure
+End Namespace

--- a/Source/Source/Yamo/Internal/Helpers/ValueTupleTypeInfo.vb
+++ b/Source/Source/Yamo/Internal/Helpers/ValueTupleTypeInfo.vb
@@ -1,0 +1,44 @@
+﻿Namespace Internal.Helpers
+
+  ''' <summary>
+  ''' Value tuple and nullable value tuple type info.<br/>
+  ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+  ''' </summary>
+  Public Class ValueTupleTypeInfo
+
+    ''' <summary>
+    ''' Gets (nullable) value tuple type.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <returns></returns>
+    Public ReadOnly Property ValueTupleType As Type
+
+    ''' <summary>
+    ''' Gets flattened ValueTuple arguments.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <returns></returns>
+    Public ReadOnly Property FlattenedArguments As List(Of Type)
+
+    ''' <summary>
+    ''' Gets nested ValueTuple constructor infos.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <returns></returns>
+    Public ReadOnly Property CtorInfos As List(Of CtorInfo)
+
+    ''' <summary>
+    ''' Creates new instance of <see cref="ValueTupleTypeInfo"/>.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <param name="valueTupleType"></param>
+    ''' <param name="flattenedArguments"></param>
+    ''' <param name="ctorInfos"></param>
+    Public Sub New(valueTupleType As Type, flattenedArguments As List(Of Type), ctorInfos As List(Of CtorInfo))
+      Me.ValueTupleType = valueTupleType
+      Me.FlattenedArguments = flattenedArguments
+      Me.CtorInfos = ctorInfos
+    End Sub
+
+  End Class
+End Namespace

--- a/Source/Source/Yamo/Internal/Query/CustomEntityReadInfo.vb
+++ b/Source/Source/Yamo/Internal/Query/CustomEntityReadInfo.vb
@@ -98,29 +98,25 @@ Namespace Internal.Query
     End Function
 
     ''' <summary>
-    ''' Creates new instances of <see cref="CustomEntityReadInfo"/> for generic type.<br/>
+    ''' Creates new instances of <see cref="CustomEntityReadInfo"/> for (nullable) value tuple type.<br/>
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
     ''' <param name="dialectProvider"></param>
     ''' <param name="model"></param>
     ''' <param name="type"></param>
     ''' <returns></returns>
-    Public Shared Function CreateForGenericType(dialectProvider As SqlDialectProvider, model As Model, type As Type) As CustomEntityReadInfo()
+    Public Shared Function CreateForValueTupleType(dialectProvider As SqlDialectProvider, model As Model, type As Type) As CustomEntityReadInfo()
       Dim underlyingNullableType = Nullable.GetUnderlyingType(type)
 
       If underlyingNullableType IsNot Nothing Then
         type = underlyingNullableType
       End If
 
-      If Not type.IsGenericType Then
-        Throw New ArgumentException($"Type '{type}' is not generic type.")
-      End If
-
-      Dim args = type.GetGenericArguments()
-      Dim result = New CustomEntityReadInfo(args.Length - 1) {}
+      Dim args = Helpers.Types.GetFlattenedValueTupleGenericArguments(type)
+      Dim result = New CustomEntityReadInfo(args.Count - 1) {}
       Dim readerIndex = 0
 
-      For i = 0 To args.Length - 1
+      For i = 0 To args.Count - 1
         Dim argType = args(i)
 
         If Helpers.Types.IsProbablyModel(argType) Then

--- a/Source/Source/Yamo/Internal/Query/QueryExecutor.vb
+++ b/Source/Source/Yamo/Internal/Query/QueryExecutor.vb
@@ -69,7 +69,7 @@ Namespace Internal.Query
               reader = CustomResultReaderCache.GetResultFactory(Of T)(m_DbContext.Model, resultType)
 
               If isValueTuple Then
-                customEntityInfos = CustomEntityReadInfo.CreateForGenericType(m_DialectProvider, m_DbContext.Model, resultType)
+                customEntityInfos = CustomEntityReadInfo.CreateForValueTupleType(m_DialectProvider, m_DbContext.Model, resultType)
               Else
                 customEntityInfos = CustomEntityReadInfo.CreateForModelType(m_DialectProvider, m_DbContext.Model, resultType)
               End If
@@ -104,7 +104,7 @@ Namespace Internal.Query
 
       If isValueTuple Then
         reader = CustomResultReaderCache.GetResultFactory(Of T)(m_DbContext.Model, resultType)
-        customEntityInfos = CustomEntityReadInfo.CreateForGenericType(m_DialectProvider, m_DbContext.Model, resultType)
+        customEntityInfos = CustomEntityReadInfo.CreateForValueTupleType(m_DialectProvider, m_DbContext.Model, resultType)
       ElseIf isModel Then
         reader = CustomResultReaderCache.GetResultFactory(Of T)(m_DbContext.Model, resultType)
         customEntityInfos = CustomEntityReadInfo.CreateForModelType(m_DialectProvider, m_DbContext.Model, resultType)

--- a/Source/Test/Yamo.Test/Tests/CustomSelectTests.vb
+++ b/Source/Test/Yamo.Test/Tests/CustomSelectTests.vb
@@ -1253,6 +1253,77 @@ Namespace Tests
     End Sub
 
     <TestMethod()>
+    Public Overridable Sub CustomSelectOfLargeValueTuple()
+      Dim article1 = Me.ModelFactory.CreateArticle(1)
+      Dim article2 = Me.ModelFactory.CreateArticle(2)
+      Dim article3 = Me.ModelFactory.CreateArticle(3)
+
+      InsertItems(article1, article2, article3)
+
+      Using db = CreateDbContext()
+        ' select large ValueTuple
+        Dim result1 = db.From(Of Article).
+                         Where(Function(a) a.Id = article1.Id).
+                         Select(Function(a) (1, 2, 3, 4, 5, 6, 7, Article:=a)).
+                         FirstOrDefault()
+        Assert.AreEqual((1, 2, 3, 4, 5, 6, 7, article1), result1)
+
+        Dim result2 = db.From(Of Article).
+                         Where(Function(a) a.Id = article1.Id).
+                         Select(Function(a) (1, 2, 3, 4, 5, 6, 7, Article:=a, 9, 10, 11, 12, 13, 14, 15, 16)).
+                         FirstOrDefault()
+        Assert.AreEqual((1, 2, 3, 4, 5, 6, 7, article1, 9, 10, 11, 12, 13, 14, 15, 16), result2)
+
+        ' select large ValueTuple, but no row is returned
+        Dim result3 = db.From(Of Article).
+                         Where(Function(a) a.Id = article1.Id).
+                         Select(Function(a) (1, 2, 3, 4, 5, 6, 7, Article:=a)).
+                         FirstOrDefault()
+        Assert.AreEqual(New ValueTuple(Of Int32, Int32, Int32, Int32, Int32, Int32, Int32, ValueTuple(Of Article))(1, 2, 3, 4, 5, 6, 7, New ValueTuple(Of Article)(article1)), result3)
+
+        Dim result4 = db.From(Of Article).
+                         Where(Function(a) a.Id = -1).
+                         Select(Function(a) (1, 2, 3, 4, 5, 6, 7, Article:=a, 9, 10, 11, 12, 13, 14, 15, 16)).
+                         FirstOrDefault()
+        Assert.AreEqual(New ValueTuple(Of Int32, Int32, Int32, Int32, Int32, Int32, Int32, ValueTuple(Of Article, Int32, Int32, Int32, Int32, Int32, Int32, ValueTuple(Of Int32, Int32)))(0, 0, 0, 0, 0, 0, 0, New ValueTuple(Of Article, Int32, Int32, Int32, Int32, Int32, Int32, ValueTuple(Of Int32, Int32))(Nothing, 0, 0, 0, 0, 0, 0, New ValueTuple(Of Int32, Int32)(0, 0))), result4)
+
+        ' select large ValueTuples
+        Dim result5 = db.From(Of Article).
+                         OrderBy(Function(a) a.Id).
+                         Select(Function(a) (1, 2, 3, 4, 5, 6, 7, Article:=a)).
+                         ToList()
+        Assert.AreEqual(3, result5.Count)
+        Assert.AreEqual((1, 2, 3, 4, 5, 6, 7, article1), result5(0))
+        Assert.AreEqual((1, 2, 3, 4, 5, 6, 7, article2), result5(1))
+        Assert.AreEqual((1, 2, 3, 4, 5, 6, 7, article3), result5(2))
+
+        Dim result6 = db.From(Of Article).
+                         OrderBy(Function(a) a.Id).
+                         Select(Function(a) (1, 2, 3, 4, 5, 6, 7, Article:=a, 9, 10, 11, 12, 13, 14, 15, 16)).
+                         ToList()
+        Assert.AreEqual(3, result6.Count)
+        Assert.AreEqual((1, 2, 3, 4, 5, 6, 7, article1, 9, 10, 11, 12, 13, 14, 15, 16), result6(0))
+        Assert.AreEqual((1, 2, 3, 4, 5, 6, 7, article2, 9, 10, 11, 12, 13, 14, 15, 16), result6(1))
+        Assert.AreEqual((1, 2, 3, 4, 5, 6, 7, article3, 9, 10, 11, 12, 13, 14, 15, 16), result6(2))
+
+        ' select large ValueTuples, but no row is returned
+        Dim result7 = db.From(Of Article).
+                         Where(Function(a) a.Id = -1).
+                         OrderBy(Function(a) a.Id).
+                         Select(Function(a) (1, 2, 3, 4, 5, 6, 7, Article:=a)).
+                         ToList()
+        Assert.AreEqual(0, result7.Count)
+
+        Dim result8 = db.From(Of Article).
+                         Where(Function(a) a.Id = -1).
+                         OrderBy(Function(a) a.Id).
+                         Select(Function(a) (1, 2, 3, 4, 5, 6, 7, Article:=a, 9, 10, 11, 12, 13, 14, 15, 16)).
+                         ToList()
+        Assert.AreEqual(0, result8.Count)
+      End Using
+    End Sub
+
+    <TestMethod()>
     Public Overridable Sub CustomSelectOfValueTupleWithMultipleEntities()
       Dim article1 = Me.ModelFactory.CreateArticle(1)
       Dim article2 = Me.ModelFactory.CreateArticle(2)

--- a/Source/Test/Yamo.Test/Tests/QueryFirstOrDefaultTests.vb
+++ b/Source/Test/Yamo.Test/Tests/QueryFirstOrDefaultTests.vb
@@ -671,5 +671,68 @@ Namespace Tests
       End Using
     End Sub
 
+    <TestMethod()>
+    Public Overridable Sub QueryFirstOrDefaultOfLargeValueTuple()
+      Dim article1 = Me.ModelFactory.CreateArticle(1)
+      Dim article2 = Me.ModelFactory.CreateArticle(2)
+      Dim article3 = Me.ModelFactory.CreateArticle(3)
+
+      InsertItems(article1, article2, article3)
+
+      Using db = CreateDbContext()
+        ' 7 elements: (Int32, Int32, Int32, Int32, Int32, Int32, Int32)
+        Dim result1 = db.QueryFirstOrDefault(Of (Int32, Int32, Int32, Int32, Int32, Int32, Int32))("SELECT 1, 2, 3, 4, 5, 6, Id FROM Article WHERE 1 = 2")
+        Assert.AreEqual(New ValueTuple(Of Int32, Int32, Int32, Int32, Int32, Int32, Int32), result1)
+
+        Dim result2 = db.QueryFirstOrDefault(Of (Int32, Int32, Int32, Int32, Int32, Int32, Int32)?)("SELECT 1, 2, 3, 4, 5, 6, Id FROM Article WHERE 1 = 2")
+        Assert.IsFalse(result2.HasValue)
+
+        Dim result3 = db.QueryFirstOrDefault(Of (Int32, Int32, Int32, Int32, Int32, Int32, Int32))($"SELECT 1, 2, 3, 4, 5, 6, Id FROM Article WHERE Id = {article1.Id}")
+        Assert.AreEqual((1, 2, 3, 4, 5, 6, 1), result3)
+
+        Dim result4 = db.QueryFirstOrDefault(Of (Int32, Int32, Int32, Int32, Int32, Int32, Int32)?)($"SELECT 1, 2, 3, 4, 5, 6, Id FROM Article WHERE Id = {article1.Id}")
+        Assert.AreEqual((1, 2, 3, 4, 5, 6, 1), result4.Value)
+
+        ' 8 elements: (Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32))
+        Dim result5 = db.QueryFirstOrDefault(Of (Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32))("SELECT 1, 2, 3, 4, 5, 6, 7, Id FROM Article WHERE 1 = 2")
+        Assert.AreEqual(New ValueTuple(Of Int32, Int32, Int32, Int32, Int32, Int32, Int32, ValueTuple(Of Int32))(0, 0, 0, 0, 0, 0, 0, New ValueTuple(Of Int32)(0)), result5)
+
+        Dim result6 = db.QueryFirstOrDefault(Of (Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32)?)("SELECT 1, 2, 3, 4, 5, 6, 7, Id FROM Article WHERE 1 = 2")
+        Assert.IsFalse(result6.HasValue)
+
+        Dim result7 = db.QueryFirstOrDefault(Of (Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32))($"SELECT 1, 2, 3, 4, 5, 6, 7, Id FROM Article WHERE Id = {article1.Id}")
+        Assert.AreEqual((1, 2, 3, 4, 5, 6, 7, 1), result7)
+
+        Dim result8 = db.QueryFirstOrDefault(Of (Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32)?)($"SELECT 1, 2, 3, 4, 5, 6, 7, Id FROM Article WHERE Id = {article1.Id}")
+        Assert.AreEqual((1, 2, 3, 4, 5, 6, 7, 1), result8.Value)
+
+        ' 15 elements: (Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Article)))
+        Dim result9 = db.QueryFirstOrDefault(Of (Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Article))($"SELECT 1, 2, 3, 4, 5, 6, 7, 8, Id, 10, 11, 12, 13, 14, {Sql.Model.Columns(Of Article)()} FROM Article WHERE 1 = 2")
+        Assert.AreEqual(New ValueTuple(Of Int32, Int32, Int32, Int32, Int32, Int32, Int32, ValueTuple(Of Int32, Int32, Int32, Int32, Int32, Int32, Int32, ValueTuple(Of Article)))(0, 0, 0, 0, 0, 0, 0, New ValueTuple(Of Int32, Int32, Int32, Int32, Int32, Int32, Int32, ValueTuple(Of Article))(0, 0, 0, 0, 0, 0, 0, New ValueTuple(Of Article)(Nothing))), result9)
+
+        Dim result10 = db.QueryFirstOrDefault(Of (Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Article)?)($"SELECT 1, 2, 3, 4, 5, 6, 7, 8, Id, 10, 11, 12, 13, 14, {Sql.Model.Columns(Of Article)()} FROM Article WHERE 1 = 2")
+        Assert.IsFalse(result10.HasValue)
+
+        Dim result11 = db.QueryFirstOrDefault(Of (Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Article))($"SELECT 1, 2, 3, 4, 5, 6, 7, 8, Id, 10, 11, 12, 13, 14, {Sql.Model.Columns(Of Article)()} FROM Article WHERE Id = {article1.Id}")
+        Assert.AreEqual((1, 2, 3, 4, 5, 6, 7, 8, 1, 10, 11, 12, 13, 14, article1), result11)
+
+        Dim result12 = db.QueryFirstOrDefault(Of (Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Article)?)($"SELECT 1, 2, 3, 4, 5, 6, 7, 8, Id, 10, 11, 12, 13, 14, {Sql.Model.Columns(Of Article)()} FROM Article WHERE Id = {article1.Id}")
+        Assert.AreEqual((1, 2, 3, 4, 5, 6, 7, 8, 1, 10, 11, 12, 13, 14, article1), result12.Value)
+
+        ' 16 elements (Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Article, Int32)))
+        Dim result13 = db.QueryFirstOrDefault(Of (Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Article, Int32))($"SELECT 1, 2, 3, 4, 5, 6, 7, 8, Id, 10, 11, 12, 13, 14, {Sql.Model.Columns(Of Article)()}, 16 FROM Article WHERE 1 = 2")
+        Assert.AreEqual(New ValueTuple(Of Int32, Int32, Int32, Int32, Int32, Int32, Int32, ValueTuple(Of Int32, Int32, Int32, Int32, Int32, Int32, Int32, ValueTuple(Of Article, Int32)))(0, 0, 0, 0, 0, 0, 0, New ValueTuple(Of Int32, Int32, Int32, Int32, Int32, Int32, Int32, ValueTuple(Of Article, Int32))(0, 0, 0, 0, 0, 0, 0, New ValueTuple(Of Article, Int32)(Nothing, 0))), result13)
+
+        Dim result14 = db.QueryFirstOrDefault(Of (Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Article, Int32)?)($"SELECT 1, 2, 3, 4, 5, 6, 7, 8, Id, 10, 11, 12, 13, 14, {Sql.Model.Columns(Of Article)()}, 16 FROM Article WHERE 1 = 2")
+        Assert.IsFalse(result14.HasValue)
+
+        Dim result15 = db.QueryFirstOrDefault(Of (Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Article, Int32))($"SELECT 1, 2, 3, 4, 5, 6, 7, 8, Id, 10, 11, 12, 13, 14, {Sql.Model.Columns(Of Article)()}, 16 FROM Article WHERE Id = {article1.Id}")
+        Assert.AreEqual((1, 2, 3, 4, 5, 6, 7, 8, 1, 10, 11, 12, 13, 14, article1, 16), result15)
+
+        Dim result16 = db.QueryFirstOrDefault(Of (Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Article, Int32)?)($"SELECT 1, 2, 3, 4, 5, 6, 7, 8, Id, 10, 11, 12, 13, 14, {Sql.Model.Columns(Of Article)()}, 16 FROM Article WHERE Id = {article1.Id}")
+        Assert.AreEqual((1, 2, 3, 4, 5, 6, 7, 8, 1, 10, 11, 12, 13, 14, article1, 16), result16.Value)
+      End Using
+    End Sub
+
   End Class
 End Namespace

--- a/Source/Test/Yamo.Test/Tests/QueryTests.vb
+++ b/Source/Test/Yamo.Test/Tests/QueryTests.vb
@@ -802,5 +802,92 @@ Namespace Tests
       End Using
     End Sub
 
+    <TestMethod()>
+    Public Overridable Sub QueryOfLargeValueTuple()
+      Dim article1 = Me.ModelFactory.CreateArticle(1)
+      Dim article2 = Me.ModelFactory.CreateArticle(2)
+      Dim article3 = Me.ModelFactory.CreateArticle(3)
+
+      InsertItems(article1, article2, article3)
+
+      Using db = CreateDbContext()
+        ' 7 elements: (Int32, Int32, Int32, Int32, Int32, Int32, Int32)
+        Dim result1 = db.Query(Of (Int32, Int32, Int32, Int32, Int32, Int32, Int32))("SELECT 1, 2, 3, 4, 5, 6, Id FROM Article WHERE 1 = 2 ORDER BY Id")
+        Assert.AreEqual(0, result1.Count)
+
+        Dim result2 = db.Query(Of (Int32, Int32, Int32, Int32, Int32, Int32, Int32)?)("SELECT 1, 2, 3, 4, 5, 6, Id FROM Article WHERE 1 = 2 ORDER BY Id")
+        Assert.AreEqual(0, result2.Count)
+
+        Dim result3 = db.Query(Of (Int32, Int32, Int32, Int32, Int32, Int32, Int32))("SELECT 1, 2, 3, 4, 5, 6, Id FROM Article ORDER BY Id")
+        Assert.AreEqual(3, result3.Count)
+        Assert.AreEqual((1, 2, 3, 4, 5, 6, 1), result3(0))
+        Assert.AreEqual((1, 2, 3, 4, 5, 6, 2), result3(1))
+        Assert.AreEqual((1, 2, 3, 4, 5, 6, 3), result3(2))
+
+        Dim result4 = db.Query(Of (Int32, Int32, Int32, Int32, Int32, Int32, Int32)?)("SELECT 1, 2, 3, 4, 5, 6, Id FROM Article ORDER BY Id")
+        Assert.AreEqual(3, result4.Count)
+        Assert.AreEqual((1, 2, 3, 4, 5, 6, 1), result4(0).Value)
+        Assert.AreEqual((1, 2, 3, 4, 5, 6, 2), result4(1).Value)
+        Assert.AreEqual((1, 2, 3, 4, 5, 6, 3), result4(2).Value)
+
+        ' 8 elements: (Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32))
+        Dim result5 = db.Query(Of (Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32))("SELECT 1, 2, 3, 4, 5, 6, 7, Id FROM Article WHERE 1 = 2 ORDER BY Id")
+        Assert.AreEqual(0, result5.Count)
+
+        Dim result6 = db.Query(Of (Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32)?)("SELECT 1, 2, 3, 4, 5, 6, 7, Id FROM Article WHERE 1 = 2 ORDER BY Id")
+        Assert.AreEqual(0, result6.Count)
+
+        Dim result7 = db.Query(Of (Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32))("SELECT 1, 2, 3, 4, 5, 6, 7, Id FROM Article ORDER BY Id")
+        Assert.AreEqual(3, result7.Count)
+        Assert.AreEqual((1, 2, 3, 4, 5, 6, 7, 1), result7(0))
+        Assert.AreEqual((1, 2, 3, 4, 5, 6, 7, 2), result7(1))
+        Assert.AreEqual((1, 2, 3, 4, 5, 6, 7, 3), result7(2))
+
+        Dim result8 = db.Query(Of (Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32)?)("SELECT 1, 2, 3, 4, 5, 6, 7, Id FROM Article ORDER BY Id")
+        Assert.AreEqual(3, result7.Count)
+        Assert.AreEqual((1, 2, 3, 4, 5, 6, 7, 1), result8(0).Value)
+        Assert.AreEqual((1, 2, 3, 4, 5, 6, 7, 2), result8(1).Value)
+        Assert.AreEqual((1, 2, 3, 4, 5, 6, 7, 3), result8(2).Value)
+
+        ' 15 elements: (Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Article)))
+        Dim result9 = db.Query(Of (Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Article))($"SELECT 1, 2, 3, 4, 5, 6, 7, 8, Id x, 10, 11, 12, 13, 14, {Sql.Model.Columns(Of Article)()} FROM Article WHERE 1 = 2 ORDER BY Id")
+        Assert.AreEqual(0, result9.Count)
+
+        Dim result10 = db.Query(Of (Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Article)?)($"SELECT 1, 2, 3, 4, 5, 6, 7, 8, Id x, 10, 11, 12, 13, 14, {Sql.Model.Columns(Of Article)()} FROM Article WHERE 1 = 2 ORDER BY Id")
+        Assert.AreEqual(0, result10.Count)
+
+        Dim result11 = db.Query(Of (Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Article))($"SELECT 1, 2, 3, 4, 5, 6, 7, 8, Id x, 10, 11, 12, 13, 14, {Sql.Model.Columns(Of Article)()} FROM Article ORDER BY Id")
+        Assert.AreEqual(3, result11.Count)
+        Assert.AreEqual((1, 2, 3, 4, 5, 6, 7, 8, 1, 10, 11, 12, 13, 14, article1), result11(0))
+        Assert.AreEqual((1, 2, 3, 4, 5, 6, 7, 8, 2, 10, 11, 12, 13, 14, article2), result11(1))
+        Assert.AreEqual((1, 2, 3, 4, 5, 6, 7, 8, 3, 10, 11, 12, 13, 14, article3), result11(2))
+
+        Dim result12 = db.Query(Of (Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Article)?)($"SELECT 1, 2, 3, 4, 5, 6, 7, 8, Id x, 10, 11, 12, 13, 14, {Sql.Model.Columns(Of Article)()} FROM Article ORDER BY Id")
+        Assert.AreEqual(3, result12.Count)
+        Assert.AreEqual((1, 2, 3, 4, 5, 6, 7, 8, 1, 10, 11, 12, 13, 14, article1), result12(0).Value)
+        Assert.AreEqual((1, 2, 3, 4, 5, 6, 7, 8, 2, 10, 11, 12, 13, 14, article2), result12(1).Value)
+        Assert.AreEqual((1, 2, 3, 4, 5, 6, 7, 8, 3, 10, 11, 12, 13, 14, article3), result12(2).Value)
+
+        ' 16 elements (Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Int32, Int32, Int32, Int32, Int32, Int32, Int32, (Article, Int32)))
+        Dim result13 = db.Query(Of (Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Article, Int32))($"SELECT 1, 2, 3, 4, 5, 6, 7, 8, Id x, 10, 11, 12, 13, 14, {Sql.Model.Columns(Of Article)()}, 16 FROM Article WHERE 1 = 2 ORDER BY Id")
+        Assert.AreEqual(0, result13.Count)
+
+        Dim result14 = db.Query(Of (Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Article, Int32)?)($"SELECT 1, 2, 3, 4, 5, 6, 7, 8, Id x, 10, 11, 12, 13, 14, {Sql.Model.Columns(Of Article)()}, 16 FROM Article WHERE 1 = 2 ORDER BY Id")
+        Assert.AreEqual(0, result14.Count)
+
+        Dim result15 = db.Query(Of (Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Article, Int32))($"SELECT 1, 2, 3, 4, 5, 6, 7, 8, Id x, 10, 11, 12, 13, 14, {Sql.Model.Columns(Of Article)()}, 16 FROM Article ORDER BY Id")
+        Assert.AreEqual(3, result15.Count)
+        Assert.AreEqual((1, 2, 3, 4, 5, 6, 7, 8, 1, 10, 11, 12, 13, 14, article1, 16), result15(0))
+        Assert.AreEqual((1, 2, 3, 4, 5, 6, 7, 8, 2, 10, 11, 12, 13, 14, article2, 16), result15(1))
+        Assert.AreEqual((1, 2, 3, 4, 5, 6, 7, 8, 3, 10, 11, 12, 13, 14, article3, 16), result15(2))
+
+        Dim result16 = db.Query(Of (Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Article, Int32)?)($"SELECT 1, 2, 3, 4, 5, 6, 7, 8, Id x, 10, 11, 12, 13, 14, {Sql.Model.Columns(Of Article)()}, 16 FROM Article ORDER BY Id")
+        Assert.AreEqual(3, result16.Count)
+        Assert.AreEqual((1, 2, 3, 4, 5, 6, 7, 8, 1, 10, 11, 12, 13, 14, article1, 16), result16(0).Value)
+        Assert.AreEqual((1, 2, 3, 4, 5, 6, 7, 8, 2, 10, 11, 12, 13, 14, article2, 16), result16(1).Value)
+        Assert.AreEqual((1, 2, 3, 4, 5, 6, 7, 8, 3, 10, 11, 12, 13, 14, article3, 16), result16(2).Value)
+      End Using
+    End Sub
+
   End Class
 End Namespace


### PR DESCRIPTION
It is now possible to return value tuples with 8 and more elements (where `TRest` is another value tuple).

It is supported in `Query` and `QueryFirstOrDefault` methods:
```cs
using (var db = CreateContext())
{
    var value = db.QueryFirstOrDefault<(int, int, int, int, int, int, int, int, int)>("SELECT 1, 2, 3, 4, 5, 6, 7, 8, 9");
    var list = db.Query<(int, int, int, int, int, int, int, int, int)>("SELECT 1, 2, 3, 4, 5, 6, 7, 8, 9");
}
```
And also in `Select` method:
```vbnet
Using db = CreateDbContext()
  Dim list = db.From(Of Article).
                Select(Function(x) (x.Id, x, 1, 2, 3, 4, 5, 6, 7, 8, 9)).
                ToList()
End Using
```
However, latter works only in VB.NET, since [C# doesn't allow that currently](https://github.com/dotnet/roslyn/issues/12897).