### PR TITLE
Changed default behavior of `SelectAll` method

### DIFF
--- a/Source/Samples/Yamo.Playground.CS/MyContext.cs
+++ b/Source/Samples/Yamo.Playground.CS/MyContext.cs
@@ -9,6 +9,7 @@ using Yamo.Metadata.Builders;
 using Yamo.Playground.CS.Model;
 using Yamo.SqlServer;
 using System.Data;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Yamo.Playground.CS
 {

--- a/Source/Source/Yamo/Expressions/Builders/SelectSqlExpressionBuilder.vb
+++ b/Source/Source/Yamo/Expressions/Builders/SelectSqlExpressionBuilder.vb
@@ -600,12 +600,21 @@ Namespace Expressions.Builders
     End Sub
 
     ''' <summary>
-    ''' Adds select all columns.<br/>
+    ''' Adds automatic select of (all) columns.<br/>
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
-    ''' <param name="entityTypes"></param>
-    Public Sub AddSelectAll(<DisallowNull> ParamArray entityTypes As Type())
-      ' right now this does nothing; refactor?
+    ''' <param name="behavior"></param>
+    Public Sub AddSelectAll(behavior As SelectColumnsBehavior)
+      If behavior = SelectColumnsBehavior.ExcludeNonRequiredColumns Then
+        ' main entity is always included
+        For i = 1 To m_Model.GetEntityCount() - 1
+          Dim sqlEntity = m_Model.GetEntity(i)
+
+          If sqlEntity.Relationship Is Nothing Then
+            sqlEntity.Exclude()
+          End If
+        Next
+      End If
     End Sub
 
     ''' <summary>
@@ -702,7 +711,7 @@ Namespace Expressions.Builders
     End Sub
 
     ''' <summary>
-    ''' Adds select.<br/>
+    ''' Adds custom select.<br/>
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
     ''' <param name="selector"></param>

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpression.vb
@@ -190,7 +190,7 @@ Namespace Expressions
     ''' </summary>
     ''' <returns></returns>
     Public Function SelectAll() As SelectedSelectSqlExpression(Of T)
-      Me.Builder.AddSelectAll(GetType(T))
+      Me.Builder.AddSelectAll(SelectColumnsBehavior.ExcludeNonRequiredColumns)
       Return New SelectedSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2.vb
@@ -347,11 +347,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3.vb
@@ -414,11 +414,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4.vb
@@ -463,11 +463,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5.vb
@@ -530,11 +530,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6.vb
@@ -597,11 +597,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
@@ -664,11 +664,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
@@ -721,11 +721,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
@@ -788,11 +788,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
@@ -855,11 +855,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
@@ -922,11 +922,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
@@ -989,11 +989,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
@@ -1056,11 +1056,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
@@ -1123,11 +1123,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
@@ -1190,11 +1190,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
@@ -1257,11 +1257,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
@@ -1324,11 +1324,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16), GetType(T17))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
@@ -1391,11 +1391,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16), GetType(T17), GetType(T18))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
@@ -1458,11 +1458,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16), GetType(T17), GetType(T18), GetType(T19))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
@@ -1525,11 +1525,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16), GetType(T17), GetType(T18), GetType(T19), GetType(T20))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
@@ -1592,11 +1592,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16), GetType(T17), GetType(T18), GetType(T19), GetType(T20), GetType(T21))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
@@ -1659,11 +1659,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16), GetType(T17), GetType(T18), GetType(T19), GetType(T20), GetType(T21), GetType(T22))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
@@ -1726,11 +1726,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16), GetType(T17), GetType(T18), GetType(T19), GetType(T20), GetType(T21), GetType(T22), GetType(T23))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
@@ -1793,11 +1793,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16), GetType(T17), GetType(T18), GetType(T19), GetType(T20), GetType(T21), GetType(T22), GetType(T23), GetType(T24))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
+++ b/Source/Source/Yamo/Expressions/FilteredSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
@@ -1860,11 +1860,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16), GetType(T17), GetType(T18), GetType(T19), GetType(T20), GetType(T21), GetType(T22), GetType(T23), GetType(T24), GetType(T25))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpression.vb
@@ -176,7 +176,7 @@ Namespace Expressions
     ''' </summary>
     ''' <returns></returns>
     Public Function SelectAll() As SelectedSelectSqlExpression(Of T)
-      Me.Builder.AddSelectAll(GetType(T))
+      Me.Builder.AddSelectAll(SelectColumnsBehavior.ExcludeNonRequiredColumns)
       Return New SelectedSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2.vb
@@ -303,11 +303,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3.vb
@@ -360,11 +360,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4.vb
@@ -399,11 +399,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5.vb
@@ -456,11 +456,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6.vb
@@ -513,11 +513,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
@@ -570,11 +570,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
@@ -627,11 +627,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
@@ -684,11 +684,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
@@ -741,11 +741,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
@@ -798,11 +798,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
@@ -855,11 +855,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
@@ -912,11 +912,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
@@ -969,11 +969,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
@@ -1026,11 +1026,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
@@ -1083,11 +1083,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
@@ -1140,11 +1140,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16), GetType(T17))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
@@ -1197,11 +1197,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16), GetType(T17), GetType(T18))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
@@ -1254,11 +1254,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16), GetType(T17), GetType(T18), GetType(T19))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
@@ -1311,11 +1311,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16), GetType(T17), GetType(T18), GetType(T19), GetType(T20))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
@@ -1368,11 +1368,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16), GetType(T17), GetType(T18), GetType(T19), GetType(T20), GetType(T21))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
@@ -1425,11 +1425,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16), GetType(T17), GetType(T18), GetType(T19), GetType(T20), GetType(T21), GetType(T22))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
@@ -1482,11 +1482,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16), GetType(T17), GetType(T18), GetType(T19), GetType(T20), GetType(T21), GetType(T22), GetType(T23))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
@@ -1539,11 +1539,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16), GetType(T17), GetType(T18), GetType(T19), GetType(T20), GetType(T21), GetType(T22), GetType(T23), GetType(T24))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
+++ b/Source/Source/Yamo/Expressions/GroupedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
@@ -1596,11 +1596,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16), GetType(T17), GetType(T18), GetType(T19), GetType(T20), GetType(T21), GetType(T22), GetType(T23), GetType(T24), GetType(T25))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpression.vb
@@ -168,7 +168,7 @@ Namespace Expressions
     ''' </summary>
     ''' <returns></returns>
     Public Function SelectAll() As SelectedSelectSqlExpression(Of T)
-      Me.Builder.AddSelectAll(GetType(T))
+      Me.Builder.AddSelectAll(SelectColumnsBehavior.ExcludeNonRequiredColumns)
       Return New SelectedSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2.vb
@@ -295,11 +295,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3.vb
@@ -352,11 +352,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4.vb
@@ -391,11 +391,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5.vb
@@ -448,11 +448,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6.vb
@@ -505,11 +505,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
@@ -562,11 +562,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
@@ -619,11 +619,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
@@ -676,11 +676,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
@@ -733,11 +733,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
@@ -790,11 +790,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
@@ -847,11 +847,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
@@ -904,11 +904,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
@@ -961,11 +961,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
@@ -1018,11 +1018,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
@@ -1075,11 +1075,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
@@ -1132,11 +1132,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16), GetType(T17))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
@@ -1189,11 +1189,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16), GetType(T17), GetType(T18))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
@@ -1246,11 +1246,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16), GetType(T17), GetType(T18), GetType(T19))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
@@ -1303,11 +1303,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16), GetType(T17), GetType(T18), GetType(T19), GetType(T20))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
@@ -1360,11 +1360,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16), GetType(T17), GetType(T18), GetType(T19), GetType(T20), GetType(T21))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
@@ -1417,11 +1417,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16), GetType(T17), GetType(T18), GetType(T19), GetType(T20), GetType(T21), GetType(T22))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
@@ -1474,11 +1474,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16), GetType(T17), GetType(T18), GetType(T19), GetType(T20), GetType(T21), GetType(T22), GetType(T23))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
@@ -1531,11 +1531,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16), GetType(T17), GetType(T18), GetType(T19), GetType(T20), GetType(T21), GetType(T22), GetType(T23), GetType(T24))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
+++ b/Source/Source/Yamo/Expressions/HavingSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
@@ -1588,11 +1588,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16), GetType(T17), GetType(T18), GetType(T19), GetType(T20), GetType(T21), GetType(T22), GetType(T23), GetType(T24), GetType(T25))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpression.vb
@@ -26,7 +26,7 @@ Namespace Expressions
     ''' </summary>
     ''' <returns></returns>
     Public Function SelectAll() As SelectedSelectSqlExpression(Of T)
-      Me.Builder.AddSelectAll(GetType(T))
+      Me.Builder.AddSelectAll(SelectColumnsBehavior.ExcludeNonRequiredColumns)
       Return New SelectedSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2.vb
@@ -23,11 +23,12 @@ Namespace Expressions
     End Sub
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3.vb
@@ -24,11 +24,12 @@ Namespace Expressions
     End Sub
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4.vb
@@ -25,11 +25,12 @@ Namespace Expressions
     End Sub
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5.vb
@@ -26,11 +26,12 @@ Namespace Expressions
     End Sub
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6.vb
@@ -27,11 +27,12 @@ Namespace Expressions
     End Sub
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
@@ -28,11 +28,12 @@ Namespace Expressions
     End Sub
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
@@ -29,11 +29,12 @@ Namespace Expressions
     End Sub
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
@@ -30,11 +30,12 @@ Namespace Expressions
     End Sub
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
@@ -31,11 +31,12 @@ Namespace Expressions
     End Sub
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
@@ -32,11 +32,12 @@ Namespace Expressions
     End Sub
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
@@ -33,11 +33,12 @@ Namespace Expressions
     End Sub
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
@@ -34,11 +34,12 @@ Namespace Expressions
     End Sub
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
@@ -35,11 +35,12 @@ Namespace Expressions
     End Sub
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
@@ -36,11 +36,12 @@ Namespace Expressions
     End Sub
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
@@ -37,11 +37,12 @@ Namespace Expressions
     End Sub
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
@@ -38,11 +38,12 @@ Namespace Expressions
     End Sub
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16), GetType(T17))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
@@ -39,11 +39,12 @@ Namespace Expressions
     End Sub
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16), GetType(T17), GetType(T18))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
@@ -40,11 +40,12 @@ Namespace Expressions
     End Sub
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16), GetType(T17), GetType(T18), GetType(T19))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
@@ -41,11 +41,12 @@ Namespace Expressions
     End Sub
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16), GetType(T17), GetType(T18), GetType(T19), GetType(T20))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
@@ -42,11 +42,12 @@ Namespace Expressions
     End Sub
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16), GetType(T17), GetType(T18), GetType(T19), GetType(T20), GetType(T21))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
@@ -43,11 +43,12 @@ Namespace Expressions
     End Sub
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16), GetType(T17), GetType(T18), GetType(T19), GetType(T20), GetType(T21), GetType(T22))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
@@ -44,11 +44,12 @@ Namespace Expressions
     End Sub
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16), GetType(T17), GetType(T18), GetType(T19), GetType(T20), GetType(T21), GetType(T22), GetType(T23))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
@@ -45,11 +45,12 @@ Namespace Expressions
     End Sub
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16), GetType(T17), GetType(T18), GetType(T19), GetType(T20), GetType(T21), GetType(T22), GetType(T23), GetType(T24))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
+++ b/Source/Source/Yamo/Expressions/LimitedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
@@ -46,11 +46,12 @@ Namespace Expressions
     End Sub
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16), GetType(T17), GetType(T18), GetType(T19), GetType(T20), GetType(T21), GetType(T22), GetType(T23), GetType(T24), GetType(T25))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpression.vb
@@ -128,7 +128,7 @@ Namespace Expressions
     ''' </summary>
     ''' <returns></returns>
     Public Function SelectAll() As SelectedSelectSqlExpression(Of T)
-      Me.Builder.AddSelectAll(GetType(T))
+      Me.Builder.AddSelectAll(SelectColumnsBehavior.ExcludeNonRequiredColumns)
       Return New SelectedSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2.vb
@@ -201,11 +201,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3.vb
@@ -240,11 +240,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4.vb
@@ -279,11 +279,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5.vb
@@ -318,11 +318,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6.vb
@@ -357,11 +357,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
@@ -396,11 +396,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
@@ -435,11 +435,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
@@ -474,11 +474,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
@@ -513,11 +513,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
@@ -552,11 +552,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
@@ -591,11 +591,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
@@ -630,11 +630,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
@@ -669,11 +669,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
@@ -708,11 +708,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
@@ -747,11 +747,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
@@ -786,11 +786,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16), GetType(T17))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
@@ -825,11 +825,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16), GetType(T17), GetType(T18))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
@@ -864,11 +864,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16), GetType(T17), GetType(T18), GetType(T19))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
@@ -903,11 +903,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16), GetType(T17), GetType(T18), GetType(T19), GetType(T20))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
@@ -942,11 +942,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16), GetType(T17), GetType(T18), GetType(T19), GetType(T20), GetType(T21))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
@@ -981,11 +981,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16), GetType(T17), GetType(T18), GetType(T19), GetType(T20), GetType(T21), GetType(T22))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
@@ -1020,11 +1020,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16), GetType(T17), GetType(T18), GetType(T19), GetType(T20), GetType(T21), GetType(T22), GetType(T23))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
@@ -1059,11 +1059,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16), GetType(T17), GetType(T18), GetType(T19), GetType(T20), GetType(T21), GetType(T22), GetType(T23), GetType(T24))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
+++ b/Source/Source/Yamo/Expressions/OrderedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
@@ -1098,11 +1098,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16), GetType(T17), GetType(T18), GetType(T19), GetType(T20), GetType(T21), GetType(T22), GetType(T23), GetType(T24), GetType(T25))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpression.vb
@@ -512,7 +512,7 @@ Namespace Expressions
     ''' </summary>
     ''' <returns></returns>
     Public Function SelectAll() As SelectedSelectSqlExpression(Of T)
-      Me.Builder.AddSelectAll(GetType(T))
+      Me.Builder.AddSelectAll(SelectColumnsBehavior.ExcludeNonRequiredColumns)
       Return New SelectedSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2.vb
@@ -719,11 +719,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3.vb
@@ -786,11 +786,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4.vb
@@ -875,11 +875,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5.vb
@@ -982,11 +982,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6.vb
@@ -1089,11 +1089,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7.vb
@@ -916,11 +916,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
@@ -973,11 +973,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
@@ -1040,11 +1040,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
@@ -1107,11 +1107,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
@@ -1174,11 +1174,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
@@ -1241,11 +1241,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
@@ -1308,11 +1308,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
@@ -1375,11 +1375,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
@@ -1442,11 +1442,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
@@ -1509,11 +1509,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
@@ -1576,11 +1576,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16), GetType(T17))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
@@ -1643,11 +1643,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16), GetType(T17), GetType(T18))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
@@ -1710,11 +1710,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16), GetType(T17), GetType(T18), GetType(T19))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
@@ -1777,11 +1777,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16), GetType(T17), GetType(T18), GetType(T19), GetType(T20))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
@@ -1844,11 +1844,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16), GetType(T17), GetType(T18), GetType(T19), GetType(T20), GetType(T21))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
@@ -1911,11 +1911,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16), GetType(T17), GetType(T18), GetType(T19), GetType(T20), GetType(T21), GetType(T22))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
@@ -1978,11 +1978,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16), GetType(T17), GetType(T18), GetType(T19), GetType(T20), GetType(T21), GetType(T22), GetType(T23))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
@@ -2045,11 +2045,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16), GetType(T17), GetType(T18), GetType(T19), GetType(T20), GetType(T21), GetType(T22), GetType(T23), GetType(T24))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
@@ -1869,11 +1869,12 @@ Namespace Expressions
     End Function
 
     ''' <summary>
-    ''' Adds SELECT clause with all columns of all tables (entities).
+    ''' Adds SELECT clause with all columns of the tables (entities) used in the query. Behavior parameter controls whether columns of all or only required tables are included.
     ''' </summary>
+    ''' <param name="behavior"></param>
     ''' <returns></returns>
-    Public Function SelectAll() As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
-      Me.Builder.AddSelectAll(GetType(T1), GetType(T2), GetType(T3), GetType(T4), GetType(T5), GetType(T6), GetType(T7), GetType(T8), GetType(T9), GetType(T10), GetType(T11), GetType(T12), GetType(T13), GetType(T14), GetType(T15), GetType(T16), GetType(T17), GetType(T18), GetType(T19), GetType(T20), GetType(T21), GetType(T22), GetType(T23), GetType(T24), GetType(T25))
+    Public Function SelectAll(Optional behavior As SelectColumnsBehavior = SelectColumnsBehavior.ExcludeNonRequiredColumns) As SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
+      Me.Builder.AddSelectAll(behavior)
       Return New SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/WithHintsSelectSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/WithHintsSelectSqlExpression.vb
@@ -482,7 +482,7 @@ Namespace Expressions
     ''' </summary>
     ''' <returns></returns>
     Public Function SelectAll() As SelectedSelectSqlExpression(Of T)
-      Me.Builder.AddSelectAll(GetType(T))
+      Me.Builder.AddSelectAll(SelectColumnsBehavior.ExcludeNonRequiredColumns)
       Return New SelectedSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/SelectColumnsBehavior.vb
+++ b/Source/Source/Yamo/SelectColumnsBehavior.vb
@@ -1,0 +1,16 @@
+﻿''' <summary>
+''' Defines what columns will be included in the SELECT clause.<br/>
+''' This can be additionally tweaked by calling Include() and Exclude() methods.
+''' </summary>
+Public Enum SelectColumnsBehavior
+  ''' <summary>
+  ''' Include only columns that are necessary to create result entities.<br/>
+  ''' I.e. columns of the main entity and all joined entities necessary to fill relationship navigation properties.
+  ''' </summary>
+  ExcludeNonRequiredColumns = 0
+  ''' <summary>
+  ''' Include columns of all entities in the query, even if they are not used to create the result.<br/>
+  ''' I.e. columns of the joined entities that do not fill any relationship navigation property will be included as well.
+  ''' </summary>
+  SelectAllColumns = 1
+End Enum

--- a/Source/Test/Yamo.Test.SQLite/Tests/SelectColumnsTests.vb
+++ b/Source/Test/Yamo.Test.SQLite/Tests/SelectColumnsTests.vb
@@ -1,0 +1,14 @@
+﻿Imports Yamo.Test
+
+Namespace Tests
+
+  <TestClass()>
+  Public Class SelectColumnsTests
+    Inherits Yamo.Test.Tests.SelectColumnsTests
+
+    Protected Overrides Function CreateTestEnvironment() As ITestEnvironment
+      Return SQLiteTestEnvironment.Create()
+    End Function
+
+  End Class
+End Namespace

--- a/Source/Test/Yamo.Test.SqlServer/Tests/SelectColumnsTests.vb
+++ b/Source/Test/Yamo.Test.SqlServer/Tests/SelectColumnsTests.vb
@@ -1,0 +1,14 @@
+﻿Imports Yamo.Test
+
+Namespace Tests
+
+  <TestClass()>
+  Public Class SelectColumnsTests
+    Inherits Yamo.Test.Tests.SelectColumnsTests
+
+    Protected Overrides Function CreateTestEnvironment() As ITestEnvironment
+      Return SqlServerTestEnvironment.Create()
+    End Function
+
+  End Class
+End Namespace

--- a/Source/Test/Yamo.Test/Tests/SelectColumnsTests.vb
+++ b/Source/Test/Yamo.Test/Tests/SelectColumnsTests.vb
@@ -1,0 +1,274 @@
+﻿Imports Yamo.Metadata
+Imports Yamo.Test.Model
+
+Namespace Tests
+
+  Public MustInherit Class SelectColumnsTests
+    Inherits BaseIntegrationTests
+
+    Protected Const English As String = "en"
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithDefinedRelationshipUsingSelectAllColumnsBehavior()
+      Dim article = Me.ModelFactory.CreateArticle(1)
+      Dim labelEn = Me.ModelFactory.CreateLabel("", 1, English)
+
+      InsertItems(article, labelEn)
+
+      Using db = CreateDbContext()
+        Dim articleEntity = db.Model.GetEntity(article.GetType())
+        Dim labelEntity = db.Model.GetEntity(labelEn.GetType())
+
+        ' ensure relationship is defined
+        Assert.IsNotNull(articleEntity.GetRelationshipNavigation(NameOf(article.Label)))
+
+        Dim result = db.From(Of Article).
+                        Join(Of Label)(Function(j) j.T1.Id = j.T2.Id).
+                        SelectAll(SelectColumnsBehavior.SelectAllColumns).FirstOrDefault()
+
+        Assert.AreEqual(article, result)
+        Assert.AreEqual(labelEn, result.Label)
+
+        Dim sql = db.GetLastCommandText()
+
+        EnsureColumnsArePresent(sql, articleEntity)
+        EnsureColumnsArePresent(sql, labelEntity)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithAdHocRelationshipUsingSelectAllColumnsBehavior()
+      Dim article = Me.ModelFactory.CreateArticle(1)
+      Dim item = Me.ModelFactory.CreateItemWithAllSupportedValuesWithEmptyValues()
+      item.IntColumn = article.Id
+
+      InsertItems(article, item)
+
+      Using db = CreateDbContext()
+        Dim articleEntity = db.Model.GetEntity(article.GetType())
+        Dim itemEntity = db.Model.GetEntity(item.GetType())
+
+        ' ensure relationship is not defined
+        Assert.IsFalse(db.Model.GetEntity(article.GetType()).GetRelationshipNavigations(item.GetType()).Any())
+
+        Dim result = db.From(Of Article).
+                        Join(Of ItemWithAllSupportedValues)(Function(j) j.T1.Id = j.T2.IntColumn).As(Function(x) x.Tag).
+                        SelectAll(SelectColumnsBehavior.SelectAllColumns).FirstOrDefault()
+
+        Assert.AreEqual(article, result)
+        Assert.AreEqual(item, result.Tag)
+
+        Dim sql = db.GetLastCommandText()
+
+        EnsureColumnsArePresent(sql, articleEntity)
+        EnsureColumnsArePresent(sql, itemEntity)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithoutDefinedRelationshipUsingSelectAllColumnsBehavior()
+      Dim article = Me.ModelFactory.CreateArticle(1)
+      Dim item = Me.ModelFactory.CreateItemWithAllSupportedValuesWithEmptyValues()
+      item.IntColumn = article.Id
+
+      InsertItems(article, item)
+
+      Using db = CreateDbContext()
+        Dim articleEntity = db.Model.GetEntity(article.GetType())
+        Dim itemEntity = db.Model.GetEntity(item.GetType())
+
+        ' ensure relationship is not defined
+        Assert.IsFalse(db.Model.GetEntity(article.GetType()).GetRelationshipNavigations(item.GetType()).Any())
+
+        Dim result = db.From(Of Article).
+                        Join(Of ItemWithAllSupportedValues)(Function(j) j.T1.Id = j.T2.IntColumn).
+                        SelectAll(SelectColumnsBehavior.SelectAllColumns).FirstOrDefault()
+
+        Assert.AreEqual(article, result)
+
+        Dim sql = db.GetLastCommandText()
+
+        EnsureColumnsArePresent(sql, articleEntity)
+        EnsureColumnsArePresent(sql, itemEntity)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithExcludeUsingSelectAllColumnsBehavior()
+      Dim article = Me.ModelFactory.CreateArticle(1)
+      Dim labelEn = Me.ModelFactory.CreateLabel("", 1, English)
+
+      InsertItems(article, labelEn)
+
+      Using db = CreateDbContext()
+        Dim articleEntity = db.Model.GetEntity(article.GetType())
+        Dim labelEntity = db.Model.GetEntity(labelEn.GetType())
+
+        ' ensure relationship is defined
+        Assert.IsNotNull(articleEntity.GetRelationshipNavigation(NameOf(article.Label)))
+
+        Dim result = db.From(Of Article).
+                        Join(Of Label)(Function(j) j.T1.Id = j.T2.Id).
+                        SelectAll(SelectColumnsBehavior.SelectAllColumns).ExcludeT2().FirstOrDefault()
+
+        Assert.AreEqual(article, result)
+        Assert.IsNull(result.Label)
+
+        Dim sql = db.GetLastCommandText()
+
+        EnsureColumnsArePresent(sql, articleEntity)
+        EnsureColumnsAreNotPresent(sql, labelEntity)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithDefinedRelationshipUsingExcludeNonRequiredColumnsBehavior()
+      Dim article = Me.ModelFactory.CreateArticle(1)
+      Dim labelEn = Me.ModelFactory.CreateLabel("", 1, English)
+
+      InsertItems(article, labelEn)
+
+      Using db = CreateDbContext()
+        Dim articleEntity = db.Model.GetEntity(article.GetType())
+        Dim labelEntity = db.Model.GetEntity(labelEn.GetType())
+
+        ' ensure relationship is defined
+        Assert.IsNotNull(articleEntity.GetRelationshipNavigation(NameOf(article.Label)))
+
+        Dim result = db.From(Of Article).
+                        Join(Of Label)(Function(j) j.T1.Id = j.T2.Id).
+                        SelectAll(SelectColumnsBehavior.ExcludeNonRequiredColumns).FirstOrDefault()
+
+        Assert.AreEqual(article, result)
+        Assert.AreEqual(labelEn, result.Label)
+
+        Dim sql = db.GetLastCommandText()
+
+        EnsureColumnsArePresent(sql, articleEntity)
+        EnsureColumnsArePresent(sql, labelEntity)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithAdHocRelationshipUsingExcludeNonRequiredColumnsBehavior()
+      Dim article = Me.ModelFactory.CreateArticle(1)
+      Dim item = Me.ModelFactory.CreateItemWithAllSupportedValuesWithEmptyValues()
+      item.IntColumn = article.Id
+
+      InsertItems(article, item)
+
+      Using db = CreateDbContext()
+        Dim articleEntity = db.Model.GetEntity(article.GetType())
+        Dim itemEntity = db.Model.GetEntity(item.GetType())
+
+        ' ensure relationship is not defined
+        Assert.IsFalse(db.Model.GetEntity(article.GetType()).GetRelationshipNavigations(item.GetType()).Any())
+
+        Dim result = db.From(Of Article).
+                        Join(Of ItemWithAllSupportedValues)(Function(j) j.T1.Id = j.T2.IntColumn).As(Function(x) x.Tag).
+                        SelectAll(SelectColumnsBehavior.ExcludeNonRequiredColumns).FirstOrDefault()
+
+        Assert.AreEqual(article, result)
+        Assert.AreEqual(item, result.Tag)
+
+        Dim sql = db.GetLastCommandText()
+
+        EnsureColumnsArePresent(sql, articleEntity)
+        EnsureColumnsArePresent(sql, itemEntity)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithoutDefinedRelationshipUsingExcludeNonRequiredColumnsBehavior()
+      Dim article = Me.ModelFactory.CreateArticle(1)
+      Dim item = Me.ModelFactory.CreateItemWithAllSupportedValuesWithEmptyValues()
+      item.IntColumn = article.Id
+
+      InsertItems(article, item)
+
+      Using db = CreateDbContext()
+        Dim articleEntity = db.Model.GetEntity(article.GetType())
+        Dim itemEntity = db.Model.GetEntity(item.GetType())
+
+        ' ensure relationship is not defined
+        Assert.IsFalse(db.Model.GetEntity(article.GetType()).GetRelationshipNavigations(item.GetType()).Any())
+
+        Dim result = db.From(Of Article).
+                        Join(Of ItemWithAllSupportedValues)(Function(j) j.T1.Id = j.T2.IntColumn).
+                        SelectAll(SelectColumnsBehavior.ExcludeNonRequiredColumns).FirstOrDefault()
+
+        Assert.AreEqual(article, result)
+
+        Dim sql = db.GetLastCommandText()
+
+        EnsureColumnsArePresent(sql, articleEntity)
+        EnsureColumnsAreNotPresent(sql, itemEntity)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithExcludeUsingExcludeNonRequiredColumnsBehavior()
+      Dim article = Me.ModelFactory.CreateArticle(1)
+      Dim labelEn = Me.ModelFactory.CreateLabel("", 1, English)
+
+      InsertItems(article, labelEn)
+
+      Using db = CreateDbContext()
+        Dim articleEntity = db.Model.GetEntity(article.GetType())
+        Dim labelEntity = db.Model.GetEntity(labelEn.GetType())
+
+        ' ensure relationship is defined
+        Assert.IsNotNull(articleEntity.GetRelationshipNavigation(NameOf(article.Label)))
+
+        Dim result = db.From(Of Article).
+                        Join(Of Label)(Function(j) j.T1.Id = j.T2.Id).
+                        SelectAll(SelectColumnsBehavior.ExcludeNonRequiredColumns).ExcludeT2().FirstOrDefault()
+
+        Assert.AreEqual(article, result)
+        Assert.IsNull(result.Label)
+
+        Dim sql = db.GetLastCommandText()
+
+        EnsureColumnsArePresent(sql, articleEntity)
+        EnsureColumnsAreNotPresent(sql, labelEntity)
+      End Using
+    End Sub
+
+    Private Sub EnsureColumnsArePresent(sql As String, entity As Entity)
+      sql = GetColumnsPartFromQuery(sql)
+
+      For Each prop In entity.GetProperties()
+        If prop.ColumnName = "Id" Then
+          ' skip id, because it's not unique (ugly workaround)
+          Continue For
+        End If
+
+        Assert.IsTrue(sql.Contains(prop.ColumnName))
+      Next
+    End Sub
+
+    Private Sub EnsureColumnsAreNotPresent(sql As String, entity As Entity)
+      sql = GetColumnsPartFromQuery(sql)
+
+      For Each prop In entity.GetProperties()
+        If prop.ColumnName = "Id" Then
+          ' skip id, because it's not unique (ugly workaround)
+          Continue For
+        End If
+
+        Assert.IsFalse(sql.Contains(prop.ColumnName))
+      Next
+    End Sub
+
+    Private Shared Function GetColumnsPartFromQuery(sql As String) As String
+      Dim startToken = "SELECT"
+      Dim endToken = "FROM"
+
+      Dim startIndex = sql.IndexOf(startToken)
+      Dim endIndex = sql.IndexOf(endToken)
+
+      Return sql.Substring(startIndex + startToken.Length, endIndex - startIndex - startToken.Length)
+    End Function
+
+  End Class
+End Namespace


### PR DESCRIPTION
So far, calling `SelectAll` always included all columns of all joined tables in the `SELECT` clause, even if certain tables were not processed in the resultset (to fill relationship navigation properties). For performance (or other) reasons, such tables could have been excluded manually using `ExcludeTx` methods.

This PR changes the default behavior or `SelectAll` method. From now on, only required columns are included by default in the `SELECT` clause. I.e. included are all columns of the main entity and all columns of joined tables that are used to fill relationship navigation properties. Relationship navigation could be defined either in the `DbContext` using `HasOne` or `HasMany` methods or ad hoc in the query using `As` method.

Default behavior can be changed using parameter of type `SelectColumnsBehavior`.

Example:
```cs
using (var db = CreateContext())
{
    // there is no relationship between Blog and Person defined in the DbContext and no As() method is used either

    // by default, SelectColumnsBehavior.ExcludeNonRequiredColumns is used
    // only columns of blog table are selected
    var list1 = db.From<Blog>()
                  .Join<Person>((b, p) => b.CreatedUserId == p.Id)
                  .Where(p => p.FirstName == "Joe")
                  .SelectAll()
                  .ToList();

    // Generated SQL:
    // SELECT [T0].[Id], [T0].[Title], [T0].[Content], [T0].[Created], [T0].[CreatedUserId], [T0].[Modified], [T0].[ModifiedUserId], [T0].[Deleted], [T0].[DeletedUserId] FROM [Blog] [T0] INNER JOIN [Person] [T1] ON [T0].[CreatedUserId] = [T1].[Id] WHERE [T1].[FirstName] = @p0

    // columns of all tables in the query are selected
    var list2 = db.From<Blog>()
                  .Join<Person>((b, p) => b.CreatedUserId == p.Id)
                  .Where(p => p.FirstName == "Joe")
                  .SelectAll(SelectColumnsBehavior.SelectAllColumns)
                  .ToList();

    // Generated SQL:
    // SELECT [T0].[Id], [T0].[Title], [T0].[Content], [T0].[Created], [T0].[CreatedUserId], [T0].[Modified], [T0].[ModifiedUserId], [T0].[Deleted], [T0].[DeletedUserId], [T1].[Id], [T1].[FirstName], [T1].[LastName], [T1].[BirthDate] FROM [Blog] [T0] INNER JOIN [Person] [T1] ON [T0].[CreatedUserId] = [T1].[Id] WHERE [T1].[FirstName] = @p0
}
```

Note that this is a breaking change. In some cases (e.g. queries with `DISTINCT` clause), different result might be now returned, unless `SelectColumnsBehavior.SelectAllColumns` is used!