### PR TITLE
Fixed using FirstOrDefault() with JOINs

### DIFF
--- a/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.Common.vb
+++ b/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.Common.vb
@@ -2,7 +2,11 @@
 
   Partial Public Class CodeGenerator
 
-    Protected Sub AddComment(builder As CodeBuilder, comment As String, Optional typeParams() As String = Nothing, Optional params() As String = Nothing, Optional returns As String = Nothing)
+    Protected Sub AddComment(builder As CodeBuilder, comment As String, Optional typeParams() As String = Nothing, Optional params() As String = Nothing, Optional commentedParams() As (Param As String, Comment As String) = Nothing, Optional returns As String = Nothing)
+      If params IsNot Nothing AndAlso commentedParams IsNot Nothing Then
+        Throw New Exception("Both params and commentedParams are not allowed.")
+      End If
+
       builder.Indent().AppendLine("''' <summary>")
       builder.Indent().AppendLine("''' " & comment)
       builder.Indent().AppendLine("''' </summary>")
@@ -16,6 +20,10 @@
       If params IsNot Nothing Then
         For Each param In params
           builder.Indent().AppendLine($"''' <param name=""{param}""></param>")
+        Next
+      ElseIf commentedParams IsNot Nothing Then
+        For Each param In commentedParams
+          builder.Indent().AppendLine($"''' <param name=""{param.Param}"">{param.Comment}</param>")
         Next
       End If
 

--- a/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.FirstOrDefault.vb
+++ b/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.FirstOrDefault.vb
@@ -4,13 +4,14 @@
 
     Protected Sub GenerateFirstOrDefault(builder As CodeBuilder, entityCount As Int32)
       Dim comment = "Executes SQL query and returns first record or a default value."
-      AddComment(builder, comment, returns:="")
+      Dim params = {("behavior", "Defines how collection navigation properties are filled. This setting has no effect if no collection navigation properties are used.")}
+      AddComment(builder, comment, commentedParams:=params, returns:="")
 
       Dim generic = GetGenericName(1, entityCount = 1)
 
-      builder.Indent().AppendLine($"Public Function FirstOrDefault() As {generic}").PushIndent()
+      builder.Indent().AppendLine($"Public Function FirstOrDefault(Optional behavior As CollectionNavigationFillBehavior = CollectionNavigationFillBehavior.ProcessOnlyFirstRow) As {generic}").PushIndent()
       builder.Indent().AppendLine("Dim query = Me.Builder.CreateQuery()")
-      builder.Indent().AppendLine($"Return Me.Executor.ReadFirstOrDefault(Of {generic})(query)").PopIndent()
+      builder.Indent().AppendLine($"Return Me.Executor.ReadFirstOrDefault(Of {generic})(query, behavior)").PopIndent()
       builder.Indent().AppendLine("End Function")
     End Sub
 

--- a/Source/Source/Yamo/CollectionNavigationFillBehavior.vb
+++ b/Source/Source/Yamo/CollectionNavigationFillBehavior.vb
@@ -1,0 +1,17 @@
+﻿''' <summary>
+''' Defines how collection navigation properties are filled during FirstOrDefault() calls.
+''' </summary>
+Public Enum CollectionNavigationFillBehavior
+  ''' <summary>
+  ''' Process only first row from the resultset. Any collection navigation property will contain maximum 1 item.
+  ''' </summary>
+  ProcessOnlyFirstRow = 1
+  ''' <summary>
+  ''' Process the resultset until it contains the same main entity. If resultset is sorted properly and all rows related to main entity are grouped together, all collection navigation properties will be filled with all related items.
+  ''' </summary>
+  ProcessUntilMainEntityChange = 2
+  ''' <summary>
+  ''' Process the whole resultset. All collection navigation properties will be filled with all related items, no matter how the resultset is sorted.
+  ''' </summary>
+  ProcessAllRows = 3
+End Enum

--- a/Source/Source/Yamo/Expressions/DistinctSelectSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/DistinctSelectSqlExpression.vb
@@ -32,10 +32,11 @@ Namespace Expressions
     ''' <summary>
     ''' Executes SQL query and returns first record or a default value.
     ''' </summary>
+    ''' <param name="behavior">Defines how collection navigation properties are filled. This setting has no effect if no collection navigation properties are used.</param>
     ''' <returns></returns>
-    Public Function FirstOrDefault() As T
+    Public Function FirstOrDefault(Optional behavior As CollectionNavigationFillBehavior = CollectionNavigationFillBehavior.ProcessOnlyFirstRow) As T
       Dim query = Me.Builder.CreateQuery()
-      Return Me.Executor.ReadFirstOrDefault(Of T)(query)
+      Return Me.Executor.ReadFirstOrDefault(Of T)(query, behavior)
     End Function
 
   End Class

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpression.vb
@@ -121,10 +121,11 @@ Namespace Expressions
     ''' <summary>
     ''' Executes SQL query and returns first record or a default value.
     ''' </summary>
+    ''' <param name="behavior">Defines how collection navigation properties are filled. This setting has no effect if no collection navigation properties are used.</param>
     ''' <returns></returns>
-    Public Function FirstOrDefault() As T
+    Public Function FirstOrDefault(Optional behavior As CollectionNavigationFillBehavior = CollectionNavigationFillBehavior.ProcessOnlyFirstRow) As T
       Dim query = Me.Builder.CreateQuery()
-      Return Me.Executor.ReadFirstOrDefault(Of T)(query)
+      Return Me.Executor.ReadFirstOrDefault(Of T)(query, behavior)
     End Function
 
   End Class

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2.vb
@@ -160,10 +160,11 @@ Namespace Expressions
     ''' <summary>
     ''' Executes SQL query and returns first record or a default value.
     ''' </summary>
+    ''' <param name="behavior">Defines how collection navigation properties are filled. This setting has no effect if no collection navigation properties are used.</param>
     ''' <returns></returns>
-    Public Function FirstOrDefault() As T1
+    Public Function FirstOrDefault(Optional behavior As CollectionNavigationFillBehavior = CollectionNavigationFillBehavior.ProcessOnlyFirstRow) As T1
       Dim query = Me.Builder.CreateQuery()
-      Return Me.Executor.ReadFirstOrDefault(Of T1)(query)
+      Return Me.Executor.ReadFirstOrDefault(Of T1)(query, behavior)
     End Function
 
   End Class

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3.vb
@@ -179,10 +179,11 @@ Namespace Expressions
     ''' <summary>
     ''' Executes SQL query and returns first record or a default value.
     ''' </summary>
+    ''' <param name="behavior">Defines how collection navigation properties are filled. This setting has no effect if no collection navigation properties are used.</param>
     ''' <returns></returns>
-    Public Function FirstOrDefault() As T1
+    Public Function FirstOrDefault(Optional behavior As CollectionNavigationFillBehavior = CollectionNavigationFillBehavior.ProcessOnlyFirstRow) As T1
       Dim query = Me.Builder.CreateQuery()
-      Return Me.Executor.ReadFirstOrDefault(Of T1)(query)
+      Return Me.Executor.ReadFirstOrDefault(Of T1)(query, behavior)
     End Function
 
   End Class

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4.vb
@@ -198,10 +198,11 @@ Namespace Expressions
     ''' <summary>
     ''' Executes SQL query and returns first record or a default value.
     ''' </summary>
+    ''' <param name="behavior">Defines how collection navigation properties are filled. This setting has no effect if no collection navigation properties are used.</param>
     ''' <returns></returns>
-    Public Function FirstOrDefault() As T1
+    Public Function FirstOrDefault(Optional behavior As CollectionNavigationFillBehavior = CollectionNavigationFillBehavior.ProcessOnlyFirstRow) As T1
       Dim query = Me.Builder.CreateQuery()
-      Return Me.Executor.ReadFirstOrDefault(Of T1)(query)
+      Return Me.Executor.ReadFirstOrDefault(Of T1)(query, behavior)
     End Function
 
   End Class

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5.vb
@@ -217,10 +217,11 @@ Namespace Expressions
     ''' <summary>
     ''' Executes SQL query and returns first record or a default value.
     ''' </summary>
+    ''' <param name="behavior">Defines how collection navigation properties are filled. This setting has no effect if no collection navigation properties are used.</param>
     ''' <returns></returns>
-    Public Function FirstOrDefault() As T1
+    Public Function FirstOrDefault(Optional behavior As CollectionNavigationFillBehavior = CollectionNavigationFillBehavior.ProcessOnlyFirstRow) As T1
       Dim query = Me.Builder.CreateQuery()
-      Return Me.Executor.ReadFirstOrDefault(Of T1)(query)
+      Return Me.Executor.ReadFirstOrDefault(Of T1)(query, behavior)
     End Function
 
   End Class

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6.vb
@@ -236,10 +236,11 @@ Namespace Expressions
     ''' <summary>
     ''' Executes SQL query and returns first record or a default value.
     ''' </summary>
+    ''' <param name="behavior">Defines how collection navigation properties are filled. This setting has no effect if no collection navigation properties are used.</param>
     ''' <returns></returns>
-    Public Function FirstOrDefault() As T1
+    Public Function FirstOrDefault(Optional behavior As CollectionNavigationFillBehavior = CollectionNavigationFillBehavior.ProcessOnlyFirstRow) As T1
       Dim query = Me.Builder.CreateQuery()
-      Return Me.Executor.ReadFirstOrDefault(Of T1)(query)
+      Return Me.Executor.ReadFirstOrDefault(Of T1)(query, behavior)
     End Function
 
   End Class

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
@@ -255,10 +255,11 @@ Namespace Expressions
     ''' <summary>
     ''' Executes SQL query and returns first record or a default value.
     ''' </summary>
+    ''' <param name="behavior">Defines how collection navigation properties are filled. This setting has no effect if no collection navigation properties are used.</param>
     ''' <returns></returns>
-    Public Function FirstOrDefault() As T1
+    Public Function FirstOrDefault(Optional behavior As CollectionNavigationFillBehavior = CollectionNavigationFillBehavior.ProcessOnlyFirstRow) As T1
       Dim query = Me.Builder.CreateQuery()
-      Return Me.Executor.ReadFirstOrDefault(Of T1)(query)
+      Return Me.Executor.ReadFirstOrDefault(Of T1)(query, behavior)
     End Function
 
   End Class

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
@@ -194,10 +194,11 @@ Namespace Expressions
     ''' <summary>
     ''' Executes SQL query and returns first record or a default value.
     ''' </summary>
+    ''' <param name="behavior">Defines how collection navigation properties are filled. This setting has no effect if no collection navigation properties are used.</param>
     ''' <returns></returns>
-    Public Function FirstOrDefault() As T1
+    Public Function FirstOrDefault(Optional behavior As CollectionNavigationFillBehavior = CollectionNavigationFillBehavior.ProcessOnlyFirstRow) As T1
       Dim query = Me.Builder.CreateQuery()
-      Return Me.Executor.ReadFirstOrDefault(Of T1)(query)
+      Return Me.Executor.ReadFirstOrDefault(Of T1)(query, behavior)
     End Function
 
   End Class

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
@@ -203,10 +203,11 @@ Namespace Expressions
     ''' <summary>
     ''' Executes SQL query and returns first record or a default value.
     ''' </summary>
+    ''' <param name="behavior">Defines how collection navigation properties are filled. This setting has no effect if no collection navigation properties are used.</param>
     ''' <returns></returns>
-    Public Function FirstOrDefault() As T1
+    Public Function FirstOrDefault(Optional behavior As CollectionNavigationFillBehavior = CollectionNavigationFillBehavior.ProcessOnlyFirstRow) As T1
       Dim query = Me.Builder.CreateQuery()
-      Return Me.Executor.ReadFirstOrDefault(Of T1)(query)
+      Return Me.Executor.ReadFirstOrDefault(Of T1)(query, behavior)
     End Function
 
   End Class

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
@@ -212,10 +212,11 @@ Namespace Expressions
     ''' <summary>
     ''' Executes SQL query and returns first record or a default value.
     ''' </summary>
+    ''' <param name="behavior">Defines how collection navigation properties are filled. This setting has no effect if no collection navigation properties are used.</param>
     ''' <returns></returns>
-    Public Function FirstOrDefault() As T1
+    Public Function FirstOrDefault(Optional behavior As CollectionNavigationFillBehavior = CollectionNavigationFillBehavior.ProcessOnlyFirstRow) As T1
       Dim query = Me.Builder.CreateQuery()
-      Return Me.Executor.ReadFirstOrDefault(Of T1)(query)
+      Return Me.Executor.ReadFirstOrDefault(Of T1)(query, behavior)
     End Function
 
   End Class

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
@@ -221,10 +221,11 @@ Namespace Expressions
     ''' <summary>
     ''' Executes SQL query and returns first record or a default value.
     ''' </summary>
+    ''' <param name="behavior">Defines how collection navigation properties are filled. This setting has no effect if no collection navigation properties are used.</param>
     ''' <returns></returns>
-    Public Function FirstOrDefault() As T1
+    Public Function FirstOrDefault(Optional behavior As CollectionNavigationFillBehavior = CollectionNavigationFillBehavior.ProcessOnlyFirstRow) As T1
       Dim query = Me.Builder.CreateQuery()
-      Return Me.Executor.ReadFirstOrDefault(Of T1)(query)
+      Return Me.Executor.ReadFirstOrDefault(Of T1)(query, behavior)
     End Function
 
   End Class

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
@@ -230,10 +230,11 @@ Namespace Expressions
     ''' <summary>
     ''' Executes SQL query and returns first record or a default value.
     ''' </summary>
+    ''' <param name="behavior">Defines how collection navigation properties are filled. This setting has no effect if no collection navigation properties are used.</param>
     ''' <returns></returns>
-    Public Function FirstOrDefault() As T1
+    Public Function FirstOrDefault(Optional behavior As CollectionNavigationFillBehavior = CollectionNavigationFillBehavior.ProcessOnlyFirstRow) As T1
       Dim query = Me.Builder.CreateQuery()
-      Return Me.Executor.ReadFirstOrDefault(Of T1)(query)
+      Return Me.Executor.ReadFirstOrDefault(Of T1)(query, behavior)
     End Function
 
   End Class

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
@@ -239,10 +239,11 @@ Namespace Expressions
     ''' <summary>
     ''' Executes SQL query and returns first record or a default value.
     ''' </summary>
+    ''' <param name="behavior">Defines how collection navigation properties are filled. This setting has no effect if no collection navigation properties are used.</param>
     ''' <returns></returns>
-    Public Function FirstOrDefault() As T1
+    Public Function FirstOrDefault(Optional behavior As CollectionNavigationFillBehavior = CollectionNavigationFillBehavior.ProcessOnlyFirstRow) As T1
       Dim query = Me.Builder.CreateQuery()
-      Return Me.Executor.ReadFirstOrDefault(Of T1)(query)
+      Return Me.Executor.ReadFirstOrDefault(Of T1)(query, behavior)
     End Function
 
   End Class

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
@@ -248,10 +248,11 @@ Namespace Expressions
     ''' <summary>
     ''' Executes SQL query and returns first record or a default value.
     ''' </summary>
+    ''' <param name="behavior">Defines how collection navigation properties are filled. This setting has no effect if no collection navigation properties are used.</param>
     ''' <returns></returns>
-    Public Function FirstOrDefault() As T1
+    Public Function FirstOrDefault(Optional behavior As CollectionNavigationFillBehavior = CollectionNavigationFillBehavior.ProcessOnlyFirstRow) As T1
       Dim query = Me.Builder.CreateQuery()
-      Return Me.Executor.ReadFirstOrDefault(Of T1)(query)
+      Return Me.Executor.ReadFirstOrDefault(Of T1)(query, behavior)
     End Function
 
   End Class

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
@@ -257,10 +257,11 @@ Namespace Expressions
     ''' <summary>
     ''' Executes SQL query and returns first record or a default value.
     ''' </summary>
+    ''' <param name="behavior">Defines how collection navigation properties are filled. This setting has no effect if no collection navigation properties are used.</param>
     ''' <returns></returns>
-    Public Function FirstOrDefault() As T1
+    Public Function FirstOrDefault(Optional behavior As CollectionNavigationFillBehavior = CollectionNavigationFillBehavior.ProcessOnlyFirstRow) As T1
       Dim query = Me.Builder.CreateQuery()
-      Return Me.Executor.ReadFirstOrDefault(Of T1)(query)
+      Return Me.Executor.ReadFirstOrDefault(Of T1)(query, behavior)
     End Function
 
   End Class

--- a/Source/Source/Yamo/Internal/Query/ChainKey.vb
+++ b/Source/Source/Yamo/Internal/Query/ChainKey.vb
@@ -62,20 +62,38 @@
     Public Overrides Function Equals(obj As Object) As Boolean
       If TypeOf obj IsNot ChainKey Then Return False
 
-      Dim key = DirectCast(obj, ChainKey)
+      Return Me = DirectCast(obj, ChainKey)
+    End Function
 
-      If Not m_Pks.Length = key.m_Pks.Length Then
-        Return False
-      Else
-        For i = 0 To m_Pks.Length - 1
-          If Not Object.Equals(m_Pks(i), key.m_Pks(i)) Then
+    ''' <summary>
+    ''' Indicates whether two <see cref="ChainKey"/> instances are equal.
+    ''' </summary>
+    ''' <param name="value1"></param>
+    ''' <param name="value2"></param>
+    ''' <returns></returns>
+    Public Shared Operator =(value1 As ChainKey, value2 As ChainKey) As Boolean
+      If value1.m_Pks.Length = value2.m_Pks.Length Then
+        For i = 0 To value1.m_Pks.Length - 1
+          If Not Object.Equals(value1.m_Pks(i), value2.m_Pks(i)) Then
             Return False
           End If
         Next
-      End If
 
-      Return True
-    End Function
+        Return True
+      Else
+        Return False
+      End If
+    End Operator
+
+    ''' <summary>
+    ''' Indicates whether two <see cref="ChainKey"/> instances are not equal.
+    ''' </summary>
+    ''' <param name="value1"></param>
+    ''' <param name="value2"></param>
+    ''' <returns></returns>
+    Public Shared Operator <>(value1 As ChainKey, value2 As ChainKey) As Boolean
+      Return Not value1 = value2
+    End Operator
 
   End Structure
 End Namespace

--- a/Source/Test/Yamo.Test.SQLite/Tests/SelectFirstOrDefaultTests.vb
+++ b/Source/Test/Yamo.Test.SQLite/Tests/SelectFirstOrDefaultTests.vb
@@ -1,0 +1,14 @@
+﻿Imports Yamo.Test
+
+Namespace Tests
+
+  <TestClass()>
+  Public Class SelectFirstOrDefaultTests
+    Inherits Yamo.Test.Tests.SelectFirstOrDefaultTests
+
+    Protected Overrides Function CreateTestEnvironment() As ITestEnvironment
+      Return SQLiteTestEnvironment.Create()
+    End Function
+
+  End Class
+End Namespace

--- a/Source/Test/Yamo.Test.SqlServer/Tests/SelectFirstOrDefaultTests.vb
+++ b/Source/Test/Yamo.Test.SqlServer/Tests/SelectFirstOrDefaultTests.vb
@@ -1,0 +1,14 @@
+﻿Imports Yamo.Test
+
+Namespace Tests
+
+  <TestClass()>
+  Public Class SelectFirstOrDefaultTests
+    Inherits Yamo.Test.Tests.SelectFirstOrDefaultTests
+
+    Protected Overrides Function CreateTestEnvironment() As ITestEnvironment
+      Return SqlServerTestEnvironment.Create()
+    End Function
+
+  End Class
+End Namespace

--- a/Source/Test/Yamo.Test/Model/ModelFactory.vb
+++ b/Source/Test/Yamo.Test/Model/ModelFactory.vb
@@ -31,6 +31,14 @@
       }
     End Function
 
+    Public Overridable Function CreateArticlePart(id As Int32, articleId As Int32, price As Decimal) As ArticlePart
+      Return New ArticlePart With {
+        .Id = id,
+        .ArticleId = articleId,
+        .Price = price
+      }
+    End Function
+
     Public Overridable Function CreateArticleSubstitution(originalArticleId As Int32, substitutionArticleId As Int32) As ArticleSubstitution
       Return New ArticleSubstitution With {
         .OriginalArticleId = originalArticleId,

--- a/Source/Test/Yamo.Test/Tests/SelectDistinctTests.vb
+++ b/Source/Test/Yamo.Test/Tests/SelectDistinctTests.vb
@@ -53,17 +53,17 @@ Namespace Tests
         Assert.AreEqual(article3, article3Result)
       End Using
 
-      ' TODO: uncomment when calling FirstOrDefault is supported in this scenario
-      'Using db = CreateDbContext()
-      '  Dim result = db.From(Of Article).
-      '                  Join(Of Label)(Function(a, l) a.Id = l.Id).
-      '                  Where(Function(j) j.T1.Id = 1).
-      '                  SelectAll().
-      '                  Distinct().
-      '                  FirstOrDefault()
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        Join(Of Label)(Function(a, l) a.Id = l.Id).
+                        Where(Function(j) j.T1.Id = 1).
+                        SelectAll().
+                        ExcludeT2().
+                        Distinct().
+                        FirstOrDefault()
 
-      '  Assert.AreEqual(article1, result)
-      'End Using
+        Assert.AreEqual(article1, result)
+      End Using
 
       Using db = CreateDbContext()
         Dim result = db.From(Of Article).

--- a/Source/Test/Yamo.Test/Tests/SelectFirstOrDefaultTests.vb
+++ b/Source/Test/Yamo.Test/Tests/SelectFirstOrDefaultTests.vb
@@ -1,0 +1,612 @@
+﻿Imports Yamo.Test.Model
+
+Namespace Tests
+
+  Public MustInherit Class SelectFirstOrDefaultTests
+    Inherits BaseIntegrationTests
+
+    Protected Const English As String = "en"
+
+    Protected Const German As String = "de"
+
+    <TestMethod()>
+    Public Overridable Sub SelectFirstOrDefaultUsingProcessOnlyFirstRowBehavior()
+      Dim article1 = Me.ModelFactory.CreateArticle(1)
+      Dim article2 = Me.ModelFactory.CreateArticle(2)
+      Dim article3 = Me.ModelFactory.CreateArticle(3)
+
+      InsertItems(article1, article2, article3)
+
+      ' using default
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        OrderBy(Function(x) x.Id).
+                        SelectAll().FirstOrDefault()
+
+        Assert.AreEqual(article1, result)
+      End Using
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        OrderBy(Function(x) x.Id).
+                        SelectAll().FirstOrDefault(CollectionNavigationFillBehavior.ProcessOnlyFirstRow)
+
+        Assert.AreEqual(article1, result)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectFirstOrDefaultUsingProcessUntilMainEntityChangeBehavior()
+      Dim article1 = Me.ModelFactory.CreateArticle(1)
+      Dim article2 = Me.ModelFactory.CreateArticle(2)
+      Dim article3 = Me.ModelFactory.CreateArticle(3)
+
+      InsertItems(article1, article2, article3)
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        OrderBy(Function(x) x.Id).
+                        SelectAll().FirstOrDefault(CollectionNavigationFillBehavior.ProcessUntilMainEntityChange)
+
+        Assert.AreEqual(article1, result)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectFirstOrDefaultUsingProcessAllRowsBehavior()
+      Dim article1 = Me.ModelFactory.CreateArticle(1)
+      Dim article2 = Me.ModelFactory.CreateArticle(2)
+      Dim article3 = Me.ModelFactory.CreateArticle(3)
+
+      InsertItems(article1, article2, article3)
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        OrderBy(Function(x) x.Id).
+                        SelectAll().FirstOrDefault(CollectionNavigationFillBehavior.ProcessAllRows)
+
+        Assert.AreEqual(article1, result)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectFirstOrDefaultWith1To1RelationshipUsingProcessOnlyFirstRowBehavior()
+      Dim article1 = Me.ModelFactory.CreateArticle(1)
+      Dim article2 = Me.ModelFactory.CreateArticle(2)
+      Dim article3 = Me.ModelFactory.CreateArticle(3)
+
+      Dim label1 = Me.ModelFactory.CreateLabel("", 1, English)
+      Dim label2 = Me.ModelFactory.CreateLabel("", 2, English)
+      Dim label3 = Me.ModelFactory.CreateLabel("", 3, English)
+
+      InsertItems(article1, article2, article3, label1, label2, label3)
+
+      ' using default
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        Join(Of Label)(Function(j) j.T1.Id = j.T2.Id).
+                        OrderBy(Function(j) j.T1.Id).
+                        SelectAll().FirstOrDefault()
+
+        Assert.AreEqual(article1, result)
+        Assert.AreEqual(label1, result.Label)
+      End Using
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        Join(Of Label)(Function(j) j.T1.Id = j.T2.Id).
+                        OrderBy(Function(j) j.T1.Id).
+                        SelectAll().FirstOrDefault(CollectionNavigationFillBehavior.ProcessOnlyFirstRow)
+
+        Assert.AreEqual(article1, result)
+        Assert.AreEqual(label1, result.Label)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectFirstOrDefaultWith1To1RelationshipUsingProcessUntilMainEntityChangeBehavior()
+      Dim article1 = Me.ModelFactory.CreateArticle(1)
+      Dim article2 = Me.ModelFactory.CreateArticle(2)
+      Dim article3 = Me.ModelFactory.CreateArticle(3)
+
+      Dim label1 = Me.ModelFactory.CreateLabel("", 1, English)
+      Dim label2 = Me.ModelFactory.CreateLabel("", 2, English)
+      Dim label3 = Me.ModelFactory.CreateLabel("", 3, English)
+
+      InsertItems(article1, article2, article3, label1, label2, label3)
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        Join(Of Label)(Function(j) j.T1.Id = j.T2.Id).
+                        OrderBy(Function(j) j.T1.Id).
+                        SelectAll().FirstOrDefault(CollectionNavigationFillBehavior.ProcessUntilMainEntityChange)
+
+        Assert.AreEqual(article1, result)
+        Assert.AreEqual(label1, result.Label)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectFirstOrDefaultWith1To1RelationshipUsingProcessAllRowsBehavior()
+      Dim article1 = Me.ModelFactory.CreateArticle(1)
+      Dim article2 = Me.ModelFactory.CreateArticle(2)
+      Dim article3 = Me.ModelFactory.CreateArticle(3)
+
+      Dim label1 = Me.ModelFactory.CreateLabel("", 1, English)
+      Dim label2 = Me.ModelFactory.CreateLabel("", 2, English)
+      Dim label3 = Me.ModelFactory.CreateLabel("", 3, English)
+
+      InsertItems(article1, article2, article3, label1, label2, label3)
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        Join(Of Label)(Function(j) j.T1.Id = j.T2.Id).
+                        OrderBy(Function(j) j.T1.Id).
+                        SelectAll().FirstOrDefault(CollectionNavigationFillBehavior.ProcessAllRows)
+
+        Assert.AreEqual(article1, result)
+        Assert.AreEqual(label1, result.Label)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectFirstOrDefaultWith1ToNRelationshipUsingProcessOnlyFirstRowBehavior()
+      Dim article1 = Me.ModelFactory.CreateArticle(1)
+      Dim article2 = Me.ModelFactory.CreateArticle(2)
+      Dim article3 = Me.ModelFactory.CreateArticle(3)
+
+      Dim article1Part1 = Me.ModelFactory.CreateArticlePart(1001, 1, 7D)
+      Dim article1Part2 = Me.ModelFactory.CreateArticlePart(1002, 1, 2D)
+      Dim article1Part3 = Me.ModelFactory.CreateArticlePart(1003, 1, 1D)
+      Dim article2Part1 = Me.ModelFactory.CreateArticlePart(2001, 2, 3D)
+      Dim article2Part2 = Me.ModelFactory.CreateArticlePart(2002, 2, 4D)
+      Dim article3Part1 = Me.ModelFactory.CreateArticlePart(3001, 3, 5D)
+      Dim article3Part2 = Me.ModelFactory.CreateArticlePart(3002, 3, 6D)
+
+      InsertItems(article1, article2, article3, article1Part1, article1Part2, article1Part3, article2Part1, article2Part2, article3Part1, article3Part2)
+
+      ' using default
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        Join(Of ArticlePart)(Function(j) j.T1.Id = j.T2.ArticleId).
+                        OrderBy(Function(j) j.T1.Id).ThenBy(Function(j) j.T2.Price).
+                        SelectAll().FirstOrDefault()
+
+        Assert.AreEqual(article1, result)
+        CollectionAssert.AreEqual({article1Part3}, result.Parts)
+      End Using
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        Join(Of ArticlePart)(Function(j) j.T1.Id = j.T2.ArticleId).
+                        OrderBy(Function(j) j.T1.Id).ThenBy(Function(j) j.T2.Price).
+                        SelectAll().FirstOrDefault(CollectionNavigationFillBehavior.ProcessOnlyFirstRow)
+
+        Assert.AreEqual(article1, result)
+        CollectionAssert.AreEqual({article1Part3}, result.Parts)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectFirstOrDefaultWith1ToNRelationshipUsingProcessUntilMainEntityChangeBehavior()
+      Dim article1 = Me.ModelFactory.CreateArticle(1)
+      Dim article2 = Me.ModelFactory.CreateArticle(2)
+      Dim article3 = Me.ModelFactory.CreateArticle(3)
+
+      Dim article1Part1 = Me.ModelFactory.CreateArticlePart(1001, 1, 7D)
+      Dim article1Part2 = Me.ModelFactory.CreateArticlePart(1002, 1, 2D)
+      Dim article1Part3 = Me.ModelFactory.CreateArticlePart(1003, 1, 1D)
+      Dim article2Part1 = Me.ModelFactory.CreateArticlePart(2001, 2, 3D)
+      Dim article2Part2 = Me.ModelFactory.CreateArticlePart(2002, 2, 4D)
+      Dim article3Part1 = Me.ModelFactory.CreateArticlePart(3001, 3, 5D)
+      Dim article3Part2 = Me.ModelFactory.CreateArticlePart(3002, 3, 6D)
+
+      InsertItems(article1, article2, article3, article1Part1, article1Part2, article1Part3, article2Part1, article2Part2, article3Part1, article3Part2)
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        Join(Of ArticlePart)(Function(j) j.T1.Id = j.T2.ArticleId).
+                        OrderBy(Function(j) j.T1.Id).ThenBy(Function(j) j.T2.Price).
+                        SelectAll().FirstOrDefault(CollectionNavigationFillBehavior.ProcessUntilMainEntityChange)
+
+        Assert.AreEqual(article1, result)
+        CollectionAssert.AreEqual({article1Part3, article1Part2, article1Part1}, result.Parts)
+      End Using
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        Join(Of ArticlePart)(Function(j) j.T1.Id = j.T2.ArticleId).
+                        OrderBy(Function(j) j.T2.Price).
+                        SelectAll().FirstOrDefault(CollectionNavigationFillBehavior.ProcessUntilMainEntityChange)
+
+        Assert.AreEqual(article1, result)
+        CollectionAssert.AreEqual({article1Part3, article1Part2}, result.Parts)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectFirstOrDefaultWith1ToNRelationshipUsingProcessAllRowsBehavior()
+      Dim article1 = Me.ModelFactory.CreateArticle(1)
+      Dim article2 = Me.ModelFactory.CreateArticle(2)
+      Dim article3 = Me.ModelFactory.CreateArticle(3)
+
+      Dim article1Part1 = Me.ModelFactory.CreateArticlePart(1001, 1, 7D)
+      Dim article1Part2 = Me.ModelFactory.CreateArticlePart(1002, 1, 2D)
+      Dim article1Part3 = Me.ModelFactory.CreateArticlePart(1003, 1, 1D)
+      Dim article2Part1 = Me.ModelFactory.CreateArticlePart(2001, 2, 3D)
+      Dim article2Part2 = Me.ModelFactory.CreateArticlePart(2002, 2, 4D)
+      Dim article3Part1 = Me.ModelFactory.CreateArticlePart(3001, 3, 5D)
+      Dim article3Part2 = Me.ModelFactory.CreateArticlePart(3002, 3, 6D)
+
+      InsertItems(article1, article2, article3, article1Part1, article1Part2, article1Part3, article2Part1, article2Part2, article3Part1, article3Part2)
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        Join(Of ArticlePart)(Function(j) j.T1.Id = j.T2.ArticleId).
+                        OrderBy(Function(j) j.T1.Id).ThenBy(Function(j) j.T2.Price).
+                        SelectAll().FirstOrDefault(CollectionNavigationFillBehavior.ProcessAllRows)
+
+        Assert.AreEqual(article1, result)
+        CollectionAssert.AreEqual({article1Part3, article1Part2, article1Part1}, result.Parts)
+      End Using
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        Join(Of ArticlePart)(Function(j) j.T1.Id = j.T2.ArticleId).
+                        OrderBy(Function(j) j.T2.Price).
+                        SelectAll().FirstOrDefault(CollectionNavigationFillBehavior.ProcessAllRows)
+
+        Assert.AreEqual(article1, result)
+        CollectionAssert.AreEqual({article1Part3, article1Part2, article1Part1}, result.Parts)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectFirstOrDefaultWithMultiple1To1And1ToNAndMToNRelationshipUsingProcessOnlyFirstRowBehavior()
+      Dim article1 = Me.ModelFactory.CreateArticle(1)
+      Dim article2 = Me.ModelFactory.CreateArticle(2)
+      Dim article3 = Me.ModelFactory.CreateArticle(3)
+
+      Dim article1Label = Me.ModelFactory.CreateLabel(NameOf(Article), 1, English)
+      Dim article2Label = Me.ModelFactory.CreateLabel(NameOf(Article), 2, English)
+      Dim article3Label = Me.ModelFactory.CreateLabel(NameOf(Article), 3, English)
+
+      Dim article1Part1 = Me.ModelFactory.CreateArticlePart(1001, 1, 7D)
+      Dim article1Part2 = Me.ModelFactory.CreateArticlePart(1002, 1, 2D)
+      Dim article1Part3 = Me.ModelFactory.CreateArticlePart(1003, 1, 1D)
+      Dim article2Part1 = Me.ModelFactory.CreateArticlePart(2001, 2, 3D)
+      Dim article2Part2 = Me.ModelFactory.CreateArticlePart(2002, 2, 4D)
+      Dim article3Part1 = Me.ModelFactory.CreateArticlePart(3001, 3, 5D)
+      Dim article3Part2 = Me.ModelFactory.CreateArticlePart(3002, 3, 6D)
+
+      Dim article1Part1Label = Me.ModelFactory.CreateLabel(NameOf(ArticlePart), 1001, English)
+      Dim article1Part2Label = Me.ModelFactory.CreateLabel(NameOf(ArticlePart), 1002, English)
+      Dim article1Part3Label = Me.ModelFactory.CreateLabel(NameOf(ArticlePart), 1003, English)
+      Dim article2Part1Label = Me.ModelFactory.CreateLabel(NameOf(ArticlePart), 2001, English)
+      Dim article2Part2Label = Me.ModelFactory.CreateLabel(NameOf(ArticlePart), 2002, English)
+      Dim article3Part1Label = Me.ModelFactory.CreateLabel(NameOf(ArticlePart), 3001, English)
+      Dim article3Part2Label = Me.ModelFactory.CreateLabel(NameOf(ArticlePart), 3002, English)
+
+      Dim category1 = Me.ModelFactory.CreateCategory(1)
+      Dim category2 = Me.ModelFactory.CreateCategory(2)
+      Dim category3 = Me.ModelFactory.CreateCategory(3)
+
+      Dim category1Label = Me.ModelFactory.CreateLabel(NameOf(Category), 1, English)
+      Dim category2Label = Me.ModelFactory.CreateLabel(NameOf(Category), 2, English)
+      Dim category3Label = Me.ModelFactory.CreateLabel(NameOf(Category), 3, English)
+
+      Dim article1Category1 = Me.ModelFactory.CreateArticleCategory(1, 1)
+      Dim article1Category2 = Me.ModelFactory.CreateArticleCategory(1, 2)
+      Dim article1Category3 = Me.ModelFactory.CreateArticleCategory(1, 3)
+      Dim article2Category1 = Me.ModelFactory.CreateArticleCategory(2, 1)
+      Dim article2Category2 = Me.ModelFactory.CreateArticleCategory(2, 2)
+      Dim article3Category1 = Me.ModelFactory.CreateArticleCategory(3, 1)
+      Dim article3Category3 = Me.ModelFactory.CreateArticleCategory(3, 3)
+
+      InsertItems(article1, article2, article3)
+      InsertItems(article1Label, article2Label, article3Label)
+      InsertItems(article1Part1, article1Part2, article1Part3, article2Part1, article2Part2, article3Part1, article3Part2)
+      InsertItems(article1Part1Label, article1Part2Label, article1Part3Label, article2Part1Label, article2Part2Label, article3Part1Label, article3Part2Label)
+      InsertItems(category1, category2, category3)
+      InsertItems(category1Label, category2Label, category3Label)
+      InsertItems(article1Category1, article1Category2, article1Category3, article2Category1, article2Category2, article3Category1, article3Category3)
+
+      ' using default
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        LeftJoin(Of Label)(Function(j) j.T2.TableId = NameOf(Article) AndAlso j.T1.Id = j.T2.Id).
+                        LeftJoin(Of ArticlePart)(Function(j) j.T1.Id = j.T3.ArticleId).
+                        LeftJoin(Of Label)(Function(j) j.T4.TableId = NameOf(ArticlePart) AndAlso j.T3.Id = j.T4.Id).
+                        LeftJoin(Of ArticleCategory)(Function(j) j.T1.Id = j.T5.ArticleId).
+                        LeftJoin(Of Category)(Function(j) j.T5.CategoryId = j.T6.Id).As(Function(j) j.T1.Categories).
+                        LeftJoin(Of Label)(Function(j) j.T7.TableId = NameOf(Category) AndAlso j.T6.Id = j.T7.Id).
+                        OrderBy(Function(j) j.T1.Id).ThenBy(Function(j) j.T3.Price).ThenByDescending(Function(j) j.T6.Id).
+                        SelectAll().FirstOrDefault()
+
+        Assert.AreEqual(article1, result)
+        Assert.AreEqual(article1Label, result.Label)
+        CollectionAssert.AreEqual({article1Part3}, result.Parts)
+        Assert.AreEqual(article1Part3Label, result.Parts(0).Label)
+        CollectionAssert.AreEqual({category3}, result.Categories)
+        Assert.AreEqual(category3Label, result.Categories(0).Label)
+      End Using
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        LeftJoin(Of Label)(Function(j) j.T2.TableId = NameOf(Article) AndAlso j.T1.Id = j.T2.Id).
+                        LeftJoin(Of ArticlePart)(Function(j) j.T1.Id = j.T3.ArticleId).
+                        LeftJoin(Of Label)(Function(j) j.T4.TableId = NameOf(ArticlePart) AndAlso j.T3.Id = j.T4.Id).
+                        LeftJoin(Of ArticleCategory)(Function(j) j.T1.Id = j.T5.ArticleId).
+                        LeftJoin(Of Category)(Function(j) j.T5.CategoryId = j.T6.Id).As(Function(j) j.T1.Categories).
+                        LeftJoin(Of Label)(Function(j) j.T7.TableId = NameOf(Category) AndAlso j.T6.Id = j.T7.Id).
+                        OrderBy(Function(j) j.T1.Id).ThenBy(Function(j) j.T3.Price).ThenByDescending(Function(j) j.T6.Id).
+                        SelectAll().FirstOrDefault(CollectionNavigationFillBehavior.ProcessOnlyFirstRow)
+
+        Assert.AreEqual(article1, result)
+        Assert.AreEqual(article1Label, result.Label)
+        CollectionAssert.AreEqual({article1Part3}, result.Parts)
+        Assert.AreEqual(article1Part3Label, result.Parts(0).Label)
+        CollectionAssert.AreEqual({category3}, result.Categories)
+        Assert.AreEqual(category3Label, result.Categories(0).Label)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectFirstOrDefaultWithMultiple1To1And1ToNAndMToNRelationshipUsingProcessUntilMainEntityChangeBehavior()
+      Dim article1 = Me.ModelFactory.CreateArticle(1)
+      Dim article2 = Me.ModelFactory.CreateArticle(2)
+      Dim article3 = Me.ModelFactory.CreateArticle(3)
+
+      Dim article1Label = Me.ModelFactory.CreateLabel(NameOf(Article), 1, English)
+      Dim article2Label = Me.ModelFactory.CreateLabel(NameOf(Article), 2, English)
+      Dim article3Label = Me.ModelFactory.CreateLabel(NameOf(Article), 3, English)
+
+      Dim article1Part1 = Me.ModelFactory.CreateArticlePart(1001, 1, 7D)
+      Dim article1Part2 = Me.ModelFactory.CreateArticlePart(1002, 1, 2D)
+      Dim article1Part3 = Me.ModelFactory.CreateArticlePart(1003, 1, 1D)
+      Dim article2Part1 = Me.ModelFactory.CreateArticlePart(2001, 2, 3D)
+      Dim article2Part2 = Me.ModelFactory.CreateArticlePart(2002, 2, 4D)
+      Dim article3Part1 = Me.ModelFactory.CreateArticlePart(3001, 3, 5D)
+      Dim article3Part2 = Me.ModelFactory.CreateArticlePart(3002, 3, 6D)
+
+      Dim article1Part1Label = Me.ModelFactory.CreateLabel(NameOf(ArticlePart), 1001, English)
+      Dim article1Part2Label = Me.ModelFactory.CreateLabel(NameOf(ArticlePart), 1002, English)
+      Dim article1Part3Label = Me.ModelFactory.CreateLabel(NameOf(ArticlePart), 1003, English)
+      Dim article2Part1Label = Me.ModelFactory.CreateLabel(NameOf(ArticlePart), 2001, English)
+      Dim article2Part2Label = Me.ModelFactory.CreateLabel(NameOf(ArticlePart), 2002, English)
+      Dim article3Part1Label = Me.ModelFactory.CreateLabel(NameOf(ArticlePart), 3001, English)
+      Dim article3Part2Label = Me.ModelFactory.CreateLabel(NameOf(ArticlePart), 3002, English)
+
+      Dim category1 = Me.ModelFactory.CreateCategory(1)
+      Dim category2 = Me.ModelFactory.CreateCategory(2)
+      Dim category3 = Me.ModelFactory.CreateCategory(3)
+
+      Dim category1Label = Me.ModelFactory.CreateLabel(NameOf(Category), 1, English)
+      Dim category2Label = Me.ModelFactory.CreateLabel(NameOf(Category), 2, English)
+      Dim category3Label = Me.ModelFactory.CreateLabel(NameOf(Category), 3, English)
+
+      Dim article1Category1 = Me.ModelFactory.CreateArticleCategory(1, 1)
+      Dim article1Category2 = Me.ModelFactory.CreateArticleCategory(1, 2)
+      Dim article1Category3 = Me.ModelFactory.CreateArticleCategory(1, 3)
+      Dim article2Category1 = Me.ModelFactory.CreateArticleCategory(2, 1)
+      Dim article2Category2 = Me.ModelFactory.CreateArticleCategory(2, 2)
+      Dim article3Category1 = Me.ModelFactory.CreateArticleCategory(3, 1)
+      Dim article3Category3 = Me.ModelFactory.CreateArticleCategory(3, 3)
+
+      InsertItems(article1, article2, article3)
+      InsertItems(article1Label, article2Label, article3Label)
+      InsertItems(article1Part1, article1Part2, article1Part3, article2Part1, article2Part2, article3Part1, article3Part2)
+      InsertItems(article1Part1Label, article1Part2Label, article1Part3Label, article2Part1Label, article2Part2Label, article3Part1Label, article3Part2Label)
+      InsertItems(category1, category2, category3)
+      InsertItems(category1Label, category2Label, category3Label)
+      InsertItems(article1Category1, article1Category2, article1Category3, article2Category1, article2Category2, article3Category1, article3Category3)
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        LeftJoin(Of Label)(Function(j) j.T2.TableId = NameOf(Article) AndAlso j.T1.Id = j.T2.Id).
+                        LeftJoin(Of ArticlePart)(Function(j) j.T1.Id = j.T3.ArticleId).
+                        LeftJoin(Of Label)(Function(j) j.T4.TableId = NameOf(ArticlePart) AndAlso j.T3.Id = j.T4.Id).
+                        LeftJoin(Of ArticleCategory)(Function(j) j.T1.Id = j.T5.ArticleId).
+                        LeftJoin(Of Category)(Function(j) j.T5.CategoryId = j.T6.Id).As(Function(j) j.T1.Categories).
+                        LeftJoin(Of Label)(Function(j) j.T7.TableId = NameOf(Category) AndAlso j.T6.Id = j.T7.Id).
+                        OrderBy(Function(j) j.T1.Id).ThenBy(Function(j) j.T3.Price).ThenByDescending(Function(j) j.T6.Id).
+                        SelectAll().FirstOrDefault(CollectionNavigationFillBehavior.ProcessUntilMainEntityChange)
+
+        Assert.AreEqual(article1, result)
+        Assert.AreEqual(article1Label, result.Label)
+        CollectionAssert.AreEqual({article1Part3, article1Part2, article1Part1}, result.Parts)
+        Assert.AreEqual(article1Part3Label, result.Parts(0).Label)
+        Assert.AreEqual(article1Part2Label, result.Parts(1).Label)
+        Assert.AreEqual(article1Part1Label, result.Parts(2).Label)
+        CollectionAssert.AreEqual({category3, category2, category1}, result.Categories)
+        Assert.AreEqual(category3Label, result.Categories(0).Label)
+        Assert.AreEqual(category2Label, result.Categories(1).Label)
+        Assert.AreEqual(category1Label, result.Categories(2).Label)
+      End Using
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        LeftJoin(Of Label)(Function(j) j.T2.TableId = NameOf(Article) AndAlso j.T1.Id = j.T2.Id).
+                        LeftJoin(Of ArticlePart)(Function(j) j.T1.Id = j.T3.ArticleId).
+                        LeftJoin(Of Label)(Function(j) j.T4.TableId = NameOf(ArticlePart) AndAlso j.T3.Id = j.T4.Id).
+                        LeftJoin(Of ArticleCategory)(Function(j) j.T1.Id = j.T5.ArticleId).
+                        LeftJoin(Of Category)(Function(j) j.T5.CategoryId = j.T6.Id).As(Function(j) j.T1.Categories).
+                        LeftJoin(Of Label)(Function(j) j.T7.TableId = NameOf(Category) AndAlso j.T6.Id = j.T7.Id).
+                        OrderBy(Function(j) j.T3.Price).ThenByDescending(Function(j) j.T6.Id).
+                        SelectAll().FirstOrDefault(CollectionNavigationFillBehavior.ProcessUntilMainEntityChange)
+
+        Assert.AreEqual(article1, result)
+        Assert.AreEqual(article1Label, result.Label)
+        CollectionAssert.AreEqual({article1Part3, article1Part2}, result.Parts)
+        Assert.AreEqual(article1Part3Label, result.Parts(0).Label)
+        Assert.AreEqual(article1Part2Label, result.Parts(1).Label)
+        CollectionAssert.AreEqual({category3, category2, category1}, result.Categories)
+        Assert.AreEqual(category3Label, result.Categories(0).Label)
+        Assert.AreEqual(category2Label, result.Categories(1).Label)
+        Assert.AreEqual(category1Label, result.Categories(2).Label)
+      End Using
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        LeftJoin(Of Label)(Function(j) j.T2.TableId = NameOf(Article) AndAlso j.T1.Id = j.T2.Id).
+                        LeftJoin(Of ArticlePart)(Function(j) j.T1.Id = j.T3.ArticleId).
+                        LeftJoin(Of Label)(Function(j) j.T4.TableId = NameOf(ArticlePart) AndAlso j.T3.Id = j.T4.Id).
+                        LeftJoin(Of ArticleCategory)(Function(j) j.T1.Id = j.T5.ArticleId).
+                        LeftJoin(Of Category)(Function(j) j.T5.CategoryId = j.T6.Id).As(Function(j) j.T1.Categories).
+                        LeftJoin(Of Label)(Function(j) j.T7.TableId = NameOf(Category) AndAlso j.T6.Id = j.T7.Id).
+                        OrderByDescending(Function(j) j.T6.Id).ThenBy(Function(j) j.T1.Id).ThenBy(Function(j) j.T3.Price).
+                        SelectAll().FirstOrDefault(CollectionNavigationFillBehavior.ProcessUntilMainEntityChange)
+
+        Assert.AreEqual(article1, result)
+        Assert.AreEqual(article1Label, result.Label)
+        CollectionAssert.AreEqual({article1Part3, article1Part2, article1Part1}, result.Parts)
+        Assert.AreEqual(article1Part3Label, result.Parts(0).Label)
+        Assert.AreEqual(article1Part2Label, result.Parts(1).Label)
+        Assert.AreEqual(article1Part1Label, result.Parts(2).Label)
+        CollectionAssert.AreEqual({category3}, result.Categories)
+        Assert.AreEqual(category3Label, result.Categories(0).Label)
+      End Using
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        LeftJoin(Of Label)(Function(j) j.T2.TableId = NameOf(Article) AndAlso j.T1.Id = j.T2.Id).
+                        LeftJoin(Of ArticlePart)(Function(j) j.T1.Id = j.T3.ArticleId).
+                        LeftJoin(Of Label)(Function(j) j.T4.TableId = NameOf(ArticlePart) AndAlso j.T3.Id = j.T4.Id).
+                        LeftJoin(Of ArticleCategory)(Function(j) j.T1.Id = j.T5.ArticleId).
+                        LeftJoin(Of Category)(Function(j) j.T5.CategoryId = j.T6.Id).As(Function(j) j.T1.Categories).
+                        LeftJoin(Of Label)(Function(j) j.T7.TableId = NameOf(Category) AndAlso j.T6.Id = j.T7.Id).
+                        OrderByDescending(Function(j) j.T6.Id).ThenBy(Function(j) j.T3.Price).
+                        SelectAll().FirstOrDefault(CollectionNavigationFillBehavior.ProcessUntilMainEntityChange)
+
+        Assert.AreEqual(article1, result)
+        Assert.AreEqual(article1Label, result.Label)
+        CollectionAssert.AreEqual({article1Part3, article1Part2}, result.Parts)
+        Assert.AreEqual(article1Part3Label, result.Parts(0).Label)
+        Assert.AreEqual(article1Part2Label, result.Parts(1).Label)
+        CollectionAssert.AreEqual({category3}, result.Categories)
+        Assert.AreEqual(category3Label, result.Categories(0).Label)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectFirstOrDefaultWithMultiple1To1And1ToNAndMToNRelationshipUsingProcessAllRowsBehavior()
+      Dim article1 = Me.ModelFactory.CreateArticle(1)
+      Dim article2 = Me.ModelFactory.CreateArticle(2)
+      Dim article3 = Me.ModelFactory.CreateArticle(3)
+
+      Dim article1Label = Me.ModelFactory.CreateLabel(NameOf(Article), 1, English)
+      Dim article2Label = Me.ModelFactory.CreateLabel(NameOf(Article), 2, English)
+      Dim article3Label = Me.ModelFactory.CreateLabel(NameOf(Article), 3, English)
+
+      Dim article1Part1 = Me.ModelFactory.CreateArticlePart(1001, 1, 7D)
+      Dim article1Part2 = Me.ModelFactory.CreateArticlePart(1002, 1, 2D)
+      Dim article1Part3 = Me.ModelFactory.CreateArticlePart(1003, 1, 1D)
+      Dim article2Part1 = Me.ModelFactory.CreateArticlePart(2001, 2, 3D)
+      Dim article2Part2 = Me.ModelFactory.CreateArticlePart(2002, 2, 4D)
+      Dim article3Part1 = Me.ModelFactory.CreateArticlePart(3001, 3, 5D)
+      Dim article3Part2 = Me.ModelFactory.CreateArticlePart(3002, 3, 6D)
+
+      Dim article1Part1Label = Me.ModelFactory.CreateLabel(NameOf(ArticlePart), 1001, English)
+      Dim article1Part2Label = Me.ModelFactory.CreateLabel(NameOf(ArticlePart), 1002, English)
+      Dim article1Part3Label = Me.ModelFactory.CreateLabel(NameOf(ArticlePart), 1003, English)
+      Dim article2Part1Label = Me.ModelFactory.CreateLabel(NameOf(ArticlePart), 2001, English)
+      Dim article2Part2Label = Me.ModelFactory.CreateLabel(NameOf(ArticlePart), 2002, English)
+      Dim article3Part1Label = Me.ModelFactory.CreateLabel(NameOf(ArticlePart), 3001, English)
+      Dim article3Part2Label = Me.ModelFactory.CreateLabel(NameOf(ArticlePart), 3002, English)
+
+      Dim category1 = Me.ModelFactory.CreateCategory(1)
+      Dim category2 = Me.ModelFactory.CreateCategory(2)
+      Dim category3 = Me.ModelFactory.CreateCategory(3)
+
+      Dim category1Label = Me.ModelFactory.CreateLabel(NameOf(Category), 1, English)
+      Dim category2Label = Me.ModelFactory.CreateLabel(NameOf(Category), 2, English)
+      Dim category3Label = Me.ModelFactory.CreateLabel(NameOf(Category), 3, English)
+
+      Dim article1Category1 = Me.ModelFactory.CreateArticleCategory(1, 1)
+      Dim article1Category2 = Me.ModelFactory.CreateArticleCategory(1, 2)
+      Dim article1Category3 = Me.ModelFactory.CreateArticleCategory(1, 3)
+      Dim article2Category1 = Me.ModelFactory.CreateArticleCategory(2, 1)
+      Dim article2Category2 = Me.ModelFactory.CreateArticleCategory(2, 2)
+      Dim article3Category1 = Me.ModelFactory.CreateArticleCategory(3, 1)
+      Dim article3Category3 = Me.ModelFactory.CreateArticleCategory(3, 3)
+
+      InsertItems(article1, article2, article3)
+      InsertItems(article1Label, article2Label, article3Label)
+      InsertItems(article1Part1, article1Part2, article1Part3, article2Part1, article2Part2, article3Part1, article3Part2)
+      InsertItems(article1Part1Label, article1Part2Label, article1Part3Label, article2Part1Label, article2Part2Label, article3Part1Label, article3Part2Label)
+      InsertItems(category1, category2, category3)
+      InsertItems(category1Label, category2Label, category3Label)
+      InsertItems(article1Category1, article1Category2, article1Category3, article2Category1, article2Category2, article3Category1, article3Category3)
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        LeftJoin(Of Label)(Function(j) j.T2.TableId = NameOf(Article) AndAlso j.T1.Id = j.T2.Id).
+                        LeftJoin(Of ArticlePart)(Function(j) j.T1.Id = j.T3.ArticleId).
+                        LeftJoin(Of Label)(Function(j) j.T4.TableId = NameOf(ArticlePart) AndAlso j.T3.Id = j.T4.Id).
+                        LeftJoin(Of ArticleCategory)(Function(j) j.T1.Id = j.T5.ArticleId).
+                        LeftJoin(Of Category)(Function(j) j.T5.CategoryId = j.T6.Id).As(Function(j) j.T1.Categories).
+                        LeftJoin(Of Label)(Function(j) j.T7.TableId = NameOf(Category) AndAlso j.T6.Id = j.T7.Id).
+                        OrderBy(Function(j) j.T1.Id).ThenBy(Function(j) j.T3.Price).ThenByDescending(Function(j) j.T6.Id).
+                        SelectAll().FirstOrDefault(CollectionNavigationFillBehavior.ProcessAllRows)
+
+        Assert.AreEqual(article1, result)
+        Assert.AreEqual(article1Label, result.Label)
+        CollectionAssert.AreEqual({article1Part3, article1Part2, article1Part1}, result.Parts)
+        Assert.AreEqual(article1Part3Label, result.Parts(0).Label)
+        Assert.AreEqual(article1Part2Label, result.Parts(1).Label)
+        Assert.AreEqual(article1Part1Label, result.Parts(2).Label)
+        CollectionAssert.AreEqual({category3, category2, category1}, result.Categories)
+        Assert.AreEqual(category3Label, result.Categories(0).Label)
+        Assert.AreEqual(category2Label, result.Categories(1).Label)
+        Assert.AreEqual(category1Label, result.Categories(2).Label)
+      End Using
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        LeftJoin(Of Label)(Function(j) j.T2.TableId = NameOf(Article) AndAlso j.T1.Id = j.T2.Id).
+                        LeftJoin(Of ArticlePart)(Function(j) j.T1.Id = j.T3.ArticleId).
+                        LeftJoin(Of Label)(Function(j) j.T4.TableId = NameOf(ArticlePart) AndAlso j.T3.Id = j.T4.Id).
+                        LeftJoin(Of ArticleCategory)(Function(j) j.T1.Id = j.T5.ArticleId).
+                        LeftJoin(Of Category)(Function(j) j.T5.CategoryId = j.T6.Id).As(Function(j) j.T1.Categories).
+                        LeftJoin(Of Label)(Function(j) j.T7.TableId = NameOf(Category) AndAlso j.T6.Id = j.T7.Id).
+                        OrderBy(Function(j) j.T3.Price).ThenByDescending(Function(j) j.T6.Id).
+                        SelectAll().FirstOrDefault(CollectionNavigationFillBehavior.ProcessAllRows)
+
+        Assert.AreEqual(article1, result)
+        Assert.AreEqual(article1Label, result.Label)
+        CollectionAssert.AreEqual({article1Part3, article1Part2, article1Part1}, result.Parts)
+        Assert.AreEqual(article1Part3Label, result.Parts(0).Label)
+        Assert.AreEqual(article1Part2Label, result.Parts(1).Label)
+        Assert.AreEqual(article1Part1Label, result.Parts(2).Label)
+        CollectionAssert.AreEqual({category3, category2, category1}, result.Categories)
+        Assert.AreEqual(category3Label, result.Categories(0).Label)
+        Assert.AreEqual(category2Label, result.Categories(1).Label)
+        Assert.AreEqual(category1Label, result.Categories(2).Label)
+      End Using
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        LeftJoin(Of Label)(Function(j) j.T2.TableId = NameOf(Article) AndAlso j.T1.Id = j.T2.Id).
+                        LeftJoin(Of ArticlePart)(Function(j) j.T1.Id = j.T3.ArticleId).
+                        LeftJoin(Of Label)(Function(j) j.T4.TableId = NameOf(ArticlePart) AndAlso j.T3.Id = j.T4.Id).
+                        LeftJoin(Of ArticleCategory)(Function(j) j.T1.Id = j.T5.ArticleId).
+                        LeftJoin(Of Category)(Function(j) j.T5.CategoryId = j.T6.Id).As(Function(j) j.T1.Categories).
+                        LeftJoin(Of Label)(Function(j) j.T7.TableId = NameOf(Category) AndAlso j.T6.Id = j.T7.Id).
+                        OrderByDescending(Function(j) j.T6.Id).ThenBy(Function(j) j.T1.Id).ThenBy(Function(j) j.T3.Price).
+                        SelectAll().FirstOrDefault(CollectionNavigationFillBehavior.ProcessAllRows)
+
+        Assert.AreEqual(article1, result)
+        Assert.AreEqual(article1Label, result.Label)
+        CollectionAssert.AreEqual({article1Part3, article1Part2, article1Part1}, result.Parts)
+        Assert.AreEqual(article1Part3Label, result.Parts(0).Label)
+        Assert.AreEqual(article1Part2Label, result.Parts(1).Label)
+        Assert.AreEqual(article1Part1Label, result.Parts(2).Label)
+        CollectionAssert.AreEqual({category3, category2, category1}, result.Categories)
+        Assert.AreEqual(category3Label, result.Categories(0).Label)
+        Assert.AreEqual(category2Label, result.Categories(1).Label)
+        Assert.AreEqual(category1Label, result.Categories(2).Label)
+      End Using
+    End Sub
+
+  End Class
+End Namespace


### PR DESCRIPTION
Using `FirstOrDefault` method is now possible and doesn't throw an exception. This PR fixes #28.

Optionally, you can pass `CollectionNavigationFillBehavior` parameter to define how the method should behave during processing result. Parameter has no effect if there is no joined table or all joined tables are configured to fill purely reference navigation properties (1:1 relationship). Shall any joined table fill a collection navigation property (1:N or M:N relationship), behavior will control when to stop processing the resultset.

`CollectionNavigationFillBehavior` has following enum members:
- `ProcessOnlyFirstRow`: process only first row from the resultset. Any collection navigation property will contain maximum 1 item. This is the default behavior.
- `ProcessUntilMainEntityChange`: process the resultset until it contains the same main entity. If resultset is sorted properly and all rows related to main entity are grouped together, all collection navigation properties will be filled with all related items.
- `ProcessAllRows`: process the whole resultset. All collection navigation properties will be filled with all related items, no matter how the resultset is sorted. **This always processes all the rows in the resultset**, so if you don't limit the records, there might be a negative performance impact (but Yamo is smart enough to read only primary keys and not to create all the entities when not necessary).

For example, let's imagine we have a table `Article` and table `ArticlePart`. One article can have multiple parts. There are 3 articles with following article parts:
| ArticleId | Price |
|-----------|-------|
| 1         | 10    |
| 1         | 11    |
| 1         | 15    |
| 2         | 12    |
| 2         | 13    |
| 3         | 14    |

Now we'll join articles with their parts and order the records by article part price:

```sql
SELECT * FROM Article a LEFT OUTER JOIN ArticlePart ap ON a.Id = ap.ArticleId ORDER BY ap.Price
```

 This is the resultset:
| Article.Id | ... | ArticlePart.Price |
|------------|-----|-------------------|
| 1          | ... | 10                |
| 1          | ... | 11                |
| 2          | ... | 12                |
| 2          | ... | 13                |
| 3          | ... | 14                |
| 1          | ... | 15                |

Based on our requirements, we can define how the `article.Parts` property of the returned article will be filled:

```cs
using (var db = CreateContext())
{
    // processes only first row
    var result1 = db.From<Article>()
                    .LeftJoin<ArticlePart>((a, ap) => a.Id == ap.ArticleId)
                    .OrderBy((ArticlePart ap) => ap.Price)
                    .SelectAll().FirstOrDefault();

    Assert.AreEqual(1, result1.Id);
    Assert.AreEqual(1, result1.Parts.Count);
    Assert.AreEqual(10, result1.Parts[0].Price);

    var result2 = db.From<Article>()
                    .LeftJoin<ArticlePart>((a, ap) => a.Id == ap.ArticleId)
                    .OrderBy((ArticlePart ap) => ap.Price)
                    .SelectAll().FirstOrDefault(CollectionNavigationFillBehavior.ProcessOnlyFirstRow);

    // result2 is same as result1

    // -----------------------------------

    // processes only first 2 rows
    var result3 = db.From<Article>()
                    .LeftJoin<ArticlePart>((a, ap) => a.Id == ap.ArticleId)
                    .OrderBy((ArticlePart ap) => ap.Price)
                    .SelectAll().FirstOrDefault(CollectionNavigationFillBehavior.ProcessUntilMainEntityChange);

    Assert.AreEqual(1, result3.Id);
    Assert.AreEqual(2, result3.Parts.Count);
    Assert.AreEqual(10, result3.Parts[0].Price);
    Assert.AreEqual(11, result3.Parts[1].Price);

    // -----------------------------------

    // processes all rows
    var result4 = db.From<Article>()
                    .LeftJoin<ArticlePart>((a, ap) => a.Id == ap.ArticleId)
                    .OrderBy((ArticlePart ap) => ap.Price)
                    .SelectAll().FirstOrDefault(CollectionNavigationFillBehavior.ProcessAllRows);

    Assert.AreEqual(1, result4.Id);
    Assert.AreEqual(3, result4.Parts.Count);
    Assert.AreEqual(10, result3.Parts[0].Price);
    Assert.AreEqual(11, result3.Parts[1].Price);
    Assert.AreEqual(15, result3.Parts[2].Price);
}
```