### PR TITLE
Added support for querying raw values

### DIFF
--- a/Source/Samples/Yamo.Playground.CS/Program.cs
+++ b/Source/Samples/Yamo.Playground.CS/Program.cs
@@ -68,10 +68,11 @@ namespace Yamo.Playground.CS
             //Test45();
             //Test46();
             //Test47();
-            Test48();
-            Test49();
-            Test50();
-            Test51();
+            //Test48();
+            //Test49();
+            //Test50();
+            //Test51();
+            Test52();
         }
 
         public static MyContext CreateContext()
@@ -972,6 +973,16 @@ namespace Yamo.Playground.CS
                              .ExcludeT2()
                              .Include(j => j.T1.Tag, j => j.T2)
                              .ToList();
+            }
+        }
+
+        public static void Test52()
+        {
+            using (var db = CreateContext())
+            {
+                var login = "foo";
+                var data = db.QueryFirstOrDefault<Object[]>($"SELECT Id, Login FROM [User] WHERE Login = {login}");
+                var list = db.Query<Object[]>("SELECT Id, Login FROM [User]");
             }
         }
     }

--- a/Source/Source/Yamo/Internal/Helpers/Types.vb
+++ b/Source/Source/Yamo/Internal/Helpers/Types.vb
@@ -197,6 +197,7 @@ Namespace Internal.Helpers
       If type.IsValueType Then Return False
       If type Is GetType(String) Then Return False
       If type Is GetType(Byte()) Then Return False
+      If type Is GetType(Object()) Then Return False
       Return True
     End Function
 

--- a/Source/Test/Yamo.Test.SQLite/SQLiteTestEnvironment.vb
+++ b/Source/Test/Yamo.Test.SQLite/SQLiteTestEnvironment.vb
@@ -48,4 +48,8 @@ Public Class SQLiteTestEnvironment
     Next
   End Sub
 
+  Public Function CreateRawValueComparer() As RawValueComparer Implements ITestEnvironment.CreateRawValueComparer
+    Return New SQliteRawValueComparer()
+  End Function
+
 End Class

--- a/Source/Test/Yamo.Test.SQLite/SQliteRawValueComparer.vb
+++ b/Source/Test/Yamo.Test.SQLite/SQliteRawValueComparer.vb
@@ -1,0 +1,54 @@
+﻿Imports Yamo.SQLite.Infrastructure
+
+Public Class SQliteRawValueComparer
+  Inherits RawValueComparer
+
+  Private m_Conversion As SQLiteDbValueConversion
+
+  Sub New()
+    m_Conversion = New SQLiteDbValueConversion
+  End Sub
+
+  Public Overrides Sub AreRawValuesEqual(expected As Object, actual As Object)
+    If actual IsNot DBNull.Value Then
+      If TypeOf expected Is Guid Then
+        actual = m_Conversion.FromDbValue(Of Guid)(actual)
+      ElseIf TypeOf expected Is Guid? Then
+        actual = m_Conversion.FromDbValue(Of Guid?)(actual)
+
+      ElseIf TypeOf expected Is Boolean Then
+        actual = m_Conversion.FromDbValue(Of Boolean)(actual)
+      ElseIf TypeOf expected Is Boolean? Then
+        actual = m_Conversion.FromDbValue(Of Boolean?)(actual)
+
+      ElseIf TypeOf expected Is Int16 Then
+        actual = m_Conversion.FromDbValue(Of Int16)(actual)
+      ElseIf TypeOf expected Is Int16? Then
+        actual = m_Conversion.FromDbValue(Of Int16?)(actual)
+
+      ElseIf TypeOf expected Is Int32 Then
+        actual = m_Conversion.FromDbValue(Of Int32)(actual)
+      ElseIf TypeOf expected Is Int32? Then
+        actual = m_Conversion.FromDbValue(Of Int32?)(actual)
+
+      ElseIf TypeOf expected Is Single Then
+        actual = m_Conversion.FromDbValue(Of Single)(actual)
+      ElseIf TypeOf expected Is Single? Then
+        actual = m_Conversion.FromDbValue(Of Single?)(actual)
+
+      ElseIf TypeOf expected Is Decimal Then
+        actual = m_Conversion.FromDbValue(Of Decimal)(actual)
+      ElseIf TypeOf expected Is Decimal? Then
+        actual = m_Conversion.FromDbValue(Of Decimal?)(actual)
+
+      ElseIf TypeOf expected Is DateTime Then
+        actual = m_Conversion.FromDbValue(Of DateTime)(actual)
+      ElseIf TypeOf expected Is DateTime? Then
+        actual = m_Conversion.FromDbValue(Of DateTime?)(actual)
+      End If
+    End If
+
+    MyBase.AreRawValuesEqual(expected, actual)
+  End Sub
+
+End Class

--- a/Source/Test/Yamo.Test.SqlServer/SqlServerTestEnvironment.vb
+++ b/Source/Test/Yamo.Test.SqlServer/SqlServerTestEnvironment.vb
@@ -48,4 +48,8 @@ Public Class SqlServerTestEnvironment
     Next
   End Sub
 
+  Public Function CreateRawValueComparer() As RawValueComparer Implements ITestEnvironment.CreateRawValueComparer
+    Return New RawValueComparer()
+  End Function
+
 End Class

--- a/Source/Test/Yamo.Test/ITestEnvironment.vb
+++ b/Source/Test/Yamo.Test/ITestEnvironment.vb
@@ -6,4 +6,6 @@
 
   Sub UninitializeDatabase()
 
+  Function CreateRawValueComparer() As RawValueComparer
+
 End Interface

--- a/Source/Test/Yamo.Test/Model/ItemWithAllSupportedValues.vb
+++ b/Source/Test/Yamo.Test/Model/ItemWithAllSupportedValues.vb
@@ -66,6 +66,7 @@
       Else
         Dim o = DirectCast(obj, ItemWithAllSupportedValues)
 
+        If Not Object.Equals(Me.Id, o.Id) Then Return False
         If Not Object.Equals(Me.UniqueidentifierColumn, o.UniqueidentifierColumn) Then Return False
         If Not Object.Equals(Me.UniqueidentifierColumnNull, o.UniqueidentifierColumnNull) Then Return False
         If Not Object.Equals(Me.Nvarchar50Column, o.Nvarchar50Column) Then Return False
@@ -161,6 +162,48 @@
       End If
 
       Return hashCode.ToHashCode()
+    End Function
+
+    Public Function ToRawValues() As Object()
+      Dim value = New Object() {
+        Me.Id,
+        Me.UniqueidentifierColumn,
+        Me.UniqueidentifierColumnNull,
+        Me.Nvarchar50Column,
+        Me.Nvarchar50ColumnNull,
+        Me.NvarcharMaxColumn,
+        Me.NvarcharMaxColumnNull,
+        Me.BitColumn,
+        Me.BitColumnNull,
+        Me.SmallintColumn,
+        Me.SmallintColumnNull,
+        Me.IntColumn,
+        Me.IntColumnNull,
+        Me.BigintColumn,
+        Me.BigintColumnNull,
+        Me.RealColumn,
+        Me.RealColumnNull,
+        Me.FloatColumn,
+        Me.FloatColumnNull,
+        Me.Numeric10and3Column,
+        Me.Numeric10and3ColumnNull,
+        Me.Numeric15and0Column,
+        Me.Numeric15and0ColumnNull,
+        Me.DatetimeColumn,
+        Me.DatetimeColumnNull,
+        Me.Varbinary50Column,
+        Me.Varbinary50ColumnNull,
+        Me.VarbinaryMaxColumn,
+        Me.VarbinaryMaxColumnNull
+      }
+
+      For i = 0 To value.Length - 1
+        If value(i) Is Nothing Then
+          value(i) = DBNull.Value
+        End If
+      Next
+
+      Return value
     End Function
 
   End Class

--- a/Source/Test/Yamo.Test/RawValueComparer.vb
+++ b/Source/Test/Yamo.Test/RawValueComparer.vb
@@ -1,0 +1,30 @@
+﻿Public Class RawValueComparer
+
+  Public Overridable Sub AreRawValuesEqual(expected As Object(), actual As Object())
+    If expected Is Nothing Then
+      Assert.IsNull(actual)
+      Return
+    End If
+
+    If expected IsNot Nothing Then
+      Assert.IsNotNull(actual)
+    End If
+
+    Assert.AreEqual(expected.Length, actual.Length)
+
+    For i = 0 To expected.Length - 1
+      AreRawValuesEqual(expected(i), actual(i))
+    Next
+  End Sub
+
+  Public Overridable Sub AreRawValuesEqual(expected As Object, actual As Object)
+    If TypeOf expected Is Byte() Then
+      If Not Helpers.Compare.AreByteArraysEqual(CType(expected, Byte()), CType(actual, Byte())) Then
+        Assert.Fail()
+      End If
+    Else
+      Assert.AreEqual(expected, actual)
+    End If
+  End Sub
+
+End Class

--- a/Source/Test/Yamo.Test/Tests/QueryFirstOrDefaultTests.vb
+++ b/Source/Test/Yamo.Test/Tests/QueryFirstOrDefaultTests.vb
@@ -734,5 +734,22 @@ Namespace Tests
       End Using
     End Sub
 
+    <TestMethod()>
+    Public Overridable Sub QueryFirstOrDefaultOfObjectArray()
+      Dim item = Me.ModelFactory.CreateItemWithAllSupportedValuesWithMaxValues()
+
+      InsertItems(item)
+
+      Dim comparer = Me.TestEnvironment.CreateRawValueComparer()
+
+      Using db = CreateDbContext()
+        Dim result1 = db.QueryFirstOrDefault(Of Object())($"SELECT {Sql.Model.Columns(Of ItemWithAllSupportedValues)} FROM ItemWithAllSupportedValues WHERE 1 = 2")
+        Assert.IsNull(result1)
+
+        Dim result2 = db.QueryFirstOrDefault(Of Object())($"SELECT {Sql.Model.Columns(Of ItemWithAllSupportedValues)} FROM ItemWithAllSupportedValues WHERE Id = {item.Id}")
+        comparer.AreRawValuesEqual(item.ToRawValues(), result2)
+      End Using
+    End Sub
+
   End Class
 End Namespace

--- a/Source/Test/Yamo.Test/Tests/QueryTests.vb
+++ b/Source/Test/Yamo.Test/Tests/QueryTests.vb
@@ -889,5 +889,32 @@ Namespace Tests
       End Using
     End Sub
 
+    <TestMethod()>
+    Public Overridable Sub QueryOfObjectArray()
+      Dim item1 = Me.ModelFactory.CreateItemWithAllSupportedValuesWithEmptyValues()
+      item1.IntColumn = 1
+
+      Dim item2 = Me.ModelFactory.CreateItemWithAllSupportedValuesWithMinValues()
+      item2.IntColumn = 2
+
+      Dim item3 = Me.ModelFactory.CreateItemWithAllSupportedValuesWithMaxValues()
+      item3.IntColumn = 3
+
+      InsertItems(item1, item2, item3)
+
+      Dim comparer = Me.TestEnvironment.CreateRawValueComparer()
+
+      Using db = CreateDbContext()
+        Dim result1 = db.Query(Of Object())($"SELECT {Sql.Model.Columns(Of ItemWithAllSupportedValues)} FROM ItemWithAllSupportedValues WHERE 1 = 2 ORDER BY IntColumn")
+        Assert.AreEqual(0, result1.Count)
+
+        Dim result2 = db.Query(Of Object())($"SELECT {Sql.Model.Columns(Of ItemWithAllSupportedValues)} FROM ItemWithAllSupportedValues ORDER BY IntColumn")
+        Assert.AreEqual(3, result2.Count)
+        comparer.AreRawValuesEqual(item1.ToRawValues(), result2(0))
+        comparer.AreRawValuesEqual(item2.ToRawValues(), result2(1))
+        comparer.AreRawValuesEqual(item3.ToRawValues(), result2(2))
+      End Using
+    End Sub
+
   End Class
 End Namespace

--- a/Source/Test/Yamo.Test/UnitTestEnvironment.vb
+++ b/Source/Test/Yamo.Test/UnitTestEnvironment.vb
@@ -17,4 +17,8 @@
     Throw New NotSupportedException()
   End Sub
 
+  Public Function CreateRawValueComparer() As RawValueComparer Implements ITestEnvironment.CreateRawValueComparer
+    Return New RawValueComparer()
+  End Function
+
 End Class


### PR DESCRIPTION
This PR adds support for querying "raw values" in `Query` and `QueryFirstOrDefault` methods.

If `Object[]` is used as a type parameter, array of objects with the column values of the row is returned. Basically, it just returns values from `DbDataReader.GetValues(Object[])` call.

Example:
```cs
using (var db = CreateContext())
{
    var login = "foo";
    var data = db.QueryFirstOrDefault<Object[]>($"SELECT Id, Login FROM [User] WHERE Login = {login}");
    var list = db.Query<Object[]>("SELECT Id, Login FROM [User]");
}
```