### PR TITLE
Added support for ad hoc types in custom selects

### DIFF
--- a/Source/Samples/Yamo.Playground.CS/Model/NonModelObject.cs
+++ b/Source/Samples/Yamo.Playground.CS/Model/NonModelObject.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Yamo.Playground.CS.Model
+{
+    class NonModelObject
+    {
+        public int Id { get; set; }
+
+        public string Description { get; set; }
+        
+        public object Item { get; set; }
+
+        public NonModelObject(int id)
+        {
+            this.Id = id;
+        }
+
+        public NonModelObject(int id, object item) : this(id)
+        {
+            this.Item = item;
+        }
+    }
+}

--- a/Source/Samples/Yamo.Playground.CS/Model/NonModelStruct.cs
+++ b/Source/Samples/Yamo.Playground.CS/Model/NonModelStruct.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Yamo.Playground.CS.Model
+{
+    struct NonModelStruct
+    {
+        public int Id { get; set; }
+
+        public string Description { get; set; }
+
+        public object Item { get; set; }
+
+        public NonModelStruct(int id) : this()
+        {
+            this.Id = id;
+        }
+    }
+}

--- a/Source/Samples/Yamo.Playground.CS/Program.cs
+++ b/Source/Samples/Yamo.Playground.CS/Program.cs
@@ -1038,15 +1038,23 @@ namespace Yamo.Playground.CS
                               .Select(x => new NonModelStruct(x.Id) { Description = x.Title, Item = x })
                               .ToList();
 
+                // only case where nested constructors are allowed - to get nullable value types like structs and value tuples
                 var value1 = db.From<Blog>()
-                              .Where(x => x.Id == 42)
-                              .Select<NonModelStruct?>(x => new NonModelStruct(x.Id) { Description = x.Title, Item = x })
-                              .FirstOrDefault();
+                               .Where(x => x.Id == 42)
+                               .Select(x => new NonModelStruct?(new NonModelStruct(x.Id) { Description = x.Title, Item = x }))
+                               .FirstOrDefault();
 
+                // same as above, but different approach to get nullable struct
                 var value2 = db.From<Blog>()
                                .Where(x => x.Id == 42)
                                .Select(x => (NonModelStruct?)new NonModelStruct(x.Id) { Description = x.Title, Item = x })
                                .FirstOrDefault();
+
+                // same as above, but different approach to get nullable struct
+                var value3 = db.From<Blog>()
+                              .Where(x => x.Id == 42)
+                              .Select<NonModelStruct?>(x => new NonModelStruct(x.Id) { Description = x.Title, Item = x })
+                              .FirstOrDefault();
             }
         }
 

--- a/Source/Samples/Yamo.Playground.CS/Program.cs
+++ b/Source/Samples/Yamo.Playground.CS/Program.cs
@@ -76,7 +76,8 @@ namespace Yamo.Playground.CS
             //Test51();
             //Test52();
             //Test53();
-            Test54();
+            //Test54();
+            Test55();
         }
 
         public static MyContext CreateContext()
@@ -1022,6 +1023,30 @@ namespace Yamo.Playground.CS
                 var filter = PredicateBuilder.And(bornBeforeFilter, PredicateBuilder.Or(nameFilters));
 
                 var people = db.From<Person>().Where(filter).SelectAll().ToList();
+            }
+        }
+
+        public static void Test55()
+        {
+            using (var db = CreateContext())
+            {
+                var list1 = db.From<Blog>()
+                              .Select(x => new NonModelObject(x.Id) { Description = x.Title, Item = x })
+                              .ToList();
+
+                var list2 = db.From<Blog>()
+                              .Select(x => new NonModelStruct(x.Id) { Description = x.Title, Item = x })
+                              .ToList();
+
+                var value1 = db.From<Blog>()
+                              .Where(x => x.Id == 42)
+                              .Select<NonModelStruct?>(x => new NonModelStruct(x.Id) { Description = x.Title, Item = x })
+                              .FirstOrDefault();
+
+                var value2 = db.From<Blog>()
+                               .Where(x => x.Id == 42)
+                               .Select(x => (NonModelStruct?)new NonModelStruct(x.Id) { Description = x.Title, Item = x })
+                               .FirstOrDefault();
             }
         }
 

--- a/Source/Source/Yamo/Internal/NodeInfo.vb
+++ b/Source/Source/Yamo/Internal/NodeInfo.vb
@@ -52,6 +52,27 @@ Namespace Internal
     Public Property IsNullableHasValueAccess As Boolean
 
     ''' <summary>
+    ''' Gets whether node represents cast or conversion operation.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <returns></returns>
+    Public Property IsConvert As Boolean
+
+    ''' <summary>
+    ''' Gets whether node represents <see cref="Nullable(Of T)"/> constructor.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <returns></returns>
+    Public Property IsNullableConstructor As Boolean
+
+    ''' <summary>
+    ''' Gets whether node represents object initialization.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <returns></returns>
+    Public Property IsMemberInit As Boolean
+
+    ''' <summary>
     ''' Creates new instance of <see cref="NodeInfo"/>.<br/>
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
@@ -63,6 +84,9 @@ Namespace Internal
       Me.IsCompare = False
       Me.IsNullableValueAccess = False
       Me.IsNullableHasValueAccess = False
+      Me.IsConvert = False
+      Me.IsNullableConstructor = False
+      Me.IsMemberInit = False
     End Sub
 
   End Class

--- a/Source/Source/Yamo/Internal/Query/AdHocTypeSqlResultReaderData.vb
+++ b/Source/Source/Yamo/Internal/Query/AdHocTypeSqlResultReaderData.vb
@@ -1,0 +1,42 @@
+﻿Imports System.Diagnostics.CodeAnalysis
+Imports Yamo.Internal.Query.Metadata
+
+Namespace Internal.Query
+
+  ''' <summary>
+  ''' Represents reader data for ad hoc type values.<br/>
+  ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+  ''' </summary>
+  Public Class AdHocTypeSqlResultReaderData
+    Inherits ReaderDataBase
+
+    ''' <summary>
+    ''' Gets reader data of ad hoc type constructor arguments.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <returns></returns>
+    Public ReadOnly Property CtorArguments As ReaderDataBase()
+
+    ''' <summary>
+    ''' Gets reader data of ad hoc type member inits.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <returns></returns>
+    Public ReadOnly Property MemberInits As ReaderDataBase()
+
+    ''' <summary>
+    ''' Creates new instance of <see cref="AdHocTypeSqlResultReaderData"/>.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <param name="sqlResult"></param>
+    ''' <param name="readerIndex"></param>
+    ''' <param name="ctorArguments"></param>
+    ''' <param name="memberInits"></param>
+    Public Sub New(<DisallowNull> sqlResult As AdHocTypeSqlResult, readerIndex As Int32, <DisallowNull> ctorArguments As ReaderDataBase(), <DisallowNull> memberInits As ReaderDataBase())
+      MyBase.New(sqlResult, readerIndex)
+      Me.CtorArguments = ctorArguments
+      Me.MemberInits = memberInits
+    End Sub
+
+  End Class
+End Namespace

--- a/Source/Source/Yamo/Internal/Query/Metadata/AdHocTypeSqlResult.vb
+++ b/Source/Source/Yamo/Internal/Query/Metadata/AdHocTypeSqlResult.vb
@@ -1,0 +1,103 @@
+﻿Imports System.Diagnostics.CodeAnalysis
+Imports System.Reflection
+
+Namespace Internal.Query.Metadata
+
+  ''' <summary>
+  ''' Represents SQL result of an ad hoc type.<br/>
+  ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+  ''' </summary>
+  Public Class AdHocTypeSqlResult
+    Inherits SqlResultBase
+
+    ''' <summary>
+    ''' Gets used constructor.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <returns></returns>
+    Public ReadOnly Property Constructor As <MaybeNull> ConstructorInfo
+
+    ''' <summary>
+    ''' Gets nested SQL results which represent ad hoc object constructor arguments.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <returns></returns>
+    Public ReadOnly Property CtorArguments As SqlResultBase()
+
+    ''' <summary>
+    ''' Gets if there are members to be initialized.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <returns></returns>
+    Public ReadOnly Property HasMemberInits As Boolean
+      Get
+        Return Me.Members IsNot Nothing
+      End Get
+    End Property
+
+    ''' <summary>
+    ''' Gets members.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <returns>Will return <see langword="Nothing"/> if there are no members to initialize.</returns>
+    Public ReadOnly Property Members As <MaybeNull> MemberInfo()
+
+    ''' <summary>
+    ''' Gets nested SQL results which represent ad hoc object member inits.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <returns>Will return <see langword="Nothing"/> if there are no members to initialize. For <see cref="Nullable(Of T)"/>, it represents members of the underlying type.</returns>
+    Public ReadOnly Property MemberInits As <MaybeNull> SqlResultBase()
+
+    ''' <summary>
+    ''' Creates new instance of <see cref="AdHocTypeSqlResult"/>.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <param name="resultType"></param>
+    ''' <param name="constructor">Might be <see langword="Nothing"/> for structs. For <see cref="Nullable(Of T)"/>, it represents constructor info of the underlying type.</param>
+    ''' <param name="ctorArguments"></param>
+    Public Sub New(<DisallowNull> resultType As Type, constructor As ConstructorInfo, <DisallowNull> ctorArguments As SqlResultBase())
+      MyBase.New(resultType)
+      Me.Constructor = constructor
+      Me.CtorArguments = ctorArguments
+      Me.Members = Nothing
+      Me.MemberInits = Nothing
+    End Sub
+
+    ''' <summary>
+    ''' Sets ad hoc object init members data.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <param name="members"></param>
+    ''' <param name="memberInits"></param>
+    Public Sub SetMembers(members As MemberInfo(), <DisallowNull> memberInits As SqlResultBase())
+      Me._Members = members
+      Me._MemberInits = memberInits
+    End Sub
+
+    ''' <summary>
+    ''' Gets count of columns in the resultset.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <returns></returns>
+    Public Overrides Function GetColumnCount() As Int32
+      Dim sum = Me.CtorArguments.Sum(Function(x) x.GetColumnCount())
+
+      If Me.MemberInits IsNot Nothing Then
+        sum += Me.MemberInits.Sum(Function(x) x.GetColumnCount())
+      End If
+
+      Return sum
+    End Function
+
+    ''' <summary>
+    ''' Gets reader key.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function GetKey() As AdHocTypeSqlResultReaderKey
+      Return New AdHocTypeSqlResultReaderKey(Me.ResultType, Me.Constructor, Me.Members)
+    End Function
+
+  End Class
+End Namespace

--- a/Source/Source/Yamo/Internal/Query/Metadata/AdHocTypeSqlResultReaderKey.vb
+++ b/Source/Source/Yamo/Internal/Query/Metadata/AdHocTypeSqlResultReaderKey.vb
@@ -1,0 +1,94 @@
+﻿Imports System.Diagnostics.CodeAnalysis
+Imports System.Reflection
+
+Namespace Internal.Query.Metadata
+
+  ''' <summary>
+  ''' Represents value that can be used as a dictionary key for ad hoc type SQL result reader.<br/>
+  ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+  ''' </summary>
+  Public Class AdHocTypeSqlResultReaderKey
+
+    ''' <summary>
+    ''' Gets ad hoc type.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <returns></returns>
+    Public ReadOnly Property Type As Type
+
+    ''' <summary>
+    ''' Gets constructor.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <returns></returns>
+    Public ReadOnly Property Constructor As <MaybeNull> ConstructorInfo
+
+    ''' <summary>
+    ''' Gets members.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <returns>Will return <see langword="Nothing"/> if there are no members to initialize.</returns>
+    Public ReadOnly Property Members As <MaybeNull> MemberInfo()
+
+    ''' <summary>
+    ''' Creates new instance of <see cref="AdHocTypeSqlResultReaderKey"/>.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <param name="type"></param>
+    ''' <param name="constructor">Might be <see langword="Nothing"/> for structs.</param>
+    ''' <param name="members"></param>
+    Public Sub New(<DisallowNull> type As Type, constructor As ConstructorInfo, <DisallowNull> members As MemberInfo())
+      Me.Type = type
+      Me.Constructor = constructor
+      Me.Members = members
+    End Sub
+
+    ''' <summary>
+    ''' Determines whether the specified object is equal to the current object.
+    ''' </summary>
+    ''' <param name="obj"></param>
+    ''' <returns></returns>
+    Public Overrides Function Equals(obj As Object) As Boolean
+      If obj Is Nothing OrElse TypeOf obj IsNot AdHocTypeSqlResultReaderKey Then
+        Return False
+      Else
+        Dim o = DirectCast(obj, AdHocTypeSqlResultReaderKey)
+
+        If Not Object.Equals(Me.Type, o.Type) Then Return False
+        If Not Object.Equals(Me.Constructor, o.Constructor) Then Return False
+        If Me.Members Is Nothing AndAlso o.Members IsNot Nothing Then Return False
+        If Me.Members IsNot Nothing AndAlso o.Members Is Nothing Then Return False
+
+        If Me.Members IsNot Nothing Then
+          If Not Me.Members.Length = o.Members.Length Then Return False
+
+          For i = 0 To Me.Members.Length - 1
+            If Not Me.Members(i) = o.Members(i) Then Return False
+          Next
+        End If
+
+        Return True
+      End If
+    End Function
+
+    ''' <summary>
+    ''' Serves as the hash function.
+    ''' </summary>
+    ''' <returns></returns>
+    Public Overrides Function GetHashCode() As Int32
+      Dim h = New HashCode()
+
+      h.Add(Me.Type)
+      h.Add(Me.Constructor)
+
+      If Me.Members IsNot Nothing Then
+        For i = 0 To Me.Members.Length - 1
+          h.Add(Me.Members(i))
+        Next
+      End If
+
+      Return h.ToHashCode()
+    End Function
+
+  End Class
+End Namespace

--- a/Source/Test/Yamo.Test.CS/Yamo.Test.CS.csproj
+++ b/Source/Test/Yamo.Test.CS/Yamo.Test.CS.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
     <PackageReference Include="coverlet.collector" Version="3.1.0">

--- a/Source/Test/Yamo.Test.SQLite/Yamo.Test.SQLite.vbproj
+++ b/Source/Test/Yamo.Test.SQLite/Yamo.Test.SQLite.vbproj
@@ -45,7 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
     <PackageReference Include="coverlet.collector" Version="3.1.0">

--- a/Source/Test/Yamo.Test.SqlServer/Yamo.Test.SqlServer.vbproj
+++ b/Source/Test/Yamo.Test.SqlServer/Yamo.Test.SqlServer.vbproj
@@ -45,7 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
     <PackageReference Include="coverlet.collector" Version="3.1.0">

--- a/Source/Test/Yamo.Test.VB/Yamo.Test.VB.vbproj
+++ b/Source/Test/Yamo.Test.VB/Yamo.Test.VB.vbproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
     <PackageReference Include="coverlet.collector" Version="3.1.0">

--- a/Source/Test/Yamo.Test/Model/NonModelGenericObject.vb
+++ b/Source/Test/Yamo.Test/Model/NonModelGenericObject.vb
@@ -1,0 +1,32 @@
+﻿Namespace Model
+
+  Public Class NonModelGenericObject(Of T1, T2)
+
+    Public Property Value1 As T1
+
+    Public Property Value2 As T2
+
+    Public Sub New(value1 As T1, value2 As T2)
+      Me.Value1 = value1
+      Me.Value2 = value2
+    End Sub
+
+    Public Overrides Function Equals(obj As Object) As Boolean
+      If obj Is Nothing OrElse TypeOf obj IsNot NonModelGenericObject(Of T1, T2) Then
+        Return False
+      Else
+        Dim o = DirectCast(obj, NonModelGenericObject(Of T1, T2))
+
+        If Not Object.Equals(Me.Value1, o.Value1) Then Return False
+        If Not Object.Equals(Me.Value2, o.Value2) Then Return False
+
+        Return True
+      End If
+    End Function
+
+    Public Overrides Function GetHashCode() As Int32
+      Return HashCode.Combine(Me.Value1, Me.Value2)
+    End Function
+
+  End Class
+End Namespace

--- a/Source/Test/Yamo.Test/Model/NonModelObject.vb
+++ b/Source/Test/Yamo.Test/Model/NonModelObject.vb
@@ -1,0 +1,66 @@
+﻿Namespace Model
+
+  Public Class NonModelObject
+
+    Public Property GuidValue As Guid
+
+    Public Property BooleanValue As Boolean
+
+    Public Property StringValue As String
+
+    Public Property IntValue As Int32
+
+    Public Property NullableDecimalValue As Decimal?
+
+    Public Property ItemWithAllSupportedValues As ItemWithAllSupportedValues
+
+    Public Property Article As Article
+
+    Public Property Label As Label
+
+    Public Sub New()
+    End Sub
+
+    Public Sub New(guidValue As Guid, booleanValue As Boolean)
+      Me.GuidValue = guidValue
+      Me.BooleanValue = booleanValue
+    End Sub
+
+    Public Sub New(guidValue As Guid, stringValue As String, nullableDecimalValue As Decimal?)
+      Me.GuidValue = guidValue
+      Me.StringValue = stringValue
+      Me.NullableDecimalValue = nullableDecimalValue
+    End Sub
+
+    Public Sub New(guidValue As Guid, itemWithAllSupportedValues As ItemWithAllSupportedValues)
+      Me.GuidValue = guidValue
+      Me.ItemWithAllSupportedValues = itemWithAllSupportedValues
+    End Sub
+
+    Public Sub New(article As Article, label As Label)
+      Me.Article = article
+      Me.Label = label
+    End Sub
+
+    Public Overrides Function Equals(obj As Object) As Boolean
+      If obj Is Nothing OrElse TypeOf obj IsNot NonModelObject Then
+        Return False
+      Else
+        Dim o = DirectCast(obj, NonModelObject)
+
+        If Not Object.Equals(Me.GuidValue, o.GuidValue) Then Return False
+        If Not Object.Equals(Me.BooleanValue, o.BooleanValue) Then Return False
+        If Not Object.Equals(Me.StringValue, o.StringValue) Then Return False
+        If Not Object.Equals(Me.IntValue, o.IntValue) Then Return False
+        If Not Object.Equals(Me.NullableDecimalValue, o.NullableDecimalValue) Then Return False
+
+        Return True
+      End If
+    End Function
+
+    Public Overrides Function GetHashCode() As Int32
+      Return HashCode.Combine(Me.GuidValue, Me.BooleanValue, Me.StringValue, Me.IntValue, Me.NullableDecimalValue)
+    End Function
+
+  End Class
+End Namespace

--- a/Source/Test/Yamo.Test/Model/NonModelStruct.vb
+++ b/Source/Test/Yamo.Test/Model/NonModelStruct.vb
@@ -1,0 +1,31 @@
+﻿Namespace Model
+
+  Public Structure NonModelStruct
+
+    Public Property GuidValue As Guid
+
+    Public Property BooleanValue As Boolean
+
+    Public Property StringValue As String
+
+    Public Property IntValue As Int32
+
+    Public Property NullableDecimalValue As Decimal?
+
+    Public Property ItemWithAllSupportedValues As ItemWithAllSupportedValues
+
+    Public Sub New(guidValue As Guid, stringValue As String, nullableDecimalValue As Decimal?)
+      Me.New()
+      Me.GuidValue = guidValue
+      Me.StringValue = stringValue
+      Me.NullableDecimalValue = nullableDecimalValue
+    End Sub
+
+    Public Sub New(guidValue As Guid, itemWithAllSupportedValues As ItemWithAllSupportedValues)
+      Me.New()
+      Me.GuidValue = guidValue
+      Me.ItemWithAllSupportedValues = itemWithAllSupportedValues
+    End Sub
+
+  End Structure
+End Namespace

--- a/Source/Test/Yamo.Test/Yamo.Test.vbproj
+++ b/Source/Test/Yamo.Test/Yamo.Test.vbproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
     <PackageReference Include="coverlet.collector" Version="3.1.0">


### PR DESCRIPTION
This PR adds support for querying ad hoc types in custom selects. Until now, only models, value tuples and anonymous objects were supported in custom selects. It is now possible to return any class, structure or nullable structure. Only requirement is initialization with constructor and/or member initializers. Constructor nesting is not allowed (with exception of nullable types). However, it is possible to pass whole model entities as constructor arguments or member values.

Example:
```cs
using (var db = CreateContext())
{
    var list1 = db.From<Blog>()
                  .Select(x => new NonModelObject(x.Id) { Description = x.Title, Item = x })
                  .ToList();

    var list2 = db.From<Blog>()
                  .Select(x => new NonModelStruct(x.Id) { Description = x.Title, Item = x })
                  .ToList();

    // only case where nested constructors are allowed - to get nullable value types like structs and value tuples
    var value1 = db.From<Blog>()
                   .Where(x => x.Id == 42)
                   .Select(x => new NonModelStruct?(new NonModelStruct(x.Id) { Description = x.Title, Item = x }))
                   .FirstOrDefault();

    // same as above, but different approach to get nullable struct
    var value2 = db.From<Blog>()
                   .Where(x => x.Id == 42)
                   .Select(x => (NonModelStruct?)new NonModelStruct(x.Id) { Description = x.Title, Item = x })
                   .FirstOrDefault();

    // same as above, but different approach to get nullable struct
    var value3 = db.From<Blog>()
                  .Where(x => x.Id == 42)
                  .Select<NonModelStruct?>(x => new NonModelStruct(x.Id) { Description = x.Title, Item = x })
                  .FirstOrDefault();
}
```

This PR also enables to return nullable value tuples (so far only non-nullable value were supported). Note that this is only possible in VB.NET due to syntaxt limitations.