### PR TITLE
Added PredicateBuilder

### DIFF
--- a/Source/Samples/Yamo.Playground.CS/Program.cs
+++ b/Source/Samples/Yamo.Playground.CS/Program.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Yamo.Playground.CS.Model;
 using System.Data;
+using System.Linq.Expressions;
 
 namespace Yamo.Playground.CS
 {
@@ -74,7 +75,8 @@ namespace Yamo.Playground.CS
             //Test50();
             //Test51();
             //Test52();
-            Test53();
+            //Test53();
+            Test54();
         }
 
         public static MyContext CreateContext()
@@ -1005,6 +1007,32 @@ namespace Yamo.Playground.CS
 
                 var leonardo = db.QueryFirstOrDefault<Person>($"SELECT {Yamo.Sql.Model.Columns<Person>()} FROM Person WHERE LastName = {name} AND BirthDate = {birth}");
             }
+        }
+
+        public static void Test54()
+        {
+            var bornBefore = DateTime.Now;
+            var names = new string[] { "Leonardo", "Raffaello" };
+
+            using (var db = CreateContext())
+            {
+                var bornBeforeFilter = GetBornBeforeFilter(bornBefore);
+                var nameFilters = names.Select(x => GetNameFilter(x)).ToArray();
+
+                var filter = PredicateBuilder.And(bornBeforeFilter, PredicateBuilder.Or(nameFilters));
+
+                var people = db.From<Person>().Where(filter).SelectAll().ToList();
+            }
+        }
+
+        private static Expression<Func<Person, bool>> GetNameFilter(string value)
+        {
+            return x => x.FirstName == value;
+        }
+
+        private static Expression<Func<Person, bool>> GetBornBeforeFilter(DateTime value)
+        {
+            return x => x.BirthDate < value;
         }
     }
 }

--- a/Source/Source/Yamo/Internal/ReplaceParameterVisitor.vb
+++ b/Source/Source/Yamo/Internal/ReplaceParameterVisitor.vb
@@ -1,0 +1,57 @@
+﻿Imports System.Linq.Expressions
+
+Namespace Internal
+
+  ''' <summary>
+  ''' Represents a visitor that replaces single parameter in the expression.<br/>
+  ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+  ''' </summary>
+  Public Class ReplaceParameterVisitor
+    Inherits ExpressionVisitor
+
+    ''' <summary>
+    ''' Original parameter expression
+    ''' </summary>
+    Private m_Original As ParameterExpression
+
+    ''' <summary>
+    ''' Replacement parameter expression
+    ''' </summary>
+    Private m_Replacement As ParameterExpression
+
+    ''' <summary>
+    ''' Replaces single parameter in the node.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <param name="node"></param>
+    ''' <param name="original"></param>
+    ''' <param name="replacement"></param>
+    ''' <returns></returns>
+    Public Function Replace(node As Expression, original As ParameterExpression, replacement As ParameterExpression) As Expression
+      m_Original = original
+      m_Replacement = replacement
+
+      Dim result = Visit(node)
+
+      m_Original = Nothing
+      m_Replacement = Nothing
+
+      Return result
+    End Function
+
+    ''' <summary>
+    ''' Visits parameter.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <param name="node"></param>
+    ''' <returns></returns>
+    Protected Overrides Function VisitParameter(node As ParameterExpression) As Expression
+      If node Is m_Original Then
+        node = m_Replacement
+      End If
+
+      Return MyBase.VisitParameter(node)
+    End Function
+
+  End Class
+End Namespace

--- a/Source/Source/Yamo/PredicateBuilder.vb
+++ b/Source/Source/Yamo/PredicateBuilder.vb
@@ -1,0 +1,215 @@
+﻿Imports System.Linq.Expressions
+Imports Yamo.Internal
+
+''' <summary>
+''' Provides the functionality to dynamically build predicates.
+''' </summary>
+Public Class PredicateBuilder
+
+  ''' <summary>
+  ''' Creates new instance of <see cref="PredicateBuilder"/>.
+  ''' </summary>
+  Private Sub New()
+  End Sub
+
+  ''' <summary>
+  ''' Creates predicate that represents logical AND between two predicates.
+  ''' </summary>
+  ''' <typeparam name="T"></typeparam>
+  ''' <param name="left"></param>
+  ''' <param name="right"></param>
+  ''' <returns></returns>
+  Public Shared Function [And](Of T)(left As Expression(Of Func(Of T, Boolean)), right As Expression(Of Func(Of T, Boolean))) As Expression(Of Func(Of T, Boolean))
+    Dim visitor = New ReplaceParameterVisitor()
+
+    Dim newLeft = left.Body
+    Dim newRight = visitor.Replace(right.Body, right.Parameters(0), left.Parameters(0))
+    Dim newParameters = left.Parameters
+
+    Return Expression.Lambda(Of Func(Of T, Boolean))(Expression.AndAlso(newLeft, newRight), newParameters)
+  End Function
+
+  ''' <summary>
+  ''' Creates predicate that represents logical AND between multiple predicates.<br/>
+  ''' If parameter array contains 0 predicates, result will be a predicate that always returns <see langword="True"/>.
+  ''' </summary>
+  ''' <typeparam name="T"></typeparam>
+  ''' <param name="predicates"></param>
+  ''' <returns></returns>
+  Public Shared Function [And](Of T)(ParamArray predicates As Expression(Of Func(Of T, Boolean))()) As Expression(Of Func(Of T, Boolean))
+    If predicates Is Nothing Then
+      Throw New ArgumentNullException(NameOf(predicates))
+    ElseIf predicates.Length = 0 Then
+      Return [True](Of T)()
+    ElseIf predicates.Length = 1 Then
+      Return predicates(0)
+    End If
+
+    Dim visitor = New ReplaceParameterVisitor()
+
+    Dim newPredicate = predicates(0).Body
+    Dim newParameters = predicates(0).Parameters
+
+    For i = 1 To predicates.Length - 1
+      Dim exp = predicates(i)
+      Dim right = visitor.Replace(exp.Body, exp.Parameters(0), newParameters(0))
+      newPredicate = Expression.AndAlso(newPredicate, right)
+    Next
+
+    Return Expression.Lambda(Of Func(Of T, Boolean))(newPredicate, newParameters)
+  End Function
+
+  ''' <summary>
+  ''' Creates predicate that represents logical AND between multiple predicates.<br/>
+  ''' If parameter collection contains 0 predicates, result will be a predicate that always returns <see langword="True"/>.
+  ''' </summary>
+  ''' <typeparam name="T"></typeparam>
+  ''' <param name="predicates"></param>
+  ''' <returns></returns>
+  Public Shared Function [And](Of T)(predicates As IEnumerable(Of Expression(Of Func(Of T, Boolean)))) As Expression(Of Func(Of T, Boolean))
+    If predicates Is Nothing Then
+      Throw New ArgumentNullException(NameOf(predicates))
+    End If
+
+    Dim count = predicates.Count()
+
+    If count = 0 Then
+      Return [True](Of T)()
+    ElseIf predicates.Count = 1 Then
+      Return predicates(0)
+    End If
+
+    Dim visitor = New ReplaceParameterVisitor()
+
+    Dim newPredicate = predicates(0).Body
+    Dim newParameters = predicates(0).Parameters
+    Dim skipped = False
+
+    For Each predicate In predicates
+      If skipped Then
+        Dim right = visitor.Replace(predicate.Body, predicate.Parameters(0), newParameters(0))
+        newPredicate = Expression.AndAlso(newPredicate, right)
+      Else
+        skipped = True
+      End If
+    Next
+
+    Return Expression.Lambda(Of Func(Of T, Boolean))(newPredicate, newParameters)
+  End Function
+
+  ''' <summary>
+  ''' Creates predicate that represents logical OR between two predicates.<br/>
+  ''' If parameter array contains 0 predicates, result will be a predicate that always returns <see langword="True"/>.
+  ''' </summary>
+  ''' <typeparam name="T"></typeparam>
+  ''' <param name="left"></param>
+  ''' <param name="right"></param>
+  ''' <returns></returns>
+  Public Shared Function [Or](Of T)(left As Expression(Of Func(Of T, Boolean)), right As Expression(Of Func(Of T, Boolean))) As Expression(Of Func(Of T, Boolean))
+    Dim visitor = New ReplaceParameterVisitor()
+
+    Dim newLeft = left.Body
+    Dim newRight = visitor.Replace(right.Body, right.Parameters(0), left.Parameters(0))
+    Dim newParameters = left.Parameters
+
+    Return Expression.Lambda(Of Func(Of T, Boolean))(Expression.OrElse(newLeft, newRight), newParameters)
+  End Function
+
+  ''' <summary>
+  ''' Creates predicate that represents logical OR between multiple predicates.<br/>
+  ''' If parameter collection contains 0 predicates, result will be a predicate that always returns <see langword="True"/>.
+  ''' </summary>
+  ''' <typeparam name="T"></typeparam>
+  ''' <param name="predicates"></param>
+  ''' <returns></returns>
+  Public Shared Function [Or](Of T)(ParamArray predicates As Expression(Of Func(Of T, Boolean))()) As Expression(Of Func(Of T, Boolean))
+    If predicates Is Nothing Then
+      Throw New ArgumentNullException(NameOf(predicates))
+    ElseIf predicates.Length = 0 Then
+      Return [True](Of T)()
+    ElseIf predicates.Length = 1 Then
+      Return predicates(0)
+    End If
+
+    Dim visitor = New ReplaceParameterVisitor()
+
+    Dim newPredicate = predicates(0).Body
+    Dim newParameters = predicates(0).Parameters
+
+    For i = 1 To predicates.Length - 1
+      Dim exp = predicates(i)
+      Dim right = visitor.Replace(exp.Body, exp.Parameters(0), newParameters(0))
+      newPredicate = Expression.OrElse(newPredicate, right)
+    Next
+
+    Return Expression.Lambda(Of Func(Of T, Boolean))(newPredicate, newParameters)
+  End Function
+
+  ''' <summary>
+  ''' Creates predicate that represents logical OR between multiple predicates.
+  ''' </summary>
+  ''' <typeparam name="T"></typeparam>
+  ''' <param name="predicates"></param>
+  ''' <returns></returns>
+  Public Shared Function [Or](Of T)(predicates As IEnumerable(Of Expression(Of Func(Of T, Boolean)))) As Expression(Of Func(Of T, Boolean))
+    If predicates Is Nothing Then
+      Throw New ArgumentNullException(NameOf(predicates))
+    End If
+
+    Dim count = predicates.Count()
+
+    If count = 0 Then
+      Return [True](Of T)()
+    ElseIf predicates.Count = 1 Then
+      Return predicates(0)
+    End If
+
+    Dim visitor = New ReplaceParameterVisitor()
+
+    Dim newPredicate = predicates(0).Body
+    Dim newParameters = predicates(0).Parameters
+    Dim skipped = False
+
+    For Each predicate In predicates
+      If skipped Then
+        Dim right = visitor.Replace(predicate.Body, predicate.Parameters(0), newParameters(0))
+        newPredicate = Expression.OrElse(newPredicate, right)
+      Else
+        skipped = True
+      End If
+    Next
+
+    Return Expression.Lambda(Of Func(Of T, Boolean))(newPredicate, newParameters)
+  End Function
+
+  ''' <summary>
+  ''' Creates predicate that represents logical negation of a predicate.
+  ''' </summary>
+  ''' <typeparam name="T"></typeparam>
+  ''' <param name="predicate"></param>
+  ''' <returns></returns>
+  Public Shared Function [Not](Of T)(predicate As Expression(Of Func(Of T, Boolean))) As Expression(Of Func(Of T, Boolean))
+    Return Expression.Lambda(Of Func(Of T, Boolean))(Expression.Not(predicate.Body), predicate.Parameters)
+  End Function
+
+  ''' <summary>
+  ''' Creates predicate that always returns <see langword="True"/>.
+  ''' </summary>
+  ''' <typeparam name="T"></typeparam>
+  ''' <returns></returns>
+  Public Shared Function [True](Of T)() As Expression(Of Func(Of T, Boolean))
+    Dim param = Expression.Parameter(GetType(T), "x")
+    Return Expression.Lambda(Of Func(Of T, Boolean))(Expression.Constant(True), {param})
+  End Function
+
+  ''' <summary>
+  ''' Creates predicate that always returns <see langword="False"/>.
+  ''' </summary>
+  ''' <typeparam name="T"></typeparam>
+  ''' <returns></returns>
+  Public Shared Function [False](Of T)() As Expression(Of Func(Of T, Boolean))
+    Dim param = Expression.Parameter(GetType(T), "x")
+    Return Expression.Lambda(Of Func(Of T, Boolean))(Expression.Constant(False), {param})
+  End Function
+
+End Class

--- a/Source/Test/Yamo.Test/Tests/PredicateBuilderTests.vb
+++ b/Source/Test/Yamo.Test/Tests/PredicateBuilderTests.vb
@@ -1,0 +1,237 @@
+﻿Imports System.Linq.Expressions
+Imports System.Data
+Imports Yamo.Test.Model
+
+Namespace Tests
+
+  <TestClass()>
+  Public Class PredicateBuilderTests
+    Inherits BaseUnitTests
+
+    <TestMethod()>
+    Public Overridable Sub BuildAndWith2Predicates()
+      Dim items = CreateItems()
+
+      Dim exp1 As Expression(Of Func(Of ItemWithAllSupportedValues, Boolean)) = Function(x) x.IntColumn Mod 2 = 0
+      Dim exp2 As Expression(Of Func(Of ItemWithAllSupportedValues, Boolean)) = Function(x) x.IntColumn Mod 3 = 0
+
+      Dim exp = PredicateBuilder.And(exp1, exp2)
+      Dim predicate = exp.Compile()
+
+      Dim result = items.Where(predicate).ToList()
+
+      CollectionAssert.AreEquivalent({items(0), items(6), items(12)}, result)
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub BuildAndWithParamArray()
+      Dim items = CreateItems()
+
+      Dim exp1 As Expression(Of Func(Of ItemWithAllSupportedValues, Boolean)) = Function(x) x.IntColumn Mod 2 = 0
+      Dim exp2 As Expression(Of Func(Of ItemWithAllSupportedValues, Boolean)) = Function(x) x.IntColumn Mod 3 = 0
+      Dim exp3 As Expression(Of Func(Of ItemWithAllSupportedValues, Boolean)) = Function(x) x.IntColumn Mod 4 = 0
+
+      ' 0 items
+      Dim exps As Expression(Of Func(Of ItemWithAllSupportedValues, Boolean))() = {}
+      Dim expWith0Items = PredicateBuilder.And(exps)
+      Dim predicateWith0Items = expWith0Items.Compile()
+
+      Dim result = items.Where(predicateWith0Items).ToList()
+
+      CollectionAssert.AreEquivalent(items, result)
+
+      ' 1 item
+      Dim expWith1Item = PredicateBuilder.And(exp3)
+      Dim predicateWith1Item = expWith1Item.Compile()
+
+      result = items.Where(predicateWith1Item).ToList()
+
+      CollectionAssert.AreEquivalent({items(0), items(4), items(8), items(12)}, result)
+
+      ' 3 items
+      Dim expWith3Items = PredicateBuilder.And(exp1, exp2, exp3)
+      Dim predicateWith3Items = expWith3Items.Compile()
+
+      result = items.Where(predicateWith3Items).ToList()
+
+      CollectionAssert.AreEquivalent({items(0), items(12)}, result)
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub BuildAndWithCollection()
+      Dim items = CreateItems()
+
+      Dim exp1 As Expression(Of Func(Of ItemWithAllSupportedValues, Boolean)) = Function(x) x.IntColumn Mod 2 = 0
+      Dim exp2 As Expression(Of Func(Of ItemWithAllSupportedValues, Boolean)) = Function(x) x.IntColumn Mod 3 = 0
+      Dim exp3 As Expression(Of Func(Of ItemWithAllSupportedValues, Boolean)) = Function(x) x.IntColumn Mod 4 = 0
+
+      Dim exps As List(Of Expression(Of Func(Of ItemWithAllSupportedValues, Boolean)))
+
+      ' 0 items
+      exps = New List(Of Expression(Of Func(Of ItemWithAllSupportedValues, Boolean)))()
+      Dim expWith0Items = PredicateBuilder.And(exps)
+      Dim predicateWith0Items = expWith0Items.Compile()
+
+      Dim result = items.Where(predicateWith0Items).ToList()
+
+      CollectionAssert.AreEquivalent(items, result)
+
+      ' 1 item
+      exps = {exp3}.ToList()
+      Dim expWith1Item = PredicateBuilder.And(exps)
+      Dim predicateWith1Item = expWith1Item.Compile()
+
+      result = items.Where(predicateWith1Item).ToList()
+
+      CollectionAssert.AreEquivalent({items(0), items(4), items(8), items(12)}, result)
+
+      ' 3 items
+      exps = {exp1, exp2, exp3}.ToList()
+      Dim expWith3Items = PredicateBuilder.And(exps)
+      Dim predicateWith3Items = expWith3Items.Compile()
+
+      result = items.Where(predicateWith3Items).ToList()
+
+      CollectionAssert.AreEquivalent({items(0), items(12)}, result)
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub BuildOrWith2Predicates()
+      Dim items = CreateItems()
+
+      Dim exp1 As Expression(Of Func(Of ItemWithAllSupportedValues, Boolean)) = Function(x) x.IntColumn Mod 5 = 0
+      Dim exp2 As Expression(Of Func(Of ItemWithAllSupportedValues, Boolean)) = Function(x) x.IntColumn Mod 6 = 0
+
+      Dim exp = PredicateBuilder.Or(exp1, exp2)
+
+      Dim predicate = exp.Compile()
+
+      Dim result = items.Where(predicate).ToList()
+
+      CollectionAssert.AreEquivalent({items(0), items(5), items(6), items(10), items(12), items(15)}, result)
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub BuildOrWithParamArray()
+      Dim items = CreateItems()
+
+      Dim exp1 As Expression(Of Func(Of ItemWithAllSupportedValues, Boolean)) = Function(x) x.IntColumn Mod 5 = 0
+      Dim exp2 As Expression(Of Func(Of ItemWithAllSupportedValues, Boolean)) = Function(x) x.IntColumn Mod 6 = 0
+      Dim exp3 As Expression(Of Func(Of ItemWithAllSupportedValues, Boolean)) = Function(x) x.IntColumn Mod 7 = 0
+
+      ' 0 items
+      Dim exps As Expression(Of Func(Of ItemWithAllSupportedValues, Boolean))() = {}
+      Dim expWith0Items = PredicateBuilder.Or(exps)
+      Dim predicateWith0Items = expWith0Items.Compile()
+
+      Dim result = items.Where(predicateWith0Items).ToList()
+
+      CollectionAssert.AreEquivalent(items, result)
+
+      ' 1 item
+      Dim expWith1Item = PredicateBuilder.Or(exp3)
+      Dim predicateWith1Item = expWith1Item.Compile()
+
+      result = items.Where(predicateWith1Item).ToList()
+
+      CollectionAssert.AreEquivalent({items(0), items(7), items(14)}, result)
+
+      ' 3 items
+      Dim expWith3Items = PredicateBuilder.Or(exp1, exp2, exp3)
+      Dim predicateWith3Items = expWith3Items.Compile()
+
+      result = items.Where(predicateWith3Items).ToList()
+
+      CollectionAssert.AreEquivalent({items(0), items(5), items(6), items(7), items(10), items(12), items(14), items(15)}, result)
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub BuildOrWithCollection()
+      Dim items = CreateItems()
+
+      Dim exp1 As Expression(Of Func(Of ItemWithAllSupportedValues, Boolean)) = Function(x) x.IntColumn Mod 5 = 0
+      Dim exp2 As Expression(Of Func(Of ItemWithAllSupportedValues, Boolean)) = Function(x) x.IntColumn Mod 6 = 0
+      Dim exp3 As Expression(Of Func(Of ItemWithAllSupportedValues, Boolean)) = Function(x) x.IntColumn Mod 7 = 0
+
+      Dim exps As List(Of Expression(Of Func(Of ItemWithAllSupportedValues, Boolean)))
+
+      ' 0 items
+      exps = New List(Of Expression(Of Func(Of ItemWithAllSupportedValues, Boolean)))()
+      Dim expWith0Items = PredicateBuilder.Or(exps)
+      Dim predicateWith0Items = expWith0Items.Compile()
+
+      Dim result = items.Where(predicateWith0Items).ToList()
+
+      CollectionAssert.AreEquivalent(items, result)
+
+      ' 1 item
+      exps = {exp3}.ToList()
+      Dim expWith1Item = PredicateBuilder.Or(exps)
+      Dim predicateWith1Item = expWith1Item.Compile()
+
+      result = items.Where(predicateWith1Item).ToList()
+
+      CollectionAssert.AreEquivalent({items(0), items(7), items(14)}, result)
+
+      ' 3 items
+      exps = {exp1, exp2, exp3}.ToList()
+      Dim expWith3Items = PredicateBuilder.Or(exps)
+      Dim predicateWith3Items = expWith3Items.Compile()
+
+      result = items.Where(predicateWith3Items).ToList()
+
+      CollectionAssert.AreEquivalent({items(0), items(5), items(6), items(7), items(10), items(12), items(14), items(15)}, result)
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub BuildNot()
+      Dim items = CreateItems()
+
+      Dim originalExp As Expression(Of Func(Of ItemWithAllSupportedValues, Boolean)) = Function(x) 2 < x.IntColumn
+
+      Dim exp = PredicateBuilder.Not(originalExp)
+      Dim predicate = exp.Compile()
+
+      Dim result = items.Where(predicate).ToList()
+
+      CollectionAssert.AreEquivalent({items(0), items(1), items(2)}, result)
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub BuildTrue()
+      Dim items = CreateItems()
+
+      Dim exp = PredicateBuilder.True(Of ItemWithAllSupportedValues)
+      Dim predicate = exp.Compile()
+
+      Dim result = items.Where(predicate).ToList()
+
+      CollectionAssert.AreEquivalent(items, result)
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub BuildFalse()
+      Dim items = CreateItems()
+
+      Dim exp = PredicateBuilder.False(Of ItemWithAllSupportedValues)
+      Dim predicate = exp.Compile()
+
+      Dim result = items.Where(predicate).ToList()
+
+      Assert.IsFalse(result.Any())
+    End Sub
+
+    Protected Overridable Function CreateItems() As List(Of ItemWithAllSupportedValues)
+      Dim list = New List(Of ItemWithAllSupportedValues)
+
+      For i = 0 To 15
+        Dim item = Me.ModelFactory.CreateItemWithAllSupportedValuesWithEmptyValues()
+        item.IntColumn = i
+        list.Add(item)
+      Next
+
+      Return list
+    End Function
+
+  End Class
+End Namespace


### PR DESCRIPTION
Often, condition for where clause needs to be built dynamically. So far, we can conditionally chain multiple `And` methods using either `If` method or just simply using statements of the language (`if`, `switch`, ...). This won't work for `OR` operator or parentheses though.

Another option is to conditionally build expression tree of the predicate. However, this would often require a lot of boilerplate code.

This PR introduces `PredicateBuilder` helper class that simplifies building predicate expressions. There are following methods available:
- `PredicateBuilder.And<T>(...)` - creates predicate that represents logical `AND` between predicates
- `PredicateBuilder.Or<T>(...)` - creates predicate that represents logical `OR` between predicates
- `PredicateBuilder.Not<T>(...)` - creates predicate that represents logical negation of a predicate
- `PredicateBuilder.True<T>()` - creates predicate that always returns `true`
- `PredicateBuilder.False<T>()` - creates predicate that always returns `false`

Example:

```cs
public static void Test()
{
    var bornBefore = DateTime.Now;
    var names = new string[] { "Leonardo", "Raffaello" };

    using (var db = CreateContext())
    {
        var bornBeforeFilter = GetBornBeforeFilter(bornBefore);
        var nameFilters = names.Select(x => GetNameFilter(x)).ToArray();

        var filter = PredicateBuilder.And(bornBeforeFilter, PredicateBuilder.Or(nameFilters));

        var people = db.From<Person>().Where(filter).SelectAll().ToList();
    }
}

private static Expression<Func<Person, bool>> GetNameFilter(string value)
{
    return x => x.FirstName == value;
}

private static Expression<Func<Person, bool>> GetBornBeforeFilter(DateTime value)
{
    return x => x.BirthDate < value;
}
```

This PR resolves #54.