### PR TITLE
Fix wrong key in SqlResultReaderCache

### DIFF
--- a/Source/Source/Yamo/Internal/EntityAutoFieldsGetterCache.vb
+++ b/Source/Source/Yamo/Internal/EntityAutoFieldsGetterCache.vb
@@ -11,17 +11,26 @@ Namespace Internal
   Public Class EntityAutoFieldsGetterCache
 
     ''' <summary>
-    ''' Stores cache instances.
+    ''' Stores cache instances.<br/>
+    ''' <br/>
+    ''' Key: <see cref="Model"/> instance.<br/>
+    ''' Value: <see cref="EntityAutoFieldsGetterCache"/> instance.
     ''' </summary>
     Private Shared m_Instances As Dictionary(Of Model, EntityAutoFieldsGetterCache)
 
     ''' <summary>
     ''' Stores cached on update getter instances.<br/>
+    ''' <br/>
+    ''' Key: entity type.<br/>
+    ''' Value: <see cref="Func(Of DbContext, Object())"/> delegate, where parameter is <see cref="DbContext"/> instance and return value is array of values for auto set on update properties.
     ''' </summary>
     Private m_OnUpdateGetters As Dictionary(Of Type, Func(Of DbContext, Object()))
 
     ''' <summary>
     ''' Stores cached on soft delete getter instances.<br/>
+    ''' <br/>
+    ''' Key: entity type.<br/>
+    ''' Value: <see cref="Func(Of DbContext, Object())"/> delegate, where parameter is <see cref="DbContext"/> instance and return value is array of values for auto set on soft delete properties.
     ''' </summary>
     Private m_OnDeleteGetters As Dictionary(Of Type, Func(Of DbContext, Object()))
 

--- a/Source/Source/Yamo/Internal/EntityAutoFieldsSetterCache.vb
+++ b/Source/Source/Yamo/Internal/EntityAutoFieldsSetterCache.vb
@@ -11,22 +11,34 @@ Namespace Internal
   Public Class EntityAutoFieldsSetterCache
 
     ''' <summary>
-    ''' Stores cache instances.
+    ''' Stores cache instances.<br/>
+    ''' <br/>
+    ''' Key: <see cref="Model"/> instance.<br/>
+    ''' Value: <see cref="EntityAutoFieldsSetterCache"/> instance.
     ''' </summary>
     Private Shared m_Instances As Dictionary(Of Model, EntityAutoFieldsSetterCache)
 
     ''' <summary>
-    ''' Stores cached oninsert setter instances.
+    ''' Stores cached oninsert setter instances.<br/>
+    ''' <br/>
+    ''' Key: entity type.<br/>
+    ''' Value: <see cref="Action(Of Object, DbContext)"/> delegate, where first parameter is entity instance and second parameter is <see cref="DbContext"/> instance.
     ''' </summary>
     Private m_OnInsertSetters As Dictionary(Of Type, Action(Of Object, DbContext))
 
     ''' <summary>
-    ''' Stores cached on update setter instances.
+    ''' Stores cached on update setter instances.<br/>
+    ''' <br/>
+    ''' Key: entity type.<br/>
+    ''' Value: <see cref="Action(Of Object, DbContext)"/> delegate, where first parameter is entity instance and second parameter is <see cref="DbContext"/> instance.
     ''' </summary>
     Private m_OnUpdateSetters As Dictionary(Of Type, Action(Of Object, DbContext))
 
     ''' <summary>
-    ''' Stores cached on soft delete setter instances.
+    ''' Stores cached on soft delete setter instances.<br/>
+    ''' <br/>
+    ''' Key: entity type.<br/>
+    ''' Value: <see cref="Action(Of Object, DbContext)"/> delegate, where first parameter is entity instance and second parameter is <see cref="DbContext"/> instance.
     ''' </summary>
     Private m_OnDeleteSetters As Dictionary(Of Type, Action(Of Object, DbContext))
 

--- a/Source/Source/Yamo/Internal/EntityMemberSetterCache.vb
+++ b/Source/Source/Yamo/Internal/EntityMemberSetterCache.vb
@@ -12,22 +12,34 @@ Namespace Internal
   Public Class EntityMemberSetterCache
 
     ''' <summary>
-    ''' Stores cache instances.
+    ''' Stores cache instances.<br/>
+    ''' <br/>
+    ''' Key: <see cref="Model"/> instance.<br/>
+    ''' Value: <see cref="EntityMemberSetterCache"/> instance.
     ''' </summary>
     Private Shared m_Instances As Dictionary(Of Model, EntityMemberSetterCache)
 
     ''' <summary>
-    ''' Stores cached setter instances.
+    ''' Stores cached setter instances.<br/>
+    ''' <br/>
+    ''' Key: entity type, property/field name.<br/>
+    ''' Value: <see cref="Action(Of Object, Object)"/> delegate, where first parameter is entity instance and second parameter is value to be set to a property.
     ''' </summary>
     Private m_Setters As Dictionary(Of (Type, String), Action(Of Object, Object))
 
     ''' <summary>
-    ''' Stores cached collection add setter instances.
+    ''' Stores cached collection add setter instances.<br/>
+    ''' <br/>
+    ''' Key: entity type, property/field name.<br/>
+    ''' Value: <see cref="Action(Of Object, Object)"/> delegate, where first parameter is entity instance and second parameter is value to be added to a property collection.
     ''' </summary>
     Private m_CollectionAddSetters As Dictionary(Of (Type, String), Action(Of Object, Object))
 
     ''' <summary>
-    ''' Stores cached collection init setter instances.
+    ''' Stores cached collection init setter instances.<br/>
+    ''' <br/>
+    ''' Key: entity type, property/field name.<br/>
+    ''' Value: <see cref="Action(Of Object)"/> delegate, where parameter is entity instance with a property that will be set to a new collection.
     ''' </summary>
     Private m_CollectionInitSetters As Dictionary(Of (Type, String), Action(Of Object))
 

--- a/Source/Source/Yamo/Internal/EntityReaderCache.vb
+++ b/Source/Source/Yamo/Internal/EntityReaderCache.vb
@@ -13,27 +13,42 @@ Namespace Internal
   Public Class EntityReaderCache
 
     ''' <summary>
-    ''' Stores cache instances.
+    ''' Stores cache instances.<br/>
+    ''' <br/>
+    ''' Key: actual <see cref="DbDataReader"/> type, <see cref="SqlDialectProvider"/> instance, <see cref="Model"/> instance.<br/>
+    ''' Value: <see cref="EntityReaderCache"/> instance.
     ''' </summary>
     Private Shared m_Instances As Dictionary(Of (Type, SqlDialectProvider, Model), EntityReaderCache)
 
     ''' <summary>
-    ''' Stores cached reader instances.
+    ''' Stores cached reader instances.<br/>
+    ''' <br/>
+    ''' Key: entity type.<br/>
+    ''' Value: <see cref="Func(Of DbDataReader, Int32, Boolean(), Object)"/> delegate, where first parameter is <see cref="DbDataReader"/> instance, second parameter is starting reader index, third parameter represents included columns and return value is entity instance.
     ''' </summary>
     Private m_Readers As Dictionary(Of Type, Func(Of DbDataReader, Int32, Boolean(), Object))
 
     ''' <summary>
-    ''' Stores cached contains primary key reader instances.
+    ''' Stores cached contains primary key reader instances.<br/>
+    ''' <br/>
+    ''' Key: entity type.<br/>
+    ''' Value: <see cref="Func(Of DbDataReader, Int32, Int32(), Boolean)"/> delegate, where first parameter is <see cref="DbDataReader"/> instance, second parameter is starting reader index, third parameter represents PK offset indexes and return value is entity presence indication.
     ''' </summary>
     Private m_ContainsPKReaders As Dictionary(Of Type, Func(Of DbDataReader, Int32, Int32(), Boolean))
 
     ''' <summary>
-    ''' Stores cached primary key reader instances.
+    ''' Stores cached primary key reader instances.<br/>
+    ''' <br/>
+    ''' Key: entity type.<br/>
+    ''' Value: <see cref="Func(Of DbDataReader, Int32, Int32(), Object)"/> delegate, where first parameter is <see cref="DbDataReader"/> instance, second parameter is starting reader index, third parameter represents PK offset indexes and return value is value tuple representation of entity PK.
     ''' </summary>
     Private m_PKReaders As Dictionary(Of Type, Func(Of DbDataReader, Int32, Int32(), Object))
 
     ''' <summary>
-    ''' Stores cached database generated values reader instances.
+    ''' Stores cached database generated values reader instances.<br/>
+    ''' <br/>
+    ''' Key: entity type.<br/>
+    ''' Value: <see cref="Action(Of DbDataReader, Int32, Object)"/> delegate, where first parameter is <see cref="DbDataReader"/> instance, second parameter is starting reader index and third parameter is entity instance.
     ''' </summary>
     Private m_DbGeneratedValuesReaders As Dictionary(Of Type, Action(Of DbDataReader, Int32, Object))
 

--- a/Source/Source/Yamo/Internal/EntitySqlStringProviderCache.vb
+++ b/Source/Source/Yamo/Internal/EntitySqlStringProviderCache.vb
@@ -13,32 +13,49 @@ Namespace Internal
   Public Class EntitySqlStringProviderCache
 
     ''' <summary>
-    ''' Stores cache instances.
+    ''' Stores cache instances.<br/>
+    ''' <br/>
+    ''' Key: <see cref="SqlDialectProvider"/> instance, <see cref="Model"/> instance.<br/>
+    ''' Value: <see cref="EntitySqlStringProviderCache"/> instance.
     ''' </summary>
     Private Shared m_Instances As Dictionary(Of (SqlDialectProvider, Model), EntitySqlStringProviderCache)
 
     ''' <summary>
-    ''' Stores cached insert provider instances.
+    ''' Stores cached insert provider instances.<br/>
+    ''' <br/>
+    ''' Key: entity type.<br/>
+    ''' Value: <see cref="Func(Of Object, String, Boolean, CreateInsertSqlStringResult)"/> delegate, where first parameter is entity instance, second parameter is table name, third parameter is indicator of using DB identity and defaults and return value is <see cref="CreateInsertSqlStringResult"/> instance.
     ''' </summary>
     Private m_InsertProviders As Dictionary(Of Type, Func(Of Object, String, Boolean, CreateInsertSqlStringResult))
 
     ''' <summary>
-    ''' Stores cached update provider instances.
+    ''' Stores cached update provider instances.<br/>
+    ''' <br/>
+    ''' Key: entity type.<br/>
+    ''' Value: <see cref="Func(Of Object, String, Boolean, SqlString)"/> delegate, where first parameter is entity instance, second parameter is table name, third parameter is indicator of force update of all fields and return value is <see cref="SqlString"/> instance.
     ''' </summary>
     Private m_UpdateProviders As Dictionary(Of Type, Func(Of Object, String, Boolean, SqlString))
 
     ''' <summary>
-    ''' Stores cached delete provider instances.
+    ''' Stores cached delete provider instances.<br/>
+    ''' <br/>
+    ''' Key: entity type.<br/>
+    ''' Value: <see cref="Func(Of Object, String, SqlString)"/> delegate, where first parameter is entity instance, second parameter is table name and return value is <see cref="SqlString"/> instance.
     ''' </summary>
     Private m_DeleteProviders As Dictionary(Of Type, Func(Of Object, String, SqlString))
 
     ''' <summary>
-    ''' Stores cached soft delete provider instances.
+    ''' Stores cached soft delete provider instances.<br/>
+    ''' <br/>
+    ''' Key: entity type.<br/>
+    ''' Value: <see cref="Func(Of Object, String, SqlString)"/> delegate, where first parameter is entity instance, second parameter is table name and return value is <see cref="SqlString"/> instance.
     ''' </summary>
     Private m_SoftDeleteProviders As Dictionary(Of Type, Func(Of Object, String, SqlString))
 
     ''' <summary>
-    ''' Stores cached soft delete without condition provider instances.
+    ''' Stores cached soft delete without condition provider instances.<br/>
+    ''' Key: entity type.<br/>
+    ''' Value: <see cref="Func(Of String, Object(), SqlString)"/> delegate, where first parameter is entity instance, second parameter is array of values to be set to auto set on soft delete properties and return value is <see cref="SqlString"/> instance.
     ''' </summary>
     Private m_SoftDeleteWithoutConditionProviders As Dictionary(Of Type, Func(Of String, Object(), SqlString))
 

--- a/Source/Source/Yamo/Internal/MemberCallerCache.vb
+++ b/Source/Source/Yamo/Internal/MemberCallerCache.vb
@@ -20,32 +20,50 @@ Namespace Internal
     Private Shared m_Instance As MemberCallerCache
 
     ''' <summary>
-    ''' Stores cached field caller instances.
+    ''' Stores cached field caller instances.<br/>
+    ''' <br/>
+    ''' Key: field type, <see cref="FieldInfo"/> instance.<br/>
+    ''' Value: <see cref="Func(Of Object, Object)"/> delegate, where parameter is object and return value is field value of that object.<br/>
     ''' </summary>
     Private m_FieldCallers As Dictionary(Of (Type, FieldInfo), Func(Of Object, Object))
 
     ''' <summary>
-    ''' Stores cached static field caller instances.
+    ''' Stores cached static field caller instances.<br/>
+    ''' <br/>
+    ''' Key: field type, <see cref="FieldInfo"/> instance.<br/>
+    ''' Value: <see cref="Func(Of Object, Object)"/> delegate, where return value is static field value.<br/>
     ''' </summary>
     Private m_StaticFieldCallers As Dictionary(Of (Type, FieldInfo), Func(Of Object))
 
     ''' <summary>
-    ''' Stores cached property caller instances.
+    ''' Stores cached property caller instances.<br/>
+    ''' <br/>
+    ''' Key: field type, <see cref="PropertyInfo"/> instance.<br/>
+    ''' Value: <see cref="Func(Of Object, Object)"/> delegate, where parameter is object and return value is property value of that object.<br/>
     ''' </summary>
     Private m_PropertyCallers As Dictionary(Of (Type, PropertyInfo), Func(Of Object, Object))
 
     ''' <summary>
-    ''' Stores cached static property caller instances.
+    ''' Stores cached static property caller instances.<br/>
+    ''' <br/>
+    ''' Key: field type, <see cref="PropertyInfo"/> instance.<br/>
+    ''' Value: <see cref="Func(Of Object, Object)"/> delegate, where return value is static property value.<br/>
     ''' </summary>
     Private m_StaticPropertyCallers As Dictionary(Of (Type, PropertyInfo), Func(Of Object))
 
     ''' <summary>
-    ''' Stores cached method caller instances.
+    ''' Stores cached method caller instances.<br/>
+    ''' <br/>
+    ''' Key: field type, <see cref="MethodInfo"/> instance.<br/>
+    ''' Value: <see cref="Func(Of Object, Object)"/> delegate, where parameter is object and return value is output from method of that object.<br/>
     ''' </summary>
     Private m_MethodCallers As Dictionary(Of (Type, MethodInfo), Func(Of Object, Object))
 
     ''' <summary>
-    ''' Stores cached static method caller instances.
+    ''' Stores cached static method caller instances.<br/>
+    ''' <br/>
+    ''' Key: field type, <see cref="MethodInfo"/> instance.<br/>
+    ''' Value: <see cref="Func(Of Object, Object)"/> delegate, where return value is output from static method.<br/>
     ''' </summary>
     Private m_StaticMethodCallers As Dictionary(Of (Type, MethodInfo), Func(Of Object))
 

--- a/Source/Source/Yamo/Internal/ModelCache.vb
+++ b/Source/Source/Yamo/Internal/ModelCache.vb
@@ -11,12 +11,18 @@ Namespace Internal
   Public Class ModelCache
 
     ''' <summary>
-    ''' Stores cache instances.
+    ''' Stores cache instances.<br/>
+    ''' <br/>
+    ''' Key: <see cref="SqlDialectProvider"/> type.<br/>
+    ''' Value: <see cref="ModelCache"/> instance.
     ''' </summary>
     Private Shared m_Instances As Dictionary(Of Type, ModelCache)
 
     ''' <summary>
-    ''' Stores cached model instances.
+    ''' Stores cached model instances.<br/>
+    ''' <br/>
+    ''' Key: <see cref="DbContext"/> type.<br/>
+    ''' Value: <see cref="Model"/> instance.
     ''' </summary>
     Private m_Models As Dictionary(Of Type, Model)
 

--- a/Source/Source/Yamo/Internal/ReaderEntityValueCache.vb
+++ b/Source/Source/Yamo/Internal/ReaderEntityValueCache.vb
@@ -9,7 +9,10 @@ Namespace Internal
   Public Class ReaderEntityValueCache
 
     ''' <summary>
-    ''' Stores cached instances.
+    ''' Stores cached instances.<br/>
+    ''' <br/>
+    ''' Key: <see cref="ChainKey"/>.<br/>
+    ''' Value: entity instance.
     ''' </summary>
     Private m_Cache As Dictionary(Of ChainKey, Object)()
 

--- a/Source/Source/Yamo/Internal/SqlResultReaderCache.vb
+++ b/Source/Source/Yamo/Internal/SqlResultReaderCache.vb
@@ -18,7 +18,7 @@ Namespace Internal
     ''' <summary>
     ''' Stores cache instances.
     ''' </summary>
-    Private Shared m_Instances As Dictionary(Of Model, SqlResultReaderCache)
+    Private Shared m_Instances As Dictionary(Of (Type, Model), SqlResultReaderCache)
 
     ''' <summary>
     ''' Stores cached reader instances.<br/>
@@ -36,7 +36,7 @@ Namespace Internal
     ''' Initializes <see cref="SqlResultReaderCache"/> related static data.
     ''' </summary>
     Shared Sub New()
-      m_Instances = New Dictionary(Of Model, SqlResultReaderCache)
+      m_Instances = New Dictionary(Of (Type, Model), SqlResultReaderCache)
     End Sub
 
     ''' <summary>
@@ -51,14 +51,15 @@ Namespace Internal
     ''' Gets reader.<br/>
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
+    ''' <param name="dataReaderType"></param>
     ''' <param name="model"></param>
     ''' <param name="sqlResult"></param>
     ''' <returns></returns>
-    Public Shared Function GetReader(<DisallowNull> model As Model, <DisallowNull> sqlResult As SqlResultBase) As Func(Of DbDataReader, ReaderDataBase, Object)
+    Public Shared Function GetReader(<DisallowNull> dataReaderType As Type, <DisallowNull> model As Model, <DisallowNull> sqlResult As SqlResultBase) As Func(Of DbDataReader, ReaderDataBase, Object)
       If sqlResult.ResultType.IsValueType Then
-        Return GetInstance(model).GetOrCreateValueTypeToObjectWrappedReader(model, sqlResult)
+        Return GetInstance(dataReaderType, model).GetOrCreateValueTypeToObjectWrappedReader(model, sqlResult)
       Else
-        Return DirectCast(GetInstance(model).GetOrCreateReader(model, sqlResult), Func(Of DbDataReader, ReaderDataBase, Object))
+        Return DirectCast(GetInstance(dataReaderType, model).GetOrCreateReader(model, sqlResult), Func(Of DbDataReader, ReaderDataBase, Object))
       End If
     End Function
 
@@ -67,25 +68,29 @@ Namespace Internal
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
     ''' <typeparam name="T"></typeparam>
+    ''' <param name="dataReaderType"></param>
     ''' <param name="model"></param>
     ''' <param name="sqlResult"></param>
     ''' <returns></returns>
-    Public Shared Function GetReader(Of T)(<DisallowNull> model As Model, <DisallowNull> sqlResult As SqlResultBase) As Func(Of DbDataReader, ReaderDataBase, T)
-      Return DirectCast(GetInstance(model).GetOrCreateReader(model, sqlResult), Func(Of DbDataReader, ReaderDataBase, T))
+    Public Shared Function GetReader(Of T)(<DisallowNull> dataReaderType As Type, <DisallowNull> model As Model, <DisallowNull> sqlResult As SqlResultBase) As Func(Of DbDataReader, ReaderDataBase, T)
+      Return DirectCast(GetInstance(dataReaderType, model).GetOrCreateReader(model, sqlResult), Func(Of DbDataReader, ReaderDataBase, T))
     End Function
 
     ''' <summary>
     ''' Gets <see cref="SqlResultReaderCache"/> cache instance. If it doesn't exist, it is created.
     ''' </summary>
+    ''' <param name="dataReaderType"></param>
     ''' <param name="model"></param>
     ''' <returns></returns>
-    Private Shared Function GetInstance(model As Model) As SqlResultReaderCache
+    Private Shared Function GetInstance(dataReaderType As Type, model As Model) As SqlResultReaderCache
       Dim instance As SqlResultReaderCache = Nothing
 
+      Dim key = (dataReaderType, model)
+
       SyncLock m_Instances
-        If Not m_Instances.TryGetValue(model, instance) Then
+        If Not m_Instances.TryGetValue(key, instance) Then
           instance = New SqlResultReaderCache
-          m_Instances.Add(model, instance)
+          m_Instances.Add(key, instance)
         End If
       End SyncLock
 

--- a/Source/Source/Yamo/Internal/SqlResultReaderCache.vb
+++ b/Source/Source/Yamo/Internal/SqlResultReaderCache.vb
@@ -16,19 +16,26 @@ Namespace Internal
   Public Class SqlResultReaderCache
 
     ''' <summary>
-    ''' Stores cache instances.
+    ''' Stores cache instances.<br/>
+    ''' <br/>
+    ''' Key: actual <see cref="DbDataReader"/> type, <see cref="Model"/> instance.<br/>
+    ''' Value: <see cref="SqlResultReaderCache"/> instance.
     ''' </summary>
     Private Shared m_Instances As Dictionary(Of (Type, Model), SqlResultReaderCache)
 
     ''' <summary>
     ''' Stores cached reader instances.<br/>
-    ''' Instance type is actually Func(Of DbDataReader, ReaderDataBase, T).
+    ''' <br/>
+    ''' Key: type corresponding to <see cref="SqlResultBase.ResultType"/>.<br/>
+    ''' Value: <see cref="Func(Of DbDataReader, ReaderDataBase, T)"/> delegate, where first parameter is <see cref="DbDataReader"/> instance, second parameter is <see cref="ReaderDataBase"/> instance and return value is actual result.
     ''' </summary>
     Private m_Readers As Dictionary(Of Type, Object)
 
     ''' <summary>
     ''' Stores cached reader instances that are wrapped as Func(Of DbDataReader, ReaderDataBase, Object).<br/>
-    ''' Instance type is actually Func(Of DbDataReader, ReaderDataBase, Object).
+    ''' <br/>
+    ''' Key: type corresponding to <see cref="SqlResultBase.ResultType"/>.<br/>
+    ''' Value: <see cref="Func(Of DbDataReader, ReaderDataBase, Object)"/> delegate, where first parameter is <see cref="DbDataReader"/> instance, second parameter is <see cref="ReaderDataBase"/> instance and return value is actual result casted as an <see cref="Object"/>.
     ''' </summary>
     Private m_ValueTypeWrappedReaders As Dictionary(Of Type, Func(Of DbDataReader, ReaderDataBase, Object))
 

--- a/Source/Source/Yamo/Internal/ValueTypeReaderCache.vb
+++ b/Source/Source/Yamo/Internal/ValueTypeReaderCache.vb
@@ -13,13 +13,18 @@ Namespace Internal
   Public Class ValueTypeReaderCache
 
     ''' <summary>
-    ''' Stores cache instances.
+    ''' Stores cache instances.<br/>
+    ''' <br/>
+    ''' Key: actual <see cref="DbDataReader"/> type, <see cref="SqlDialectProvider"/> instance, <see cref="Model"/> instance.<br/>
+    ''' Value: <see cref="ValueTypeReaderCache"/> instance.
     ''' </summary>
     Private Shared m_Instances As Dictionary(Of (Type, SqlDialectProvider, Model), ValueTypeReaderCache)
 
     ''' <summary>
     ''' Stores cached reader instances.<br/>
-    ''' Instance type is actually Func(Of DbDataReader, Int32, T).
+    ''' <br/>
+    ''' Key: type of scalar result.<br/>
+    ''' Value: <see cref="Func(Of DbDataReader, Int32, T)"/> delegate, where first parameter is <see cref="DbDataReader"/> instance, second parameter is starting reader index and return value is actual result.
     ''' </summary>
     Private m_Readers As Dictionary(Of Type, Object)
 


### PR DESCRIPTION
This PR solves bug from #88, where dependency on `DbDataReader` type was introduced to various factories. Indirectly, this also affects `SqlResultReaderCache`, where `DbDataReader` type is now part of the cache key.