### PR TITLE
Added support for JOIN subqueries

### DIFF
--- a/Source/Samples/Yamo.Playground.CS/Model/Article.cs
+++ b/Source/Samples/Yamo.Playground.CS/Model/Article.cs
@@ -18,5 +18,7 @@ namespace Yamo.Playground.CS.Model
         public decimal PriceWithDiscount { get; set; }
         public string LabelDescription { get; set; }
         public object Tag { get; set; }
+        public Stats Stats { get; set; }
+        public int CategoriesCount { get; set; }
     }
 }

--- a/Source/Samples/Yamo.Playground.CS/Model/Stats.cs
+++ b/Source/Samples/Yamo.Playground.CS/Model/Stats.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Yamo.Playground.CS.Model
+{
+    class Stats
+    {
+        public int ArticleId { get; set; }
+        public int CategoriesCount { get; set; }
+    }
+}

--- a/Source/Samples/Yamo.Playground.VB/Model/ArticleCategory.vb
+++ b/Source/Samples/Yamo.Playground.VB/Model/ArticleCategory.vb
@@ -1,0 +1,7 @@
+﻿Public Class ArticleCategory
+
+  Public Property ArticleId As Int32
+
+  Public Property CategoryId As Int32
+
+End Class

--- a/Source/Samples/Yamo.Playground.VB/Program.vb
+++ b/Source/Samples/Yamo.Playground.VB/Program.vb
@@ -16,4 +16,22 @@ Module Program
     Connection.Dispose()
   End Sub
 
+  Private Sub Test1()
+    Using db = CreateContext()
+      Dim list = db.From(Of Article).
+                    Join(Function(c)
+                           Return c.From(Of ArticleCategory).
+                                    GroupBy(Function(x) x.ArticleId).
+                                    Select(Function(x) (ArticleId:=x.ArticleId, CategoriesCount:=Yamo.Sql.Aggregate.Count()))
+                         End Function).
+                    On(Function(j) j.T1.Id = j.T2.ArticleId).
+                    Where(Function(j) 2 < j.T2.CategoriesCount).
+                    SelectAll().ToList()
+    End Using
+  End Sub
+
+  Private Function CreateContext() As MyContext
+    Return New MyContext()
+  End Function
+
 End Module

--- a/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.Join.vb
+++ b/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.Join.vb
@@ -23,6 +23,9 @@
       GenerateJoinWithNoParameters(builder, entityCount)
       builder.AppendLine()
 
+      GenerateJoinWithSubquery(builder, entityCount)
+      builder.AppendLine()
+
       GenerateJoinWithFormattableString(builder, entityCount)
       builder.AppendLine()
 
@@ -45,6 +48,9 @@
       builder.AppendLine()
 
       GenerateLeftJoinWithNoParameters(builder, entityCount)
+      builder.AppendLine()
+
+      GenerateLeftJoinWithSubquery(builder, entityCount)
       builder.AppendLine()
 
       GenerateLeftJoinWithFormattableString(builder, entityCount)
@@ -71,6 +77,9 @@
       GenerateRightJoinWithNoParameters(builder, entityCount)
       builder.AppendLine()
 
+      GenerateRightJoinWithSubquery(builder, entityCount)
+      builder.AppendLine()
+
       GenerateRightJoinWithFormattableString(builder, entityCount)
       builder.AppendLine()
 
@@ -95,6 +104,9 @@
       GenerateFullJoinWithNoParameters(builder, entityCount)
       builder.AppendLine()
 
+      GenerateFullJoinWithSubquery(builder, entityCount)
+      builder.AppendLine()
+
       GenerateFullJoinWithFormattableString(builder, entityCount)
       builder.AppendLine()
 
@@ -102,6 +114,9 @@
       builder.AppendLine()
 
       GenerateCrossJoin(builder, entityCount)
+      builder.AppendLine()
+
+      GenerateCrossJoinWithSubquery(builder, entityCount)
       builder.AppendLine()
 
       GenerateCrossJoinWithFormattableString(builder, entityCount)
@@ -114,6 +129,9 @@
       builder.AppendLine()
 
       GenerateInternalJoin(builder, entityCount)
+      builder.AppendLine()
+
+      GenerateInternalJoinWithSubquery(builder, entityCount)
       builder.AppendLine()
 
       GenerateInternalJoinWithFormattableString(builder, entityCount)
@@ -171,6 +189,19 @@
 
       builder.Indent().AppendLine($"Public Function Join(Of TJoined)() As JoinSelectSqlExpression(Of {generics}, TJoined)").PushIndent()
       builder.Indent().AppendLine("Return InternalJoin(Of TJoined)(JoinType.Inner)").PopIndent()
+      builder.Indent().AppendLine("End Function")
+    End Sub
+
+    Protected Sub GenerateJoinWithSubquery(builder As CodeBuilder, entityCount As Int32)
+      Dim comment = "Adds INNER JOIN clause."
+      Dim typeParams = {"TJoined"}
+      Dim params = {"tableSourceFactory", "behavior"}
+      AddComment(builder, comment, typeParams:=typeParams, params:=params, returns:="")
+
+      Dim generics = String.Join(", ", GetGenericNames(entityCount))
+
+      builder.Indent().AppendLine($"Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of {generics}, TJoined)").PushIndent()
+      builder.Indent().AppendLine("Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory, behavior)").PopIndent()
       builder.Indent().AppendLine("End Function")
     End Sub
 
@@ -252,6 +283,19 @@
       builder.Indent().AppendLine("End Function")
     End Sub
 
+    Protected Sub GenerateLeftJoinWithSubquery(builder As CodeBuilder, entityCount As Int32)
+      Dim comment = "Adds LEFT OUTER JOIN clause."
+      Dim typeParams = {"TJoined"}
+      Dim params = {"tableSourceFactory", "behavior"}
+      AddComment(builder, comment, typeParams:=typeParams, params:=params, returns:="")
+
+      Dim generics = String.Join(", ", GetGenericNames(entityCount))
+
+      builder.Indent().AppendLine($"Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of {generics}, TJoined)").PushIndent()
+      builder.Indent().AppendLine("Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory, behavior)").PopIndent()
+      builder.Indent().AppendLine("End Function")
+    End Sub
+
     Protected Sub GenerateLeftJoinWithFormattableString(builder As CodeBuilder, entityCount As Int32)
       Dim comment = "Adds LEFT OUTER JOIN clause."
       Dim typeParams = {"TJoined"}
@@ -327,6 +371,19 @@
 
       builder.Indent().AppendLine($"Public Function RightJoin(Of TJoined)() As JoinSelectSqlExpression(Of {generics}, TJoined)").PushIndent()
       builder.Indent().AppendLine("Return InternalJoin(Of TJoined)(JoinType.RightOuter)").PopIndent()
+      builder.Indent().AppendLine("End Function")
+    End Sub
+
+    Protected Sub GenerateRightJoinWithSubquery(builder As CodeBuilder, entityCount As Int32)
+      Dim comment = "Adds RIGHT OUTER JOIN clause."
+      Dim typeParams = {"TJoined"}
+      Dim params = {"tableSourceFactory", "behavior"}
+      AddComment(builder, comment, typeParams:=typeParams, params:=params, returns:="")
+
+      Dim generics = String.Join(", ", GetGenericNames(entityCount))
+
+      builder.Indent().AppendLine($"Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of {generics}, TJoined)").PushIndent()
+      builder.Indent().AppendLine("Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory, behavior)").PopIndent()
       builder.Indent().AppendLine("End Function")
     End Sub
 
@@ -408,6 +465,19 @@
       builder.Indent().AppendLine("End Function")
     End Sub
 
+    Protected Sub GenerateFullJoinWithSubquery(builder As CodeBuilder, entityCount As Int32)
+      Dim comment = "Adds FULL OUTER JOIN clause."
+      Dim typeParams = {"TJoined"}
+      Dim params = {"tableSourceFactory", "behavior"}
+      AddComment(builder, comment, typeParams:=typeParams, params:=params, returns:="")
+
+      Dim generics = String.Join(", ", GetGenericNames(entityCount))
+
+      builder.Indent().AppendLine($"Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of {generics}, TJoined)").PushIndent()
+      builder.Indent().AppendLine("Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory, behavior)").PopIndent()
+      builder.Indent().AppendLine("End Function")
+    End Sub
+
     Protected Sub GenerateFullJoinWithFormattableString(builder As CodeBuilder, entityCount As Int32)
       Dim comment = "Adds FULL OUTER JOIN clause."
       Dim typeParams = {"TJoined"}
@@ -443,6 +513,21 @@
 
       builder.Indent().AppendLine($"Public Function CrossJoin(Of TJoined)() As JoinedSelectSqlExpression(Of {generics}, TJoined)").PushIndent()
       builder.Indent().AppendLine("Return InternalJoin(Of TJoined)(JoinType.CrossJoin, Nothing, {0, 1})").PopIndent()
+      builder.Indent().AppendLine("End Function")
+    End Sub
+
+    Protected Sub GenerateCrossJoinWithSubquery(builder As CodeBuilder, entityCount As Int32)
+      Dim comment = "Adds CROSS JOIN clause."
+      Dim typeParams = {"TJoined"}
+      Dim params = {"tableSourceFactory", "behavior"}
+      AddComment(builder, comment, typeParams:=typeParams, params:=params, returns:="")
+
+      Dim generics = String.Join(", ", GetGenericNames(entityCount))
+
+      builder.Indent().AppendLine($"Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinedSelectSqlExpression(Of {generics}, TJoined)").PushIndent()
+      builder.Indent().AppendLine("Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory, behavior)")
+      builder.Indent().AppendLine("Me.Builder.AddOn(Of TJoined)(Nothing, {0, 1})")
+      builder.Indent().AppendLine($"Return New JoinedSelectSqlExpression(Of {generics}, TJoined)(Me.Builder, Me.Executor)").PopIndent()
       builder.Indent().AppendLine("End Function")
     End Sub
 
@@ -500,6 +585,20 @@
 
       builder.Indent().AppendLine($"Private Function InternalJoin(Of TJoined)(joinType As JoinType) As JoinSelectSqlExpression(Of {generics}, TJoined)").PushIndent()
       builder.Indent().AppendLine("Me.Builder.AddJoin(Of TJoined)(joinType)")
+      builder.Indent().AppendLine($"Return New JoinSelectSqlExpression(Of {generics}, TJoined)(Me.Builder, Me.Executor)").PopIndent()
+      builder.Indent().AppendLine("End Function")
+    End Sub
+
+    Protected Sub GenerateInternalJoinWithSubquery(builder As CodeBuilder, entityCount As Int32)
+      Dim comment = "Adds JOIN clause."
+      Dim typeParams = {"TJoined"}
+      Dim params = {"joinType", "tableSourceFactory", "behavior"}
+      AddComment(builder, comment, typeParams:=typeParams, params:=params, returns:="")
+
+      Dim generics = String.Join(", ", GetGenericNames(entityCount))
+
+      builder.Indent().AppendLine($"Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), behavior As NonModelEntityCreationBehavior) As JoinSelectSqlExpression(Of {generics}, TJoined)").PushIndent()
+      builder.Indent().AppendLine("Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory, behavior)")
       builder.Indent().AppendLine($"Return New JoinSelectSqlExpression(Of {generics}, TJoined)(Me.Builder, Me.Executor)").PopIndent()
       builder.Indent().AppendLine("End Function")
     End Sub

--- a/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.ToSubquery.vb
+++ b/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.ToSubquery.vb
@@ -1,0 +1,17 @@
+﻿Namespace Generator
+
+  Partial Public Class CodeGenerator
+
+    Protected Sub GenerateToSubquery(builder As CodeBuilder, entityCount As Int32)
+      Dim comment = "Creates SQL subquery."
+      AddComment(builder, comment, returns:="")
+
+      Dim generic = GetGenericName(1, entityCount = 1)
+
+      builder.Indent().AppendLine($"Public Function ToSubquery() As Subquery(Of {generic}) Implements ISubqueryableSelectSqlExpression(Of {generic}).ToSubquery").PushIndent()
+      builder.Indent().AppendLine($"Return Me.Builder.CreateSubquery(Of {generic})()").PopIndent()
+      builder.Indent().AppendLine("End Function")
+    End Sub
+
+  End Class
+End Namespace

--- a/Source/Source/Yamo.CodeGenerator/Generator/CustomDistinctSelectSqlExpressionCodeGenerator.vb
+++ b/Source/Source/Yamo.CodeGenerator/Generator/CustomDistinctSelectSqlExpressionCodeGenerator.vb
@@ -24,10 +24,16 @@
       Dim typeParams = GetGenericNames(entityCount)
       AddComment(builder, comment, typeParams:=typeParams)
 
+      Dim generic = GetGenericName(1, entityCount = 1)
+
       builder.Indent().AppendLine($"Public Class {GetFullClassName(entityCount)}").PushIndent()
       builder.Indent().AppendLine("Inherits SelectSqlExpressionBase")
+      builder.Indent().AppendLine($"Implements ISubqueryableSelectSqlExpression(Of {generic})")
       builder.AppendLine()
       GenerateConstructor(builder, entityCount)
+      builder.AppendLine()
+
+      GenerateToSubquery(builder, entityCount)
       builder.AppendLine()
 
       GenerateCustomToList(builder, entityCount)

--- a/Source/Source/Yamo.CodeGenerator/Generator/CustomSelectSqlExpressionCodeGenerator.vb
+++ b/Source/Source/Yamo.CodeGenerator/Generator/CustomSelectSqlExpressionCodeGenerator.vb
@@ -26,13 +26,19 @@
       Dim typeParams = GetGenericNames(entityCount)
       AddComment(builder, comment, typeParams:=typeParams)
 
+      Dim generic = GetGenericName(1, entityCount = 1)
+
       builder.Indent().AppendLine($"Public Class {GetFullClassName(entityCount)}").PushIndent()
       builder.Indent().AppendLine("Inherits SelectSqlExpressionBase")
+      builder.Indent().AppendLine($"Implements ISubqueryableSelectSqlExpression(Of {generic})")
       builder.AppendLine()
       GenerateConstructor(builder, entityCount)
       builder.AppendLine()
 
       GenerateCustomDistinct(builder, entityCount)
+      builder.AppendLine()
+
+      GenerateToSubquery(builder, entityCount)
       builder.AppendLine()
 
       GenerateCustomToList(builder, entityCount)

--- a/Source/Source/Yamo.CodeGenerator/Generator/DistinctSelectSqlExpressionCodeGenerator.vb
+++ b/Source/Source/Yamo.CodeGenerator/Generator/DistinctSelectSqlExpressionCodeGenerator.vb
@@ -24,10 +24,16 @@
       Dim typeParams = GetGenericNames(entityCount)
       AddComment(builder, comment, typeParams:=typeParams)
 
+      Dim generic = GetGenericName(1, entityCount = 1)
+
       builder.Indent().AppendLine($"Public Class {GetFullClassName(entityCount)}").PushIndent()
       builder.Indent().AppendLine("Inherits SelectSqlExpressionBase")
+      builder.Indent().AppendLine($"Implements ISubqueryableSelectSqlExpression(Of {generic})")
       builder.AppendLine()
       GenerateConstructor(builder, entityCount)
+      builder.AppendLine()
+
+      GenerateToSubquery(builder, entityCount)
       builder.AppendLine()
 
       GenerateToList(builder, entityCount)

--- a/Source/Source/Yamo.CodeGenerator/Generator/SelectSqlExpressionCodeGenerator.vb
+++ b/Source/Source/Yamo.CodeGenerator/Generator/SelectSqlExpressionCodeGenerator.vb
@@ -96,6 +96,16 @@
         builder.AppendLine()
 
         comment = $"Creates new instance of <see cref=""{GetFullClassName(entityCount)}""/>."
+        params = {"context"}
+        AddComment(builder, comment, params:=params)
+
+        builder.Indent().AppendLine("Friend Sub New(context As SubqueryContext)").PushIndent()
+        builder.Indent().AppendLine("MyBase.New(New SelectSqlExpressionBuilder(context, GetType(T)), context.Executor)").PopIndent()
+        builder.Indent().AppendLine("End Sub")
+
+        builder.AppendLine()
+
+        comment = $"Creates new instance of <see cref=""{GetFullClassName(entityCount)}""/>."
         params = {"context", "tableSource"}
         AddComment(builder, comment, params:=params)
 
@@ -107,11 +117,33 @@
         builder.AppendLine()
 
         comment = $"Creates new instance of <see cref=""{GetFullClassName(entityCount)}""/>."
+        params = {"context", "tableSource"}
+        AddComment(builder, comment, params:=params)
+
+        builder.Indent().AppendLine("Friend Sub New(context As SubqueryContext, tableSource As FormattableString)").PushIndent()
+        builder.Indent().AppendLine("MyBase.New(New SelectSqlExpressionBuilder(context, GetType(T)), context.Executor)")
+        builder.Indent().AppendLine("Me.Builder.SetMainTableSource(tableSource)").PopIndent()
+        builder.Indent().AppendLine("End Sub")
+
+        builder.AppendLine()
+
+        comment = $"Creates new instance of <see cref=""{GetFullClassName(entityCount)}""/>."
         params = {"context", "tableSource", "parameters"}
         AddComment(builder, comment, params:=params)
 
         builder.Indent().AppendLine("Friend Sub New(context As DbContext, tableSource As RawSqlString, ParamArray parameters() As Object)").PushIndent()
         builder.Indent().AppendLine("MyBase.New(New SelectSqlExpressionBuilder(context, GetType(T)), New QueryExecutor(context))")
+        builder.Indent().AppendLine("Me.Builder.SetMainTableSource(tableSource, parameters)").PopIndent()
+        builder.Indent().AppendLine("End Sub")
+
+        builder.AppendLine()
+
+        comment = $"Creates new instance of <see cref=""{GetFullClassName(entityCount)}""/>."
+        params = {"context", "tableSource", "parameters"}
+        AddComment(builder, comment, params:=params)
+
+        builder.Indent().AppendLine("Friend Sub New(context As SubqueryContext, tableSource As RawSqlString, ParamArray parameters() As Object)").PushIndent()
+        builder.Indent().AppendLine("MyBase.New(New SelectSqlExpressionBuilder(context, GetType(T)), context.Executor)")
         builder.Indent().AppendLine("Me.Builder.SetMainTableSource(tableSource, parameters)").PopIndent()
         builder.Indent().AppendLine("End Sub")
       Else

--- a/Source/Source/Yamo.CodeGenerator/Generator/SelectedSelectSqlExpressionCodeGenerator.vb
+++ b/Source/Source/Yamo.CodeGenerator/Generator/SelectedSelectSqlExpressionCodeGenerator.vb
@@ -27,8 +27,11 @@
       Dim typeParams = GetGenericNames(entityCount)
       AddComment(builder, comment, typeParams:=typeParams)
 
+      Dim generic = GetGenericName(1, entityCount = 1)
+
       builder.Indent().AppendLine($"Public Class {GetFullClassName(entityCount)}").PushIndent()
       builder.Indent().AppendLine("Inherits SelectSqlExpressionBase")
+      builder.Indent().AppendLine($"Implements ISubqueryableSelectSqlExpression(Of {generic})")
       builder.AppendLine()
       GenerateConstructor(builder, entityCount)
       builder.AppendLine()
@@ -43,6 +46,9 @@
       builder.AppendLine()
 
       GenerateIf(builder, entityCount)
+      builder.AppendLine()
+
+      GenerateToSubquery(builder, entityCount)
       builder.AppendLine()
 
       GenerateToList(builder, entityCount)

--- a/Source/Source/Yamo/Expressions/Builders/DeleteSqlExpressionBuilder.vb
+++ b/Source/Source/Yamo/Expressions/Builders/DeleteSqlExpressionBuilder.vb
@@ -64,7 +64,7 @@ Namespace Expressions.Builders
     ''' <param name="tableNameOverride"></param>
     Public Sub New(<DisallowNull> context As DbContext, <DisallowNull> mainEntityType As Type, softDelete As Boolean, tableNameOverride As String)
       MyBase.New(context)
-      m_Model = New DeleteSqlModel(Me.DbContext.Model, mainEntityType)
+      m_Model = New DeleteSqlModel(GetMainEntity(mainEntityType))
       m_SoftDelete = softDelete
       m_TableNameOverride = tableNameOverride
       m_TableHints = Nothing
@@ -175,7 +175,7 @@ Namespace Expressions.Builders
         table = table & " " & m_TableHints
       End If
 
-      Dim getter = EntityAutoFieldsGetterCache.GetOnDeleteGetter(m_Model.Model, entity.EntityType)
+      Dim getter = EntityAutoFieldsGetterCache.GetOnDeleteGetter(Me.DbContext.Model, entity.EntityType)
       Dim values = getter(Me.DbContext)
 
       Dim provider = EntitySqlStringProviderCache.GetSoftDeleteWithoutConditionProvider(Me, entity.EntityType)

--- a/Source/Source/Yamo/Expressions/Builders/SelectSqlExpressionBuilder.vb
+++ b/Source/Source/Yamo/Expressions/Builders/SelectSqlExpressionBuilder.vb
@@ -17,6 +17,13 @@ Namespace Expressions.Builders
     Inherits SqlExpressionBuilderBase
 
     ''' <summary>
+    ''' Gets subquery context.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <returns></returns>
+    Public ReadOnly Property SubqueryContext As <MaybeNull> SubqueryContext
+
+    ''' <summary>
     ''' Stores SQL model.
     ''' </summary>
     Private m_Model As SelectSqlModel
@@ -77,7 +84,7 @@ Namespace Expressions.Builders
     Private m_LimitExpression As String
 
     ''' <summary>
-    ''' Stores whether top should be used for limit
+    ''' Stores whether top should be used for limit.
     ''' </summary>
     Private m_UseTopForLimit As Boolean
 
@@ -102,6 +109,11 @@ Namespace Expressions.Builders
     Private m_Parameters As List(Of SqlParameter)
 
     ''' <summary>
+    ''' Stores parameter index offset.
+    ''' </summary>
+    Private m_ParameterIndexOffset As Int32
+
+    ''' <summary>
     ''' Creates new instance of <see cref="SelectSqlExpressionBuilder"/>.<br/>
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
@@ -109,7 +121,28 @@ Namespace Expressions.Builders
     ''' <param name="mainEntityType"></param>
     Public Sub New(<DisallowNull> context As DbContext, <DisallowNull> mainEntityType As Type)
       MyBase.New(context)
-      m_Model = New SelectSqlModel(Me.DbContext.Model, mainEntityType)
+      Me.SubqueryContext = Nothing
+      Initialize(mainEntityType)
+    End Sub
+
+    ''' <summary>
+    ''' Creates new instance of <see cref="SelectSqlExpressionBuilder"/>.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <param name="context"></param>
+    ''' <param name="mainEntityType"></param>
+    Public Sub New(<DisallowNull> context As SubqueryContext, <DisallowNull> mainEntityType As Type)
+      MyBase.New(context.DbContext)
+      Me.SubqueryContext = context
+      Initialize(mainEntityType)
+    End Sub
+
+    ''' <summary>
+    ''' Initializes values.
+    ''' </summary>
+    ''' <param name="mainEntityType"></param>
+    Private Sub Initialize(<DisallowNull> mainEntityType As Type)
+      m_Model = New SelectSqlModel(GetMainEntity(mainEntityType))
       m_Visitor = New SqlExpressionVisitor(Me, m_Model)
       ' lists are created only when necessary
       m_MainTableSourceExpression = Nothing
@@ -135,7 +168,7 @@ Namespace Expressions.Builders
     ''' </summary>
     ''' <param name="tableSource"></param>
     Public Sub SetMainTableSource(<DisallowNull> tableSource As FormattableString)
-      Dim sql = ConvertToSqlString(tableSource, m_Parameters.Count)
+      Dim sql = ConvertToSqlString(tableSource, GetParameterIndex())
       m_MainTableSourceExpression = sql.Sql
       m_Parameters.AddRange(sql.Parameters)
     End Sub
@@ -150,7 +183,7 @@ Namespace Expressions.Builders
       If parameters Is Nothing OrElse parameters.Length = 0 Then
         m_MainTableSourceExpression = tableSource.Value
       Else
-        Dim sql = ConvertToSqlString(tableSource.Value, parameters, m_Parameters.Count)
+        Dim sql = ConvertToSqlString(tableSource.Value, parameters, GetParameterIndex())
         m_MainTableSourceExpression = sql.Sql
         m_Parameters.AddRange(sql.Parameters)
       End If
@@ -194,10 +227,28 @@ Namespace Expressions.Builders
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="executor"></param>
+    ''' <param name="joinType"></param>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    Public Sub AddJoin(Of TJoined)(<DisallowNull> executor As QueryExecutor, joinType As JoinType, <DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), behavior As NonModelEntityCreationBehavior)
+      Dim context = New SubqueryContext(Me.DbContext, executor, GetParameterIndex())
+      Dim subquery = tableSourceFactory.Invoke(context).ToSubquery()
+      Dim sql = subquery.Query
+
+      m_CurrentJoinInfo = New JoinInfo(joinType, "(" & sql.Sql & ")", sql, behavior)
+      m_Parameters.AddRange(sql.Parameters)
+    End Sub
+
+    ''' <summary>
+    ''' Adds join.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="joinType"></param>
     ''' <param name="tableSource"></param>
     Public Sub AddJoin(Of TJoined)(joinType As JoinType, <DisallowNull> tableSource As FormattableString)
-      Dim sql = ConvertToSqlString(tableSource, m_Parameters.Count)
+      Dim sql = ConvertToSqlString(tableSource, GetParameterIndex())
       m_CurrentJoinInfo = New JoinInfo(joinType, sql.Sql)
       m_Parameters.AddRange(sql.Parameters)
     End Sub
@@ -214,7 +265,7 @@ Namespace Expressions.Builders
       If parameters Is Nothing OrElse parameters.Length = 0 Then
         m_CurrentJoinInfo = New JoinInfo(joinType, tableSource.Value)
       Else
-        Dim sql = ConvertToSqlString(tableSource.Value, parameters, m_Parameters.Count)
+        Dim sql = ConvertToSqlString(tableSource.Value, parameters, GetParameterIndex())
         m_CurrentJoinInfo = New JoinInfo(joinType, sql.Sql)
         m_Parameters.AddRange(sql.Parameters)
       End If
@@ -253,49 +304,84 @@ Namespace Expressions.Builders
         relationship = TryGetRelationship(Of TJoined)(entityIndexHints)
       End If
 
-      Dim sqlEntity = m_Model.AddJoin(Of TJoined)(relationship)
-      Dim entity = sqlEntity.Entity
-      Dim tableAlias = sqlEntity.TableAlias
+      Dim subquery = joinInfo.Subquery
+      Dim subQueryWithNonModelEntityResult = subquery?.Model.NonModelEntity IsNot Nothing
 
       Dim sql As String
-      Dim joinTypeString As String
+      Dim joinTypeString = GetJoinTypeString(joinInfo.JoinType)
 
-      Select Case joinInfo.JoinType
-        Case JoinType.Inner
-          joinTypeString = "INNER JOIN"
-        Case JoinType.LeftOuter
-          joinTypeString = "LEFT OUTER JOIN"
-        Case JoinType.RightOuter
-          joinTypeString = "RIGHT OUTER JOIN"
-        Case JoinType.FullOuter
-          joinTypeString = "FULL OUTER JOIN"
-        Case JoinType.CrossJoin
-          joinTypeString = "CROSS JOIN"
-        Case Else
-          Throw New NotSupportedException($"Unsupported join type '{joinInfo.JoinType}'.")
-      End Select
+      If subQueryWithNonModelEntityResult Then
+        Dim sqlEntity = m_Model.AddJoin(subquery.Model.NonModelEntity, relationship, joinInfo.NonModelEntityCreationBehavior)
+        Dim tableAlias = sqlEntity.TableAlias
 
-      If predicate Is Nothing Then
-        If joinInfo.TableSource Is Nothing Then
-          sql = joinTypeString & " " & Me.DialectProvider.Formatter.CreateIdentifier(entity.TableName, entity.Schema) & " " & Me.DialectProvider.Formatter.CreateIdentifier(tableAlias) & If(tableHints Is Nothing, "", " " & tableHints)
-        Else
+        If predicate Is Nothing Then
           sql = joinTypeString & " " & joinInfo.TableSource & " " & Me.DialectProvider.Formatter.CreateIdentifier(tableAlias) & If(tableHints Is Nothing, "", " " & tableHints)
-        End If
 
-        m_JoinExpressions.Add(sql)
-      Else
-        Dim result = m_Visitor.Translate(predicate, ExpressionTranslateMode.Condition, entityIndexHints, m_Parameters.Count, True, True)
+          m_JoinExpressions.Add(sql)
 
-        If joinInfo.TableSource Is Nothing Then
-          sql = joinTypeString & " " & Me.DialectProvider.Formatter.CreateIdentifier(entity.TableName, entity.Schema) & " " & Me.DialectProvider.Formatter.CreateIdentifier(tableAlias) & If(tableHints Is Nothing, "", " " & tableHints) & " ON " & result.Sql
         Else
+          Dim result = m_Visitor.Translate(predicate, ExpressionTranslateMode.Condition, entityIndexHints, GetParameterIndex(), True, True)
+
           sql = joinTypeString & " " & joinInfo.TableSource & " " & Me.DialectProvider.Formatter.CreateIdentifier(tableAlias) & If(tableHints Is Nothing, "", " " & tableHints) & " ON " & result.Sql
+
+          m_JoinExpressions.Add(sql)
+          m_Parameters.AddRange(result.Parameters)
         End If
 
-        m_JoinExpressions.Add(sql)
-        m_Parameters.AddRange(result.Parameters)
+      Else
+        Dim entity = Me.DbContext.Model.GetEntity(GetType(TJoined))
+        Dim sqlEntity = m_Model.AddJoin(entity, relationship)
+        Dim tableAlias = sqlEntity.TableAlias
+
+        If subquery IsNot Nothing AndAlso subquery.Model.MainEntity.ColumnAliases IsNot Nothing Then
+          sqlEntity.SetColumnAliases(subquery.Model.MainEntity.ColumnAliases)
+        End If
+
+        If predicate Is Nothing Then
+          If joinInfo.TableSource Is Nothing Then
+            sql = joinTypeString & " " & Me.DialectProvider.Formatter.CreateIdentifier(entity.TableName, entity.Schema) & " " & Me.DialectProvider.Formatter.CreateIdentifier(tableAlias) & If(tableHints Is Nothing, "", " " & tableHints)
+          Else
+            sql = joinTypeString & " " & joinInfo.TableSource & " " & Me.DialectProvider.Formatter.CreateIdentifier(tableAlias) & If(tableHints Is Nothing, "", " " & tableHints)
+          End If
+
+          m_JoinExpressions.Add(sql)
+
+        Else
+          Dim result = m_Visitor.Translate(predicate, ExpressionTranslateMode.Condition, entityIndexHints, GetParameterIndex(), True, True)
+
+          If joinInfo.TableSource Is Nothing Then
+            sql = joinTypeString & " " & Me.DialectProvider.Formatter.CreateIdentifier(entity.TableName, entity.Schema) & " " & Me.DialectProvider.Formatter.CreateIdentifier(tableAlias) & If(tableHints Is Nothing, "", " " & tableHints) & " ON " & result.Sql
+          Else
+            sql = joinTypeString & " " & joinInfo.TableSource & " " & Me.DialectProvider.Formatter.CreateIdentifier(tableAlias) & If(tableHints Is Nothing, "", " " & tableHints) & " ON " & result.Sql
+          End If
+
+          m_JoinExpressions.Add(sql)
+          m_Parameters.AddRange(result.Parameters)
+        End If
       End If
     End Sub
+
+    ''' <summary>
+    ''' Gets SQL join type string.
+    ''' </summary>
+    ''' <param name="joinType"></param>
+    ''' <returns></returns>
+    Private Shared Function GetJoinTypeString(joinType As JoinType) As String
+      Select Case joinType
+        Case JoinType.Inner
+          Return "INNER JOIN"
+        Case JoinType.LeftOuter
+          Return "LEFT OUTER JOIN"
+        Case JoinType.RightOuter
+          Return "RIGHT OUTER JOIN"
+        Case JoinType.FullOuter
+          Return "FULL OUTER JOIN"
+        Case JoinType.CrossJoin
+          Return "CROSS JOIN"
+        Case Else
+          Throw New NotSupportedException($"Unsupported join type '{joinType}'.")
+      End Select
+    End Function
 
     ''' <summary>
     ''' Adds ignored join.<br/>
@@ -303,7 +389,15 @@ Namespace Expressions.Builders
     ''' </summary>
     ''' <param name="entityType"></param>
     Public Sub AddIgnoredJoin(entityType As Type)
-      m_Model.AddIgnoredJoin(entityType)
+      Dim entity = Me.DbContext.Model.TryGetEntity(entityType)
+
+      If entity Is Nothing Then
+        Dim sqlEntity = New NonModelEntity(entityType)
+        sqlEntity.SetSqlResult(New ExcludedUnknownSqlResult(entityType))
+        m_Model.AddIgnoredJoin(sqlEntity)
+      Else
+        m_Model.AddIgnoredJoin(entity)
+      End If
     End Sub
 
     ''' <summary>
@@ -364,7 +458,14 @@ Namespace Expressions.Builders
       End If
 
       ' try to infer relationship from model
-      Dim declaringSqlEntity = m_Model.GetEntity(entityIndexHints(0))
+      Dim sqlEntity = m_Model.GetEntity(entityIndexHints(0))
+
+      If TypeOf sqlEntity IsNot EntityBasedSqlEntity Then
+        ' relationships are supported only for model entities
+        Return Nothing
+      End If
+
+      Dim declaringSqlEntity = DirectCast(sqlEntity, EntityBasedSqlEntity)
       Dim relationshipNavigations = declaringSqlEntity.Entity.GetRelationshipNavigations(GetType(TJoined))
 
       If relationshipNavigations.Count = 1 Then
@@ -404,6 +505,7 @@ Namespace Expressions.Builders
         Throw New Exception("Cannot infer relationship. Use expression that contains relationship property only.")
       End If
 
+      Dim lastEntity = m_Model.GetLastEntity()
       Dim declaringSqlEntity = result.Entity
       Dim propertyType = result.PropertyType
       Dim propertyName = result.PropertyName
@@ -417,9 +519,9 @@ Namespace Expressions.Builders
 
         ' there is still small possibility that item type is not genericTypes(0) type, but in most cases like List(Of) we should be ok
 
-        m_Model.GetLastEntity().SetRelationship(New SqlEntityRelationship(declaringSqlEntity, New CollectionNavigation(propertyName, genericTypes(0), propertyType)))
+        lastEntity.SetRelationship(New SqlEntityRelationship(declaringSqlEntity, New CollectionNavigation(propertyName, genericTypes(0), propertyType)))
       Else
-        m_Model.GetLastEntity().SetRelationship(New SqlEntityRelationship(declaringSqlEntity, New ReferenceNavigation(propertyName, propertyType)))
+        lastEntity.SetRelationship(New SqlEntityRelationship(declaringSqlEntity, New ReferenceNavigation(propertyName, propertyType)))
       End If
     End Sub
 
@@ -434,7 +536,7 @@ Namespace Expressions.Builders
         m_WhereExpressions = New List(Of String)
       End If
 
-      Dim result = m_Visitor.Translate(predicate, ExpressionTranslateMode.Condition, entityIndexHints, m_Parameters.Count, True, True)
+      Dim result = m_Visitor.Translate(predicate, ExpressionTranslateMode.Condition, entityIndexHints, GetParameterIndex(), True, True)
       m_WhereExpressions.Add(result.Sql)
       m_Parameters.AddRange(result.Parameters)
     End Sub
@@ -453,7 +555,7 @@ Namespace Expressions.Builders
       If parameters Is Nothing OrElse parameters.Length = 0 Then
         m_WhereExpressions.Add(predicate)
       Else
-        Dim sql = ConvertToSqlString(predicate, parameters, m_Parameters.Count)
+        Dim sql = ConvertToSqlString(predicate, parameters, GetParameterIndex())
         m_WhereExpressions.Add(sql.Sql)
         m_Parameters.AddRange(sql.Parameters)
       End If
@@ -470,7 +572,7 @@ Namespace Expressions.Builders
         m_GroupByExpressions = New List(Of String)
       End If
 
-      Dim result = m_Visitor.Translate(keySelector, ExpressionTranslateMode.GroupBy, entityIndexHints, m_Parameters.Count, True, True)
+      Dim result = m_Visitor.Translate(keySelector, ExpressionTranslateMode.GroupBy, entityIndexHints, GetParameterIndex(), True, True)
       m_GroupByExpressions.Add(result.Sql)
       m_Parameters.AddRange(result.Parameters)
     End Sub
@@ -486,7 +588,7 @@ Namespace Expressions.Builders
         m_HavingExpressions = New List(Of String)
       End If
 
-      Dim result = m_Visitor.Translate(predicate, ExpressionTranslateMode.Condition, entityIndexHints, m_Parameters.Count, True, True)
+      Dim result = m_Visitor.Translate(predicate, ExpressionTranslateMode.Condition, entityIndexHints, GetParameterIndex(), True, True)
       m_HavingExpressions.Add(result.Sql)
       m_Parameters.AddRange(result.Parameters)
     End Sub
@@ -505,7 +607,7 @@ Namespace Expressions.Builders
       If parameters Is Nothing OrElse parameters.Length = 0 Then
         m_HavingExpressions.Add(predicate)
       Else
-        Dim sql = ConvertToSqlString(predicate, parameters, m_Parameters.Count)
+        Dim sql = ConvertToSqlString(predicate, parameters, GetParameterIndex())
         m_HavingExpressions.Add(sql.Sql)
         m_Parameters.AddRange(sql.Parameters)
       End If
@@ -523,7 +625,7 @@ Namespace Expressions.Builders
         m_OrderByExpressions = New List(Of String)
       End If
 
-      Dim result = m_Visitor.Translate(keySelector, ExpressionTranslateMode.OrderBy, entityIndexHints, m_Parameters.Count, True, True)
+      Dim result = m_Visitor.Translate(keySelector, ExpressionTranslateMode.OrderBy, entityIndexHints, GetParameterIndex(), True, True)
 
       If ascending Then
         m_OrderByExpressions.Add(result.Sql)
@@ -553,7 +655,7 @@ Namespace Expressions.Builders
           m_OrderByExpressions.Add(predicate & " DESC")
         End If
       Else
-        Dim sql = ConvertToSqlString(predicate, parameters, m_Parameters.Count)
+        Dim sql = ConvertToSqlString(predicate, parameters, GetParameterIndex())
 
         If ascending Then
           m_OrderByExpressions.Add(sql.Sql)
@@ -607,14 +709,20 @@ Namespace Expressions.Builders
     Public Sub AddSelectAll(behavior As SelectColumnsBehavior)
       If behavior = SelectColumnsBehavior.ExcludeNonRequiredColumns Then
         ' main entity is always included
+        ' in case of subquery, ignore all relationships
+
+        Dim isSubquery = Me.IsSubquery()
+
         For i = 1 To m_Model.GetEntityCount() - 1
           Dim sqlEntity = m_Model.GetEntity(i)
 
-          If sqlEntity.Relationship Is Nothing Then
+          If sqlEntity.Relationship Is Nothing OrElse isSubquery Then
             sqlEntity.Exclude()
           End If
         Next
       End If
+
+      m_Model.SqlResult = New EntitySqlResult(m_Model.MainEntity)
     End Sub
 
     ''' <summary>
@@ -623,6 +731,10 @@ Namespace Expressions.Builders
     ''' </summary>
     ''' <param name="propertyExpression">Lambda expression with one parameter is expected.</param>
     Public Sub ExcludeSelected(<DisallowNull> propertyExpression As Expression)
+      If IsSubquery() Then
+        Throw New NotSupportedException("Exclude is not supported in subqueries.")
+      End If
+
       Dim result = GetEntityAndProperty(propertyExpression)
 
       If result.NotFound Then
@@ -637,7 +749,11 @@ Namespace Expressions.Builders
         Throw New Exception("Cannot infer excluded column. Use expression that contains entity property only.")
       End If
 
-      Dim entity = result.Entity
+      If TypeOf result.Entity IsNot EntityBasedSqlEntity Then
+        Throw New Exception($"Cannot exclude column. Exclusion is supported only for model entities. Type '{result.EntityType}' is not defined in the model.")
+      End If
+
+      Dim entity = DirectCast(result.Entity, EntityBasedSqlEntity)
       Dim prop = entity.Entity.GetProperty(result.PropertyName)
 
       If prop.IsKey Then
@@ -663,7 +779,11 @@ Namespace Expressions.Builders
     ''' <param name="action"></param>
     ''' <param name="entityIndexHints"></param>
     Public Sub IncludeToSelected(<DisallowNull> action As Expression, entityIndexHints As Int32())
-      Dim result = m_Visitor.TranslateIncludeAction(action, entityIndexHints, m_Parameters.Count, m_IncludedExpressionsCount)
+      If IsSubquery() Then
+        Throw New NotSupportedException("Include is not supported in subqueries.")
+      End If
+
+      Dim result = m_Visitor.TranslateIncludeAction(action, entityIndexHints, GetParameterIndex(), m_IncludedExpressionsCount)
       m_Parameters.AddRange(result.SqlString.Parameters)
       m_IncludedExpressionsCount += 1
 
@@ -680,6 +800,10 @@ Namespace Expressions.Builders
     ''' <param name="keySelectorEntityIndexHints"></param>
     ''' <param name="valueSelectorEntityIndexHints"></param>
     Public Sub IncludeToSelected(<DisallowNull> keySelector As Expression, <DisallowNull> valueSelector As Expression, keySelectorEntityIndexHints As Int32(), valueSelectorEntityIndexHints As Int32())
+      If IsSubquery() Then
+        Throw New NotSupportedException("Include is not supported in subqueries.")
+      End If
+
       Dim keyResult = GetEntityAndProperty(keySelector)
 
       If keyResult.NotFound Then
@@ -694,7 +818,7 @@ Namespace Expressions.Builders
         Throw New Exception("Cannot infer included column. Use expression that contains entity property only.")
       End If
 
-      Dim valueResult = m_Visitor.TranslateIncludeValueSelector(valueSelector, valueSelectorEntityIndexHints, m_Parameters.Count, m_IncludedExpressionsCount)
+      Dim valueResult = m_Visitor.TranslateIncludeValueSelector(valueSelector, valueSelectorEntityIndexHints, GetParameterIndex(), m_IncludedExpressionsCount)
       m_Parameters.AddRange(valueResult.SqlString.Parameters)
       m_IncludedExpressionsCount += 1
 
@@ -717,10 +841,12 @@ Namespace Expressions.Builders
     ''' <param name="selector"></param>
     ''' <param name="entityIndexHints"></param>
     Public Sub AddSelect(<DisallowNull> selector As Expression, entityIndexHints As Int32())
-      Dim result = m_Visitor.TranslateCustomSelect(selector, entityIndexHints, m_Parameters.Count)
+      Dim isSubquery = Me.IsSubquery()
+      Dim result = m_Visitor.TranslateCustomSelect(selector, entityIndexHints, GetParameterIndex(), isSubquery)
       m_SelectExpression = result.SqlString.Sql
       m_Parameters.AddRange(result.SqlString.Parameters)
-      m_Model.CustomSqlResult = result.SqlResult
+      m_Model.SqlResult = result.SqlResult
+      m_Model.NonModelEntity = result.NonModelEntity
     End Sub
 
     ''' <summary>
@@ -736,16 +862,26 @@ Namespace Expressions.Builders
     ''' </summary>
     ''' <param name="sql"></param>
     Private Sub BuildAndAppendSelectExpression(sql As StringBuilder)
+      ' aliases are necessary only for subqueries and if SELECT clause contains columns from more that one entity (aliases prevent column name conflicts)
+      Dim useColumnAliasesForModelEntities = Me.IsSubquery() AndAlso 1 < m_Model.GetNotExcludedOrIgnoredEntityCount()
+      Dim columnAliases As String() = Nothing
+
       Dim first = True
+      Dim index = 0
 
       For i = 0 To m_Model.GetEntityCount() - 1
         Dim entity = m_Model.GetEntity(i)
 
         If Not entity.IsExcludedOrIgnored Then
           Dim formattedTableAlias = Me.DialectProvider.Formatter.CreateIdentifier(entity.TableAlias)
-          Dim properties = entity.Entity.GetProperties()
+          Dim columnsCount = entity.IncludedColumns.Length
+          Dim useColumnAliasesForModelEntity = useColumnAliasesForModelEntities AndAlso TypeOf entity Is EntityBasedSqlEntity
 
-          For j = 0 To properties.Count - 1
+          If useColumnAliasesForModelEntity Then
+            columnAliases = New String(columnsCount - 1) {}
+          End If
+
+          For j = 0 To columnsCount - 1
             If entity.IncludedColumns(j) Then
               If first Then
                 first = False
@@ -755,9 +891,22 @@ Namespace Expressions.Builders
 
               sql.Append(formattedTableAlias)
               sql.Append(".")
-              Me.DialectProvider.Formatter.AppendIdentifier(sql, properties(j).ColumnName)
+              Me.DialectProvider.Formatter.AppendIdentifier(sql, entity.GetColumnName(j))
+
+              If useColumnAliasesForModelEntity Then
+                Dim columnAlias = CreateColumnAlias(index)
+                sql.Append(" ")
+                Me.DialectProvider.Formatter.AppendIdentifier(sql, columnAlias)
+                columnAliases(j) = columnAlias
+              End If
+
+              index += 1
             End If
           Next
+
+          If useColumnAliasesForModelEntity Then
+            DirectCast(entity, EntityBasedSqlEntity).SetColumnAliases(columnAliases)
+          End If
 
           Dim includedSqlResults = entity.IncludedSqlResults
 
@@ -847,12 +996,30 @@ Namespace Expressions.Builders
     End Function
 
     ''' <summary>
+    ''' Creates SQL subquery.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <typeparam name="T"></typeparam>
+    ''' <returns></returns>
+    Public Function CreateSubquery(Of T)() As Subquery(Of T)
+      Return New Subquery(Of T)(CreateQuery())
+    End Function
+
+    ''' <summary>
+    ''' Gets parameter index.
+    ''' </summary>
+    ''' <returns></returns>
+    Private Function GetParameterIndex() As Int32
+      Return m_ParameterIndexOffset + m_Parameters.Count
+    End Function
+
+    ''' <summary>
     ''' Gets entity and property name from an expression.
     ''' </summary>
     ''' <param name="propertyExpression"></param>
     ''' <param name="excludeLastModelEntity"></param>
     ''' <returns></returns>
-    Private Function GetEntityAndProperty(propertyExpression As Expression, Optional excludeLastModelEntity As Boolean = False) As (EntityType As Type, Entity As SqlEntity, PropertyType As Type, PropertyName As String, NotFound As Boolean, MultipleResults As Boolean)
+    Private Function GetEntityAndProperty(propertyExpression As Expression, Optional excludeLastModelEntity As Boolean = False) As (EntityType As Type, Entity As SqlEntityBase, PropertyType As Type, PropertyName As String, NotFound As Boolean, MultipleResults As Boolean)
       If TypeOf propertyExpression IsNot LambdaExpression Then
         Throw New ArgumentException("Expression must be of type LambdaExpression.")
       End If
@@ -861,7 +1028,7 @@ Namespace Expressions.Builders
 
       Dim parameterType = lambda.Parameters(0).Type
       Dim returnType = lambda.ReturnType
-      Dim entity As SqlEntity = Nothing
+      Dim entity As SqlEntityBase = Nothing
       Dim propertyName As String = Nothing
       Dim notFound = False
       Dim multipleResults = False
@@ -891,7 +1058,7 @@ Namespace Expressions.Builders
         For i = 0 To count - 1
           Dim item = entities(i)
 
-          If item.Entity.EntityType Is parameterType Then
+          If item.EntityType Is parameterType Then
             If entity Is Nothing Then
               entity = item
 
@@ -912,6 +1079,23 @@ Namespace Expressions.Builders
       End If
 
       Return (parameterType, entity, returnType, propertyName, notFound, multipleResults)
+    End Function
+
+    ''' <summary>
+    ''' Gets whether this is a subquery.
+    ''' </summary>
+    ''' <returns></returns>
+    Private Function IsSubquery() As Boolean
+      Return Me.SubqueryContext IsNot Nothing
+    End Function
+
+    ''' <summary>
+    ''' Creates column alias.
+    ''' </summary>
+    ''' <param name="index"></param>
+    ''' <returns></returns>
+    Private Function CreateColumnAlias(index As Int32) As String
+      Return "C" & index.ToString(Globalization.CultureInfo.InvariantCulture)
     End Function
 
   End Class

--- a/Source/Source/Yamo/Expressions/Builders/SqlExpressionBuilderBase.vb
+++ b/Source/Source/Yamo/Expressions/Builders/SqlExpressionBuilderBase.vb
@@ -3,6 +3,7 @@ Imports System.Diagnostics.CodeAnalysis
 Imports System.Text
 Imports Yamo.Infrastructure
 Imports Yamo.Internal.Query
+Imports Yamo.Metadata
 Imports Yamo.Sql
 
 Namespace Expressions.Builders
@@ -17,13 +18,15 @@ Namespace Expressions.Builders
     ''' Gets dialect provider.<br/>
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
-    Public ReadOnly DialectProvider As SqlDialectProvider
+    ''' <returns></returns>
+    Public ReadOnly Property DialectProvider As SqlDialectProvider
 
     ''' <summary>
     ''' Gets context.<br/>
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
-    Public ReadOnly DbContext As DbContext
+    ''' <returns></returns>
+    Public ReadOnly Property DbContext As DbContext
 
     ''' <summary>
     ''' Creates new instance of <see cref="SqlExpressionBuilderBase"/>.<br/>
@@ -34,6 +37,22 @@ Namespace Expressions.Builders
       Me.DialectProvider = context.Options.DialectProvider
       Me.DbContext = context
     End Sub
+
+    ''' <summary>
+    ''' Gets main entity.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <param name="mainEntityType"></param>
+    ''' <returns></returns>
+    Protected Function GetMainEntity(<DisallowNull> mainEntityType As Type) As Entity
+      Dim entity = Me.DbContext.Model.TryGetEntity(mainEntityType)
+
+      If entity Is Nothing Then
+        Throw New Exception($"Entity '{mainEntityType}' is not defined in the model. Only model entities are supported as a main entity.")
+      End If
+
+      Return entity
+    End Function
 
     ''' <summary>
     ''' Creates SQL parameter.<br/>

--- a/Source/Source/Yamo/Expressions/Builders/UpdateSqlExpressionBuilder.vb
+++ b/Source/Source/Yamo/Expressions/Builders/UpdateSqlExpressionBuilder.vb
@@ -58,7 +58,7 @@ Namespace Expressions.Builders
     ''' <param name="tableNameOverride"></param>
     Public Sub New(<DisallowNull> context As DbContext, <DisallowNull> mainEntityType As Type, tableNameOverride As String)
       MyBase.New(context)
-      m_Model = New UpdateSqlModel(Me.DbContext.Model, mainEntityType)
+      m_Model = New UpdateSqlModel(GetMainEntity(mainEntityType))
       m_TableNameOverride = tableNameOverride
       m_TableHints = Nothing
       m_Visitor = New SqlExpressionVisitor(Me, m_Model)
@@ -189,7 +189,7 @@ Namespace Expressions.Builders
         Dim properties = entity.GetSetOnUpdateProperties()
 
         If 0 < properties.Count Then
-          Dim getter = EntityAutoFieldsGetterCache.GetOnUpdateGetter(m_Model.Model, entity.EntityType)
+          Dim getter = EntityAutoFieldsGetterCache.GetOnUpdateGetter(Me.DbContext.Model, entity.EntityType)
           Dim values = getter(Me.DbContext)
 
           For i = 0 To properties.Count - 1

--- a/Source/Source/Yamo/Expressions/CustomDistinctSelectSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/CustomDistinctSelectSqlExpression.vb
@@ -11,6 +11,7 @@ Namespace Expressions
   ''' <typeparam name="T"></typeparam>
   Public Class CustomDistinctSelectSqlExpression(Of T)
     Inherits SelectSqlExpressionBase
+    Implements ISubqueryableSelectSqlExpression(Of T)
 
     ''' <summary>
     ''' Creates new instance of <see cref="CustomDistinctSelectSqlExpression(Of T)"/>.
@@ -20,6 +21,14 @@ Namespace Expressions
     Friend Sub New(builder As SelectSqlExpressionBuilder, executor As QueryExecutor)
       MyBase.New(builder, executor)
     End Sub
+
+    ''' <summary>
+    ''' Creates SQL subquery.
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function ToSubquery() As Subquery(Of T) Implements ISubqueryableSelectSqlExpression(Of T).ToSubquery
+      Return Me.Builder.CreateSubquery(Of T)()
+    End Function
 
     ''' <summary>
     ''' Executes SQL query and returns list of records.

--- a/Source/Source/Yamo/Expressions/CustomSelectSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/CustomSelectSqlExpression.vb
@@ -11,6 +11,7 @@ Namespace Expressions
   ''' <typeparam name="T"></typeparam>
   Public Class CustomSelectSqlExpression(Of T)
     Inherits SelectSqlExpressionBase
+    Implements ISubqueryableSelectSqlExpression(Of T)
 
     ''' <summary>
     ''' Creates new instance of <see cref="CustomSelectSqlExpression(Of T)"/>.
@@ -28,6 +29,14 @@ Namespace Expressions
     Public Function Distinct() As CustomDistinctSelectSqlExpression(Of T)
       Me.Builder.AddDistinct()
       Return New CustomDistinctSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Creates SQL subquery.
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function ToSubquery() As Subquery(Of T) Implements ISubqueryableSelectSqlExpression(Of T).ToSubquery
+      Return Me.Builder.CreateSubquery(Of T)()
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/DistinctSelectSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/DistinctSelectSqlExpression.vb
@@ -11,6 +11,7 @@ Namespace Expressions
   ''' <typeparam name="T"></typeparam>
   Public Class DistinctSelectSqlExpression(Of T)
     Inherits SelectSqlExpressionBase
+    Implements ISubqueryableSelectSqlExpression(Of T)
 
     ''' <summary>
     ''' Creates new instance of <see cref="DistinctSelectSqlExpression(Of T)"/>.
@@ -20,6 +21,14 @@ Namespace Expressions
     Friend Sub New(builder As SelectSqlExpressionBuilder, executor As QueryExecutor)
       MyBase.New(builder, executor)
     End Sub
+
+    ''' <summary>
+    ''' Creates SQL subquery.
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function ToSubquery() As Subquery(Of T) Implements ISubqueryableSelectSqlExpression(Of T).ToSubquery
+      Return Me.Builder.CreateSubquery(Of T)()
+    End Function
 
     ''' <summary>
     ''' Executes SQL query and returns list of records.

--- a/Source/Source/Yamo/Expressions/IQueryableWithResultSelectSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/IQueryableWithResultSelectSqlExpression.vb
@@ -1,0 +1,21 @@
+﻿Imports System.Diagnostics.CodeAnalysis
+Imports System.Linq.Expressions
+Imports Yamo.Expressions.Builders
+Imports Yamo.Internal.Query
+
+Namespace Expressions
+
+  ''' <summary>
+  ''' Represents SQL SELECT statement with result of type <typeparamref name="T"/> that can act as a subquery.
+  ''' </summary>
+  ''' <typeparam name="T"></typeparam>
+  Public Interface ISubqueryableSelectSqlExpression(Of T)
+
+    ''' <summary>
+    ''' Creates SQL subquery.
+    ''' </summary>
+    ''' <returns></returns>
+    Function ToSubquery() As Subquery(Of T)
+
+  End Interface
+End Namespace

--- a/Source/Source/Yamo/Expressions/SelectSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpression.vb
@@ -25,6 +25,14 @@ Namespace Expressions
     ''' Creates new instance of <see cref="SelectSqlExpression(Of T)"/>.
     ''' </summary>
     ''' <param name="context"></param>
+    Friend Sub New(context As SubqueryContext)
+      MyBase.New(New SelectSqlExpressionBuilder(context, GetType(T)), context.Executor)
+    End Sub
+
+    ''' <summary>
+    ''' Creates new instance of <see cref="SelectSqlExpression(Of T)"/>.
+    ''' </summary>
+    ''' <param name="context"></param>
     ''' <param name="tableSource"></param>
     Friend Sub New(context As DbContext, tableSource As FormattableString)
       MyBase.New(New SelectSqlExpressionBuilder(context, GetType(T)), New QueryExecutor(context))
@@ -36,9 +44,30 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="context"></param>
     ''' <param name="tableSource"></param>
+    Friend Sub New(context As SubqueryContext, tableSource As FormattableString)
+      MyBase.New(New SelectSqlExpressionBuilder(context, GetType(T)), context.Executor)
+      Me.Builder.SetMainTableSource(tableSource)
+    End Sub
+
+    ''' <summary>
+    ''' Creates new instance of <see cref="SelectSqlExpression(Of T)"/>.
+    ''' </summary>
+    ''' <param name="context"></param>
+    ''' <param name="tableSource"></param>
     ''' <param name="parameters"></param>
     Friend Sub New(context As DbContext, tableSource As RawSqlString, ParamArray parameters() As Object)
       MyBase.New(New SelectSqlExpressionBuilder(context, GetType(T)), New QueryExecutor(context))
+      Me.Builder.SetMainTableSource(tableSource, parameters)
+    End Sub
+
+    ''' <summary>
+    ''' Creates new instance of <see cref="SelectSqlExpression(Of T)"/>.
+    ''' </summary>
+    ''' <param name="context"></param>
+    ''' <param name="tableSource"></param>
+    ''' <param name="parameters"></param>
+    Friend Sub New(context As SubqueryContext, tableSource As RawSqlString, ParamArray parameters() As Object)
+      MyBase.New(New SelectSqlExpressionBuilder(context, GetType(T)), context.Executor)
       Me.Builder.SetMainTableSource(tableSource, parameters)
     End Sub
 
@@ -79,6 +108,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function Join(Of TJoined)() As JoinSelectSqlExpression(Of T, TJoined)
       Return InternalJoin(Of TJoined)(JoinType.Inner)
+    End Function
+
+    ''' <summary>
+    ''' Adds INNER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory, behavior)
     End Function
 
     ''' <summary>
@@ -135,6 +175,17 @@ Namespace Expressions
     ''' Adds LEFT OUTER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds LEFT OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T, TJoined)
@@ -179,6 +230,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function RightJoin(Of TJoined)() As JoinSelectSqlExpression(Of T, TJoined)
       Return InternalJoin(Of TJoined)(JoinType.RightOuter)
+    End Function
+
+    ''' <summary>
+    ''' Adds RIGHT OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory, behavior)
     End Function
 
     ''' <summary>
@@ -235,6 +297,17 @@ Namespace Expressions
     ''' Adds FULL OUTER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds FULL OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function FullJoin(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T, TJoined)
@@ -259,6 +332,19 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function CrossJoin(Of TJoined)() As JoinedSelectSqlExpression(Of T, TJoined)
       Return InternalJoin(Of TJoined)(JoinType.CrossJoin, Nothing, {0, 1})
+    End Function
+
+    ''' <summary>
+    ''' Adds CROSS JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinedSelectSqlExpression(Of T, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory, behavior)
+      Me.Builder.AddOn(Of TJoined)(Nothing, {0, 1})
+      Return New JoinedSelectSqlExpression(Of T, TJoined)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>
@@ -307,6 +393,19 @@ Namespace Expressions
     ''' <returns></returns>
     Private Function InternalJoin(Of TJoined)(joinType As JoinType) As JoinSelectSqlExpression(Of T, TJoined)
       Me.Builder.AddJoin(Of TJoined)(joinType)
+      Return New JoinSelectSqlExpression(Of T, TJoined)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="joinType"></param>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), behavior As NonModelEntityCreationBehavior) As JoinSelectSqlExpression(Of T, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory, behavior)
       Return New JoinSelectSqlExpression(Of T, TJoined)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2.vb
@@ -76,6 +76,17 @@ Namespace Expressions
     ''' Adds INNER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds INNER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function Join(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, TJoined)
@@ -140,6 +151,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function LeftJoin(Of TJoined)() As JoinSelectSqlExpression(Of T1, T2, TJoined)
       Return InternalJoin(Of TJoined)(JoinType.LeftOuter)
+    End Function
+
+    ''' <summary>
+    ''' Adds LEFT OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory, behavior)
     End Function
 
     ''' <summary>
@@ -216,6 +238,17 @@ Namespace Expressions
     ''' Adds RIGHT OUTER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds RIGHT OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function RightJoin(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, TJoined)
@@ -286,6 +319,17 @@ Namespace Expressions
     ''' Adds FULL OUTER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds FULL OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function FullJoin(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, TJoined)
@@ -310,6 +354,19 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function CrossJoin(Of TJoined)() As JoinedSelectSqlExpression(Of T1, T2, TJoined)
       Return InternalJoin(Of TJoined)(JoinType.CrossJoin, Nothing, {0, 1})
+    End Function
+
+    ''' <summary>
+    ''' Adds CROSS JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinedSelectSqlExpression(Of T1, T2, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory, behavior)
+      Me.Builder.AddOn(Of TJoined)(Nothing, {0, 1})
+      Return New JoinedSelectSqlExpression(Of T1, T2, TJoined)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>
@@ -358,6 +415,19 @@ Namespace Expressions
     ''' <returns></returns>
     Private Function InternalJoin(Of TJoined)(joinType As JoinType) As JoinSelectSqlExpression(Of T1, T2, TJoined)
       Me.Builder.AddJoin(Of TJoined)(joinType)
+      Return New JoinSelectSqlExpression(Of T1, T2, TJoined)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="joinType"></param>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), behavior As NonModelEntityCreationBehavior) As JoinSelectSqlExpression(Of T1, T2, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory, behavior)
       Return New JoinSelectSqlExpression(Of T1, T2, TJoined)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3.vb
@@ -77,6 +77,17 @@ Namespace Expressions
     ''' Adds INNER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds INNER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function Join(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, TJoined)
@@ -141,6 +152,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function LeftJoin(Of TJoined)() As JoinSelectSqlExpression(Of T1, T2, T3, TJoined)
       Return InternalJoin(Of TJoined)(JoinType.LeftOuter)
+    End Function
+
+    ''' <summary>
+    ''' Adds LEFT OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory, behavior)
     End Function
 
     ''' <summary>
@@ -217,6 +239,17 @@ Namespace Expressions
     ''' Adds RIGHT OUTER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds RIGHT OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function RightJoin(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, TJoined)
@@ -287,6 +320,17 @@ Namespace Expressions
     ''' Adds FULL OUTER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds FULL OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function FullJoin(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, TJoined)
@@ -311,6 +355,19 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function CrossJoin(Of TJoined)() As JoinedSelectSqlExpression(Of T1, T2, T3, TJoined)
       Return InternalJoin(Of TJoined)(JoinType.CrossJoin, Nothing, {0, 1})
+    End Function
+
+    ''' <summary>
+    ''' Adds CROSS JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinedSelectSqlExpression(Of T1, T2, T3, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory, behavior)
+      Me.Builder.AddOn(Of TJoined)(Nothing, {0, 1})
+      Return New JoinedSelectSqlExpression(Of T1, T2, T3, TJoined)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>
@@ -359,6 +416,19 @@ Namespace Expressions
     ''' <returns></returns>
     Private Function InternalJoin(Of TJoined)(joinType As JoinType) As JoinSelectSqlExpression(Of T1, T2, T3, TJoined)
       Me.Builder.AddJoin(Of TJoined)(joinType)
+      Return New JoinSelectSqlExpression(Of T1, T2, T3, TJoined)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="joinType"></param>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), behavior As NonModelEntityCreationBehavior) As JoinSelectSqlExpression(Of T1, T2, T3, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory, behavior)
       Return New JoinSelectSqlExpression(Of T1, T2, T3, TJoined)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4.vb
@@ -88,6 +88,17 @@ Namespace Expressions
     ''' Adds INNER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds INNER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function Join(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, TJoined)
@@ -162,6 +173,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function LeftJoin(Of TJoined)() As JoinSelectSqlExpression(Of T1, T2, T3, T4, TJoined)
       Return InternalJoin(Of TJoined)(JoinType.LeftOuter)
+    End Function
+
+    ''' <summary>
+    ''' Adds LEFT OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory, behavior)
     End Function
 
     ''' <summary>
@@ -248,6 +270,17 @@ Namespace Expressions
     ''' Adds RIGHT OUTER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds RIGHT OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function RightJoin(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, TJoined)
@@ -328,6 +361,17 @@ Namespace Expressions
     ''' Adds FULL OUTER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds FULL OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function FullJoin(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, TJoined)
@@ -352,6 +396,19 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function CrossJoin(Of TJoined)() As JoinedSelectSqlExpression(Of T1, T2, T3, T4, TJoined)
       Return InternalJoin(Of TJoined)(JoinType.CrossJoin, Nothing, {0, 1})
+    End Function
+
+    ''' <summary>
+    ''' Adds CROSS JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory, behavior)
+      Me.Builder.AddOn(Of TJoined)(Nothing, {0, 1})
+      Return New JoinedSelectSqlExpression(Of T1, T2, T3, T4, TJoined)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>
@@ -400,6 +457,19 @@ Namespace Expressions
     ''' <returns></returns>
     Private Function InternalJoin(Of TJoined)(joinType As JoinType) As JoinSelectSqlExpression(Of T1, T2, T3, T4, TJoined)
       Me.Builder.AddJoin(Of TJoined)(joinType)
+      Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, TJoined)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="joinType"></param>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), behavior As NonModelEntityCreationBehavior) As JoinSelectSqlExpression(Of T1, T2, T3, T4, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory, behavior)
       Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, TJoined)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5.vb
@@ -99,6 +99,17 @@ Namespace Expressions
     ''' Adds INNER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds INNER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function Join(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, TJoined)
@@ -183,6 +194,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function LeftJoin(Of TJoined)() As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, TJoined)
       Return InternalJoin(Of TJoined)(JoinType.LeftOuter)
+    End Function
+
+    ''' <summary>
+    ''' Adds LEFT OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory, behavior)
     End Function
 
     ''' <summary>
@@ -279,6 +301,17 @@ Namespace Expressions
     ''' Adds RIGHT OUTER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds RIGHT OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function RightJoin(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, TJoined)
@@ -369,6 +402,17 @@ Namespace Expressions
     ''' Adds FULL OUTER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds FULL OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function FullJoin(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, TJoined)
@@ -393,6 +437,19 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function CrossJoin(Of TJoined)() As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, TJoined)
       Return InternalJoin(Of TJoined)(JoinType.CrossJoin, Nothing, {0, 1})
+    End Function
+
+    ''' <summary>
+    ''' Adds CROSS JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory, behavior)
+      Me.Builder.AddOn(Of TJoined)(Nothing, {0, 1})
+      Return New JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, TJoined)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>
@@ -441,6 +498,19 @@ Namespace Expressions
     ''' <returns></returns>
     Private Function InternalJoin(Of TJoined)(joinType As JoinType) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, TJoined)
       Me.Builder.AddJoin(Of TJoined)(joinType)
+      Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, TJoined)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="joinType"></param>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), behavior As NonModelEntityCreationBehavior) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory, behavior)
       Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, TJoined)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6.vb
@@ -110,6 +110,17 @@ Namespace Expressions
     ''' Adds INNER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds INNER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function Join(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, TJoined)
@@ -204,6 +215,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function LeftJoin(Of TJoined)() As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, TJoined)
       Return InternalJoin(Of TJoined)(JoinType.LeftOuter)
+    End Function
+
+    ''' <summary>
+    ''' Adds LEFT OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory, behavior)
     End Function
 
     ''' <summary>
@@ -310,6 +332,17 @@ Namespace Expressions
     ''' Adds RIGHT OUTER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds RIGHT OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function RightJoin(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, TJoined)
@@ -410,6 +443,17 @@ Namespace Expressions
     ''' Adds FULL OUTER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds FULL OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function FullJoin(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, TJoined)
@@ -434,6 +478,19 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function CrossJoin(Of TJoined)() As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, TJoined)
       Return InternalJoin(Of TJoined)(JoinType.CrossJoin, Nothing, {0, 1})
+    End Function
+
+    ''' <summary>
+    ''' Adds CROSS JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory, behavior)
+      Me.Builder.AddOn(Of TJoined)(Nothing, {0, 1})
+      Return New JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, TJoined)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>
@@ -482,6 +539,19 @@ Namespace Expressions
     ''' <returns></returns>
     Private Function InternalJoin(Of TJoined)(joinType As JoinType) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, TJoined)
       Me.Builder.AddJoin(Of TJoined)(joinType)
+      Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, TJoined)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="joinType"></param>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), behavior As NonModelEntityCreationBehavior) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory, behavior)
       Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, TJoined)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7.vb
@@ -51,6 +51,17 @@ Namespace Expressions
     ''' Adds INNER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds INNER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function Join(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, TJoined)
@@ -85,6 +96,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function LeftJoin(Of TJoined)() As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, TJoined)
       Return InternalJoin(Of TJoined)(JoinType.LeftOuter)
+    End Function
+
+    ''' <summary>
+    ''' Adds LEFT OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory, behavior)
     End Function
 
     ''' <summary>
@@ -131,6 +153,17 @@ Namespace Expressions
     ''' Adds RIGHT OUTER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds RIGHT OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function RightJoin(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, TJoined)
@@ -171,6 +204,17 @@ Namespace Expressions
     ''' Adds FULL OUTER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds FULL OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function FullJoin(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, TJoined)
@@ -195,6 +239,19 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function CrossJoin(Of TJoined)() As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, TJoined)
       Return InternalJoin(Of TJoined)(JoinType.CrossJoin, Nothing, {0, 1})
+    End Function
+
+    ''' <summary>
+    ''' Adds CROSS JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory, behavior)
+      Me.Builder.AddOn(Of TJoined)(Nothing, {0, 1})
+      Return New JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, TJoined)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>
@@ -243,6 +300,19 @@ Namespace Expressions
     ''' <returns></returns>
     Private Function InternalJoin(Of TJoined)(joinType As JoinType) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, TJoined)
       Me.Builder.AddJoin(Of TJoined)(joinType)
+      Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, TJoined)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="joinType"></param>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), behavior As NonModelEntityCreationBehavior) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory, behavior)
       Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, TJoined)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
@@ -52,6 +52,17 @@ Namespace Expressions
     ''' Adds INNER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds INNER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function Join(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, TJoined)
@@ -86,6 +97,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function LeftJoin(Of TJoined)() As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, TJoined)
       Return InternalJoin(Of TJoined)(JoinType.LeftOuter)
+    End Function
+
+    ''' <summary>
+    ''' Adds LEFT OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory, behavior)
     End Function
 
     ''' <summary>
@@ -132,6 +154,17 @@ Namespace Expressions
     ''' Adds RIGHT OUTER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds RIGHT OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function RightJoin(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, TJoined)
@@ -172,6 +205,17 @@ Namespace Expressions
     ''' Adds FULL OUTER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds FULL OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function FullJoin(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, TJoined)
@@ -196,6 +240,19 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function CrossJoin(Of TJoined)() As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, TJoined)
       Return InternalJoin(Of TJoined)(JoinType.CrossJoin, Nothing, {0, 1})
+    End Function
+
+    ''' <summary>
+    ''' Adds CROSS JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory, behavior)
+      Me.Builder.AddOn(Of TJoined)(Nothing, {0, 1})
+      Return New JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, TJoined)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>
@@ -244,6 +301,19 @@ Namespace Expressions
     ''' <returns></returns>
     Private Function InternalJoin(Of TJoined)(joinType As JoinType) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, TJoined)
       Me.Builder.AddJoin(Of TJoined)(joinType)
+      Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, TJoined)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="joinType"></param>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), behavior As NonModelEntityCreationBehavior) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory, behavior)
       Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, TJoined)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
@@ -53,6 +53,17 @@ Namespace Expressions
     ''' Adds INNER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds INNER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function Join(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, TJoined)
@@ -87,6 +98,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function LeftJoin(Of TJoined)() As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, TJoined)
       Return InternalJoin(Of TJoined)(JoinType.LeftOuter)
+    End Function
+
+    ''' <summary>
+    ''' Adds LEFT OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory, behavior)
     End Function
 
     ''' <summary>
@@ -133,6 +155,17 @@ Namespace Expressions
     ''' Adds RIGHT OUTER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds RIGHT OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function RightJoin(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, TJoined)
@@ -173,6 +206,17 @@ Namespace Expressions
     ''' Adds FULL OUTER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds FULL OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function FullJoin(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, TJoined)
@@ -197,6 +241,19 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function CrossJoin(Of TJoined)() As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, TJoined)
       Return InternalJoin(Of TJoined)(JoinType.CrossJoin, Nothing, {0, 1})
+    End Function
+
+    ''' <summary>
+    ''' Adds CROSS JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory, behavior)
+      Me.Builder.AddOn(Of TJoined)(Nothing, {0, 1})
+      Return New JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, TJoined)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>
@@ -245,6 +302,19 @@ Namespace Expressions
     ''' <returns></returns>
     Private Function InternalJoin(Of TJoined)(joinType As JoinType) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, TJoined)
       Me.Builder.AddJoin(Of TJoined)(joinType)
+      Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, TJoined)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="joinType"></param>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), behavior As NonModelEntityCreationBehavior) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory, behavior)
       Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, TJoined)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
@@ -54,6 +54,17 @@ Namespace Expressions
     ''' Adds INNER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds INNER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function Join(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TJoined)
@@ -88,6 +99,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function LeftJoin(Of TJoined)() As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TJoined)
       Return InternalJoin(Of TJoined)(JoinType.LeftOuter)
+    End Function
+
+    ''' <summary>
+    ''' Adds LEFT OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory, behavior)
     End Function
 
     ''' <summary>
@@ -134,6 +156,17 @@ Namespace Expressions
     ''' Adds RIGHT OUTER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds RIGHT OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function RightJoin(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TJoined)
@@ -174,6 +207,17 @@ Namespace Expressions
     ''' Adds FULL OUTER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds FULL OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function FullJoin(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TJoined)
@@ -198,6 +242,19 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function CrossJoin(Of TJoined)() As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TJoined)
       Return InternalJoin(Of TJoined)(JoinType.CrossJoin, Nothing, {0, 1})
+    End Function
+
+    ''' <summary>
+    ''' Adds CROSS JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory, behavior)
+      Me.Builder.AddOn(Of TJoined)(Nothing, {0, 1})
+      Return New JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TJoined)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>
@@ -246,6 +303,19 @@ Namespace Expressions
     ''' <returns></returns>
     Private Function InternalJoin(Of TJoined)(joinType As JoinType) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TJoined)
       Me.Builder.AddJoin(Of TJoined)(joinType)
+      Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TJoined)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="joinType"></param>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), behavior As NonModelEntityCreationBehavior) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory, behavior)
       Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, TJoined)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
@@ -55,6 +55,17 @@ Namespace Expressions
     ''' Adds INNER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds INNER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function Join(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TJoined)
@@ -89,6 +100,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function LeftJoin(Of TJoined)() As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TJoined)
       Return InternalJoin(Of TJoined)(JoinType.LeftOuter)
+    End Function
+
+    ''' <summary>
+    ''' Adds LEFT OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory, behavior)
     End Function
 
     ''' <summary>
@@ -135,6 +157,17 @@ Namespace Expressions
     ''' Adds RIGHT OUTER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds RIGHT OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function RightJoin(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TJoined)
@@ -175,6 +208,17 @@ Namespace Expressions
     ''' Adds FULL OUTER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds FULL OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function FullJoin(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TJoined)
@@ -199,6 +243,19 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function CrossJoin(Of TJoined)() As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TJoined)
       Return InternalJoin(Of TJoined)(JoinType.CrossJoin, Nothing, {0, 1})
+    End Function
+
+    ''' <summary>
+    ''' Adds CROSS JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory, behavior)
+      Me.Builder.AddOn(Of TJoined)(Nothing, {0, 1})
+      Return New JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TJoined)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>
@@ -247,6 +304,19 @@ Namespace Expressions
     ''' <returns></returns>
     Private Function InternalJoin(Of TJoined)(joinType As JoinType) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TJoined)
       Me.Builder.AddJoin(Of TJoined)(joinType)
+      Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TJoined)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="joinType"></param>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), behavior As NonModelEntityCreationBehavior) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory, behavior)
       Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, TJoined)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
@@ -56,6 +56,17 @@ Namespace Expressions
     ''' Adds INNER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds INNER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function Join(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TJoined)
@@ -90,6 +101,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function LeftJoin(Of TJoined)() As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TJoined)
       Return InternalJoin(Of TJoined)(JoinType.LeftOuter)
+    End Function
+
+    ''' <summary>
+    ''' Adds LEFT OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory, behavior)
     End Function
 
     ''' <summary>
@@ -136,6 +158,17 @@ Namespace Expressions
     ''' Adds RIGHT OUTER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds RIGHT OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function RightJoin(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TJoined)
@@ -176,6 +209,17 @@ Namespace Expressions
     ''' Adds FULL OUTER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds FULL OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function FullJoin(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TJoined)
@@ -200,6 +244,19 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function CrossJoin(Of TJoined)() As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TJoined)
       Return InternalJoin(Of TJoined)(JoinType.CrossJoin, Nothing, {0, 1})
+    End Function
+
+    ''' <summary>
+    ''' Adds CROSS JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory, behavior)
+      Me.Builder.AddOn(Of TJoined)(Nothing, {0, 1})
+      Return New JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TJoined)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>
@@ -248,6 +305,19 @@ Namespace Expressions
     ''' <returns></returns>
     Private Function InternalJoin(Of TJoined)(joinType As JoinType) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TJoined)
       Me.Builder.AddJoin(Of TJoined)(joinType)
+      Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TJoined)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="joinType"></param>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), behavior As NonModelEntityCreationBehavior) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory, behavior)
       Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, TJoined)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
@@ -57,6 +57,17 @@ Namespace Expressions
     ''' Adds INNER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds INNER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function Join(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TJoined)
@@ -91,6 +102,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function LeftJoin(Of TJoined)() As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TJoined)
       Return InternalJoin(Of TJoined)(JoinType.LeftOuter)
+    End Function
+
+    ''' <summary>
+    ''' Adds LEFT OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory, behavior)
     End Function
 
     ''' <summary>
@@ -137,6 +159,17 @@ Namespace Expressions
     ''' Adds RIGHT OUTER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds RIGHT OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function RightJoin(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TJoined)
@@ -177,6 +210,17 @@ Namespace Expressions
     ''' Adds FULL OUTER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds FULL OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function FullJoin(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TJoined)
@@ -201,6 +245,19 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function CrossJoin(Of TJoined)() As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TJoined)
       Return InternalJoin(Of TJoined)(JoinType.CrossJoin, Nothing, {0, 1})
+    End Function
+
+    ''' <summary>
+    ''' Adds CROSS JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory, behavior)
+      Me.Builder.AddOn(Of TJoined)(Nothing, {0, 1})
+      Return New JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TJoined)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>
@@ -249,6 +306,19 @@ Namespace Expressions
     ''' <returns></returns>
     Private Function InternalJoin(Of TJoined)(joinType As JoinType) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TJoined)
       Me.Builder.AddJoin(Of TJoined)(joinType)
+      Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TJoined)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="joinType"></param>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), behavior As NonModelEntityCreationBehavior) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory, behavior)
       Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, TJoined)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
@@ -58,6 +58,17 @@ Namespace Expressions
     ''' Adds INNER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds INNER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function Join(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TJoined)
@@ -92,6 +103,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function LeftJoin(Of TJoined)() As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TJoined)
       Return InternalJoin(Of TJoined)(JoinType.LeftOuter)
+    End Function
+
+    ''' <summary>
+    ''' Adds LEFT OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory, behavior)
     End Function
 
     ''' <summary>
@@ -138,6 +160,17 @@ Namespace Expressions
     ''' Adds RIGHT OUTER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds RIGHT OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function RightJoin(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TJoined)
@@ -178,6 +211,17 @@ Namespace Expressions
     ''' Adds FULL OUTER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds FULL OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function FullJoin(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TJoined)
@@ -202,6 +246,19 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function CrossJoin(Of TJoined)() As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TJoined)
       Return InternalJoin(Of TJoined)(JoinType.CrossJoin, Nothing, {0, 1})
+    End Function
+
+    ''' <summary>
+    ''' Adds CROSS JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory, behavior)
+      Me.Builder.AddOn(Of TJoined)(Nothing, {0, 1})
+      Return New JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TJoined)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>
@@ -250,6 +307,19 @@ Namespace Expressions
     ''' <returns></returns>
     Private Function InternalJoin(Of TJoined)(joinType As JoinType) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TJoined)
       Me.Builder.AddJoin(Of TJoined)(joinType)
+      Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TJoined)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="joinType"></param>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), behavior As NonModelEntityCreationBehavior) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory, behavior)
       Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, TJoined)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
@@ -59,6 +59,17 @@ Namespace Expressions
     ''' Adds INNER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds INNER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function Join(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TJoined)
@@ -93,6 +104,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function LeftJoin(Of TJoined)() As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TJoined)
       Return InternalJoin(Of TJoined)(JoinType.LeftOuter)
+    End Function
+
+    ''' <summary>
+    ''' Adds LEFT OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory, behavior)
     End Function
 
     ''' <summary>
@@ -139,6 +161,17 @@ Namespace Expressions
     ''' Adds RIGHT OUTER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds RIGHT OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function RightJoin(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TJoined)
@@ -179,6 +212,17 @@ Namespace Expressions
     ''' Adds FULL OUTER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds FULL OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function FullJoin(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TJoined)
@@ -203,6 +247,19 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function CrossJoin(Of TJoined)() As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TJoined)
       Return InternalJoin(Of TJoined)(JoinType.CrossJoin, Nothing, {0, 1})
+    End Function
+
+    ''' <summary>
+    ''' Adds CROSS JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory, behavior)
+      Me.Builder.AddOn(Of TJoined)(Nothing, {0, 1})
+      Return New JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TJoined)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>
@@ -251,6 +308,19 @@ Namespace Expressions
     ''' <returns></returns>
     Private Function InternalJoin(Of TJoined)(joinType As JoinType) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TJoined)
       Me.Builder.AddJoin(Of TJoined)(joinType)
+      Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TJoined)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="joinType"></param>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), behavior As NonModelEntityCreationBehavior) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory, behavior)
       Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, TJoined)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
@@ -60,6 +60,17 @@ Namespace Expressions
     ''' Adds INNER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds INNER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function Join(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TJoined)
@@ -94,6 +105,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function LeftJoin(Of TJoined)() As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TJoined)
       Return InternalJoin(Of TJoined)(JoinType.LeftOuter)
+    End Function
+
+    ''' <summary>
+    ''' Adds LEFT OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory, behavior)
     End Function
 
     ''' <summary>
@@ -140,6 +162,17 @@ Namespace Expressions
     ''' Adds RIGHT OUTER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds RIGHT OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function RightJoin(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TJoined)
@@ -180,6 +213,17 @@ Namespace Expressions
     ''' Adds FULL OUTER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds FULL OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function FullJoin(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TJoined)
@@ -204,6 +248,19 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function CrossJoin(Of TJoined)() As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TJoined)
       Return InternalJoin(Of TJoined)(JoinType.CrossJoin, Nothing, {0, 1})
+    End Function
+
+    ''' <summary>
+    ''' Adds CROSS JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory, behavior)
+      Me.Builder.AddOn(Of TJoined)(Nothing, {0, 1})
+      Return New JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TJoined)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>
@@ -252,6 +309,19 @@ Namespace Expressions
     ''' <returns></returns>
     Private Function InternalJoin(Of TJoined)(joinType As JoinType) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TJoined)
       Me.Builder.AddJoin(Of TJoined)(joinType)
+      Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TJoined)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="joinType"></param>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), behavior As NonModelEntityCreationBehavior) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory, behavior)
       Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, TJoined)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
@@ -61,6 +61,17 @@ Namespace Expressions
     ''' Adds INNER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds INNER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function Join(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, TJoined)
@@ -95,6 +106,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function LeftJoin(Of TJoined)() As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, TJoined)
       Return InternalJoin(Of TJoined)(JoinType.LeftOuter)
+    End Function
+
+    ''' <summary>
+    ''' Adds LEFT OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory, behavior)
     End Function
 
     ''' <summary>
@@ -141,6 +163,17 @@ Namespace Expressions
     ''' Adds RIGHT OUTER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds RIGHT OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function RightJoin(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, TJoined)
@@ -181,6 +214,17 @@ Namespace Expressions
     ''' Adds FULL OUTER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds FULL OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function FullJoin(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, TJoined)
@@ -205,6 +249,19 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function CrossJoin(Of TJoined)() As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, TJoined)
       Return InternalJoin(Of TJoined)(JoinType.CrossJoin, Nothing, {0, 1})
+    End Function
+
+    ''' <summary>
+    ''' Adds CROSS JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory, behavior)
+      Me.Builder.AddOn(Of TJoined)(Nothing, {0, 1})
+      Return New JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, TJoined)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>
@@ -253,6 +310,19 @@ Namespace Expressions
     ''' <returns></returns>
     Private Function InternalJoin(Of TJoined)(joinType As JoinType) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, TJoined)
       Me.Builder.AddJoin(Of TJoined)(joinType)
+      Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, TJoined)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="joinType"></param>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), behavior As NonModelEntityCreationBehavior) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory, behavior)
       Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, TJoined)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
@@ -62,6 +62,17 @@ Namespace Expressions
     ''' Adds INNER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds INNER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function Join(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, TJoined)
@@ -96,6 +107,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function LeftJoin(Of TJoined)() As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, TJoined)
       Return InternalJoin(Of TJoined)(JoinType.LeftOuter)
+    End Function
+
+    ''' <summary>
+    ''' Adds LEFT OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory, behavior)
     End Function
 
     ''' <summary>
@@ -142,6 +164,17 @@ Namespace Expressions
     ''' Adds RIGHT OUTER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds RIGHT OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function RightJoin(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, TJoined)
@@ -182,6 +215,17 @@ Namespace Expressions
     ''' Adds FULL OUTER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds FULL OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function FullJoin(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, TJoined)
@@ -206,6 +250,19 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function CrossJoin(Of TJoined)() As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, TJoined)
       Return InternalJoin(Of TJoined)(JoinType.CrossJoin, Nothing, {0, 1})
+    End Function
+
+    ''' <summary>
+    ''' Adds CROSS JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory, behavior)
+      Me.Builder.AddOn(Of TJoined)(Nothing, {0, 1})
+      Return New JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, TJoined)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>
@@ -254,6 +311,19 @@ Namespace Expressions
     ''' <returns></returns>
     Private Function InternalJoin(Of TJoined)(joinType As JoinType) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, TJoined)
       Me.Builder.AddJoin(Of TJoined)(joinType)
+      Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, TJoined)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="joinType"></param>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), behavior As NonModelEntityCreationBehavior) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory, behavior)
       Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, TJoined)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
@@ -63,6 +63,17 @@ Namespace Expressions
     ''' Adds INNER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds INNER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function Join(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, TJoined)
@@ -97,6 +108,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function LeftJoin(Of TJoined)() As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, TJoined)
       Return InternalJoin(Of TJoined)(JoinType.LeftOuter)
+    End Function
+
+    ''' <summary>
+    ''' Adds LEFT OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory, behavior)
     End Function
 
     ''' <summary>
@@ -143,6 +165,17 @@ Namespace Expressions
     ''' Adds RIGHT OUTER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds RIGHT OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function RightJoin(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, TJoined)
@@ -183,6 +216,17 @@ Namespace Expressions
     ''' Adds FULL OUTER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds FULL OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function FullJoin(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, TJoined)
@@ -207,6 +251,19 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function CrossJoin(Of TJoined)() As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, TJoined)
       Return InternalJoin(Of TJoined)(JoinType.CrossJoin, Nothing, {0, 1})
+    End Function
+
+    ''' <summary>
+    ''' Adds CROSS JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory, behavior)
+      Me.Builder.AddOn(Of TJoined)(Nothing, {0, 1})
+      Return New JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, TJoined)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>
@@ -255,6 +312,19 @@ Namespace Expressions
     ''' <returns></returns>
     Private Function InternalJoin(Of TJoined)(joinType As JoinType) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, TJoined)
       Me.Builder.AddJoin(Of TJoined)(joinType)
+      Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, TJoined)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="joinType"></param>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), behavior As NonModelEntityCreationBehavior) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory, behavior)
       Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, TJoined)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
@@ -64,6 +64,17 @@ Namespace Expressions
     ''' Adds INNER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds INNER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function Join(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, TJoined)
@@ -98,6 +109,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function LeftJoin(Of TJoined)() As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, TJoined)
       Return InternalJoin(Of TJoined)(JoinType.LeftOuter)
+    End Function
+
+    ''' <summary>
+    ''' Adds LEFT OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory, behavior)
     End Function
 
     ''' <summary>
@@ -144,6 +166,17 @@ Namespace Expressions
     ''' Adds RIGHT OUTER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds RIGHT OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function RightJoin(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, TJoined)
@@ -184,6 +217,17 @@ Namespace Expressions
     ''' Adds FULL OUTER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds FULL OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function FullJoin(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, TJoined)
@@ -208,6 +252,19 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function CrossJoin(Of TJoined)() As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, TJoined)
       Return InternalJoin(Of TJoined)(JoinType.CrossJoin, Nothing, {0, 1})
+    End Function
+
+    ''' <summary>
+    ''' Adds CROSS JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory, behavior)
+      Me.Builder.AddOn(Of TJoined)(Nothing, {0, 1})
+      Return New JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, TJoined)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>
@@ -256,6 +313,19 @@ Namespace Expressions
     ''' <returns></returns>
     Private Function InternalJoin(Of TJoined)(joinType As JoinType) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, TJoined)
       Me.Builder.AddJoin(Of TJoined)(joinType)
+      Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, TJoined)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="joinType"></param>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), behavior As NonModelEntityCreationBehavior) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory, behavior)
       Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, TJoined)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
@@ -65,6 +65,17 @@ Namespace Expressions
     ''' Adds INNER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds INNER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function Join(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, TJoined)
@@ -99,6 +110,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function LeftJoin(Of TJoined)() As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, TJoined)
       Return InternalJoin(Of TJoined)(JoinType.LeftOuter)
+    End Function
+
+    ''' <summary>
+    ''' Adds LEFT OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory, behavior)
     End Function
 
     ''' <summary>
@@ -145,6 +167,17 @@ Namespace Expressions
     ''' Adds RIGHT OUTER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds RIGHT OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function RightJoin(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, TJoined)
@@ -185,6 +218,17 @@ Namespace Expressions
     ''' Adds FULL OUTER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds FULL OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function FullJoin(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, TJoined)
@@ -209,6 +253,19 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function CrossJoin(Of TJoined)() As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, TJoined)
       Return InternalJoin(Of TJoined)(JoinType.CrossJoin, Nothing, {0, 1})
+    End Function
+
+    ''' <summary>
+    ''' Adds CROSS JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory, behavior)
+      Me.Builder.AddOn(Of TJoined)(Nothing, {0, 1})
+      Return New JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, TJoined)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>
@@ -257,6 +314,19 @@ Namespace Expressions
     ''' <returns></returns>
     Private Function InternalJoin(Of TJoined)(joinType As JoinType) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, TJoined)
       Me.Builder.AddJoin(Of TJoined)(joinType)
+      Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, TJoined)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="joinType"></param>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), behavior As NonModelEntityCreationBehavior) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory, behavior)
       Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, TJoined)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
@@ -66,6 +66,17 @@ Namespace Expressions
     ''' Adds INNER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds INNER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function Join(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, TJoined)
@@ -100,6 +111,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function LeftJoin(Of TJoined)() As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, TJoined)
       Return InternalJoin(Of TJoined)(JoinType.LeftOuter)
+    End Function
+
+    ''' <summary>
+    ''' Adds LEFT OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory, behavior)
     End Function
 
     ''' <summary>
@@ -146,6 +168,17 @@ Namespace Expressions
     ''' Adds RIGHT OUTER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds RIGHT OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function RightJoin(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, TJoined)
@@ -186,6 +219,17 @@ Namespace Expressions
     ''' Adds FULL OUTER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds FULL OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function FullJoin(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, TJoined)
@@ -210,6 +254,19 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function CrossJoin(Of TJoined)() As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, TJoined)
       Return InternalJoin(Of TJoined)(JoinType.CrossJoin, Nothing, {0, 1})
+    End Function
+
+    ''' <summary>
+    ''' Adds CROSS JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory, behavior)
+      Me.Builder.AddOn(Of TJoined)(Nothing, {0, 1})
+      Return New JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, TJoined)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>
@@ -258,6 +315,19 @@ Namespace Expressions
     ''' <returns></returns>
     Private Function InternalJoin(Of TJoined)(joinType As JoinType) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, TJoined)
       Me.Builder.AddJoin(Of TJoined)(joinType)
+      Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, TJoined)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="joinType"></param>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), behavior As NonModelEntityCreationBehavior) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory, behavior)
       Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, TJoined)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
@@ -67,6 +67,17 @@ Namespace Expressions
     ''' Adds INNER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds INNER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function Join(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, TJoined)
@@ -101,6 +112,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function LeftJoin(Of TJoined)() As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, TJoined)
       Return InternalJoin(Of TJoined)(JoinType.LeftOuter)
+    End Function
+
+    ''' <summary>
+    ''' Adds LEFT OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory, behavior)
     End Function
 
     ''' <summary>
@@ -147,6 +169,17 @@ Namespace Expressions
     ''' Adds RIGHT OUTER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds RIGHT OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function RightJoin(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, TJoined)
@@ -187,6 +220,17 @@ Namespace Expressions
     ''' Adds FULL OUTER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds FULL OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function FullJoin(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, TJoined)
@@ -211,6 +255,19 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function CrossJoin(Of TJoined)() As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, TJoined)
       Return InternalJoin(Of TJoined)(JoinType.CrossJoin, Nothing, {0, 1})
+    End Function
+
+    ''' <summary>
+    ''' Adds CROSS JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory, behavior)
+      Me.Builder.AddOn(Of TJoined)(Nothing, {0, 1})
+      Return New JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, TJoined)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>
@@ -259,6 +316,19 @@ Namespace Expressions
     ''' <returns></returns>
     Private Function InternalJoin(Of TJoined)(joinType As JoinType) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, TJoined)
       Me.Builder.AddJoin(Of TJoined)(joinType)
+      Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, TJoined)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="joinType"></param>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), behavior As NonModelEntityCreationBehavior) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory, behavior)
       Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, TJoined)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
@@ -68,6 +68,17 @@ Namespace Expressions
     ''' Adds INNER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds INNER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function Join(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, TJoined)
@@ -102,6 +113,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function LeftJoin(Of TJoined)() As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, TJoined)
       Return InternalJoin(Of TJoined)(JoinType.LeftOuter)
+    End Function
+
+    ''' <summary>
+    ''' Adds LEFT OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory, behavior)
     End Function
 
     ''' <summary>
@@ -148,6 +170,17 @@ Namespace Expressions
     ''' Adds RIGHT OUTER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds RIGHT OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function RightJoin(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, TJoined)
@@ -188,6 +221,17 @@ Namespace Expressions
     ''' Adds FULL OUTER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds FULL OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function FullJoin(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, TJoined)
@@ -212,6 +256,19 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function CrossJoin(Of TJoined)() As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, TJoined)
       Return InternalJoin(Of TJoined)(JoinType.CrossJoin, Nothing, {0, 1})
+    End Function
+
+    ''' <summary>
+    ''' Adds CROSS JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory, behavior)
+      Me.Builder.AddOn(Of TJoined)(Nothing, {0, 1})
+      Return New JoinedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, TJoined)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>
@@ -260,6 +317,19 @@ Namespace Expressions
     ''' <returns></returns>
     Private Function InternalJoin(Of TJoined)(joinType As JoinType) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, TJoined)
       Me.Builder.AddJoin(Of TJoined)(joinType)
+      Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, TJoined)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="joinType"></param>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), behavior As NonModelEntityCreationBehavior) As JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory, behavior)
       Return New JoinSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, TJoined)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpression.vb
@@ -11,6 +11,7 @@ Namespace Expressions
   ''' <typeparam name="T"></typeparam>
   Public Class SelectedSelectSqlExpression(Of T)
     Inherits SelectSqlExpressionBase
+    Implements ISubqueryableSelectSqlExpression(Of T)
 
     ''' <summary>
     ''' Creates new instance of <see cref="SelectedSelectSqlExpression(Of T)"/>.
@@ -152,6 +153,14 @@ Namespace Expressions
       If genericType Is GetType(DistinctSelectSqlExpression(Of )) Then Return True
 
       Return False
+    End Function
+
+    ''' <summary>
+    ''' Creates SQL subquery.
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function ToSubquery() As Subquery(Of T) Implements ISubqueryableSelectSqlExpression(Of T).ToSubquery
+      Return Me.Builder.CreateSubquery(Of T)()
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2.vb
@@ -12,6 +12,7 @@ Namespace Expressions
   ''' <typeparam name="T2"></typeparam>
   Public Class SelectedSelectSqlExpression(Of T1, T2)
     Inherits SelectSqlExpressionBase
+    Implements ISubqueryableSelectSqlExpression(Of T1)
 
     ''' <summary>
     ''' Creates new instance of <see cref="SelectedSelectSqlExpression(Of T1, T2)"/>.
@@ -253,6 +254,14 @@ Namespace Expressions
       If genericType Is GetType(DistinctSelectSqlExpression(Of )) Then Return True
 
       Return False
+    End Function
+
+    ''' <summary>
+    ''' Creates SQL subquery.
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function ToSubquery() As Subquery(Of T1) Implements ISubqueryableSelectSqlExpression(Of T1).ToSubquery
+      Return Me.Builder.CreateSubquery(Of T1)()
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3.vb
@@ -13,6 +13,7 @@ Namespace Expressions
   ''' <typeparam name="T3"></typeparam>
   Public Class SelectedSelectSqlExpression(Of T1, T2, T3)
     Inherits SelectSqlExpressionBase
+    Implements ISubqueryableSelectSqlExpression(Of T1)
 
     ''' <summary>
     ''' Creates new instance of <see cref="SelectedSelectSqlExpression(Of T1, T2, T3)"/>.
@@ -336,6 +337,14 @@ Namespace Expressions
       If genericType Is GetType(DistinctSelectSqlExpression(Of )) Then Return True
 
       Return False
+    End Function
+
+    ''' <summary>
+    ''' Creates SQL subquery.
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function ToSubquery() As Subquery(Of T1) Implements ISubqueryableSelectSqlExpression(Of T1).ToSubquery
+      Return Me.Builder.CreateSubquery(Of T1)()
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4.vb
@@ -14,6 +14,7 @@ Namespace Expressions
   ''' <typeparam name="T4"></typeparam>
   Public Class SelectedSelectSqlExpression(Of T1, T2, T3, T4)
     Inherits SelectSqlExpressionBase
+    Implements ISubqueryableSelectSqlExpression(Of T1)
 
     ''' <summary>
     ''' Creates new instance of <see cref="SelectedSelectSqlExpression(Of T1, T2, T3, T4)"/>.
@@ -441,6 +442,14 @@ Namespace Expressions
       If genericType Is GetType(DistinctSelectSqlExpression(Of )) Then Return True
 
       Return False
+    End Function
+
+    ''' <summary>
+    ''' Creates SQL subquery.
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function ToSubquery() As Subquery(Of T1) Implements ISubqueryableSelectSqlExpression(Of T1).ToSubquery
+      Return Me.Builder.CreateSubquery(Of T1)()
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5.vb
@@ -15,6 +15,7 @@ Namespace Expressions
   ''' <typeparam name="T5"></typeparam>
   Public Class SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)
     Inherits SelectSqlExpressionBase
+    Implements ISubqueryableSelectSqlExpression(Of T1)
 
     ''' <summary>
     ''' Creates new instance of <see cref="SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5)"/>.
@@ -568,6 +569,14 @@ Namespace Expressions
       If genericType Is GetType(DistinctSelectSqlExpression(Of )) Then Return True
 
       Return False
+    End Function
+
+    ''' <summary>
+    ''' Creates SQL subquery.
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function ToSubquery() As Subquery(Of T1) Implements ISubqueryableSelectSqlExpression(Of T1).ToSubquery
+      Return Me.Builder.CreateSubquery(Of T1)()
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6.vb
@@ -16,6 +16,7 @@ Namespace Expressions
   ''' <typeparam name="T6"></typeparam>
   Public Class SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)
     Inherits SelectSqlExpressionBase
+    Implements ISubqueryableSelectSqlExpression(Of T1)
 
     ''' <summary>
     ''' Creates new instance of <see cref="SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6)"/>.
@@ -717,6 +718,14 @@ Namespace Expressions
       If genericType Is GetType(DistinctSelectSqlExpression(Of )) Then Return True
 
       Return False
+    End Function
+
+    ''' <summary>
+    ''' Creates SQL subquery.
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function ToSubquery() As Subquery(Of T1) Implements ISubqueryableSelectSqlExpression(Of T1).ToSubquery
+      Return Me.Builder.CreateSubquery(Of T1)()
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
@@ -17,6 +17,7 @@ Namespace Expressions
   ''' <typeparam name="T7"></typeparam>
   Public Class SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)
     Inherits SelectSqlExpressionBase
+    Implements ISubqueryableSelectSqlExpression(Of T1)
 
     ''' <summary>
     ''' Creates new instance of <see cref="SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7)"/>.
@@ -888,6 +889,14 @@ Namespace Expressions
       If genericType Is GetType(DistinctSelectSqlExpression(Of )) Then Return True
 
       Return False
+    End Function
+
+    ''' <summary>
+    ''' Creates SQL subquery.
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function ToSubquery() As Subquery(Of T1) Implements ISubqueryableSelectSqlExpression(Of T1).ToSubquery
+      Return Me.Builder.CreateSubquery(Of T1)()
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
@@ -18,6 +18,7 @@ Namespace Expressions
   ''' <typeparam name="T8"></typeparam>
   Public Class SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)
     Inherits SelectSqlExpressionBase
+    Implements ISubqueryableSelectSqlExpression(Of T1)
 
     ''' <summary>
     ''' Creates new instance of <see cref="SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8)"/>.
@@ -1081,6 +1082,14 @@ Namespace Expressions
       If genericType Is GetType(DistinctSelectSqlExpression(Of )) Then Return True
 
       Return False
+    End Function
+
+    ''' <summary>
+    ''' Creates SQL subquery.
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function ToSubquery() As Subquery(Of T1) Implements ISubqueryableSelectSqlExpression(Of T1).ToSubquery
+      Return Me.Builder.CreateSubquery(Of T1)()
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
@@ -19,6 +19,7 @@ Namespace Expressions
   ''' <typeparam name="T9"></typeparam>
   Public Class SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)
     Inherits SelectSqlExpressionBase
+    Implements ISubqueryableSelectSqlExpression(Of T1)
 
     ''' <summary>
     ''' Creates new instance of <see cref="SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9)"/>.
@@ -1296,6 +1297,14 @@ Namespace Expressions
       If genericType Is GetType(DistinctSelectSqlExpression(Of )) Then Return True
 
       Return False
+    End Function
+
+    ''' <summary>
+    ''' Creates SQL subquery.
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function ToSubquery() As Subquery(Of T1) Implements ISubqueryableSelectSqlExpression(Of T1).ToSubquery
+      Return Me.Builder.CreateSubquery(Of T1)()
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
@@ -20,6 +20,7 @@ Namespace Expressions
   ''' <typeparam name="T10"></typeparam>
   Public Class SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)
     Inherits SelectSqlExpressionBase
+    Implements ISubqueryableSelectSqlExpression(Of T1)
 
     ''' <summary>
     ''' Creates new instance of <see cref="SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)"/>.
@@ -1533,6 +1534,14 @@ Namespace Expressions
       If genericType Is GetType(DistinctSelectSqlExpression(Of )) Then Return True
 
       Return False
+    End Function
+
+    ''' <summary>
+    ''' Creates SQL subquery.
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function ToSubquery() As Subquery(Of T1) Implements ISubqueryableSelectSqlExpression(Of T1).ToSubquery
+      Return Me.Builder.CreateSubquery(Of T1)()
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
@@ -21,6 +21,7 @@ Namespace Expressions
   ''' <typeparam name="T11"></typeparam>
   Public Class SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
     Inherits SelectSqlExpressionBase
+    Implements ISubqueryableSelectSqlExpression(Of T1)
 
     ''' <summary>
     ''' Creates new instance of <see cref="SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)"/>.
@@ -1792,6 +1793,14 @@ Namespace Expressions
       If genericType Is GetType(DistinctSelectSqlExpression(Of )) Then Return True
 
       Return False
+    End Function
+
+    ''' <summary>
+    ''' Creates SQL subquery.
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function ToSubquery() As Subquery(Of T1) Implements ISubqueryableSelectSqlExpression(Of T1).ToSubquery
+      Return Me.Builder.CreateSubquery(Of T1)()
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
@@ -22,6 +22,7 @@ Namespace Expressions
   ''' <typeparam name="T12"></typeparam>
   Public Class SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)
     Inherits SelectSqlExpressionBase
+    Implements ISubqueryableSelectSqlExpression(Of T1)
 
     ''' <summary>
     ''' Creates new instance of <see cref="SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)"/>.
@@ -2073,6 +2074,14 @@ Namespace Expressions
       If genericType Is GetType(DistinctSelectSqlExpression(Of )) Then Return True
 
       Return False
+    End Function
+
+    ''' <summary>
+    ''' Creates SQL subquery.
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function ToSubquery() As Subquery(Of T1) Implements ISubqueryableSelectSqlExpression(Of T1).ToSubquery
+      Return Me.Builder.CreateSubquery(Of T1)()
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
@@ -23,6 +23,7 @@ Namespace Expressions
   ''' <typeparam name="T13"></typeparam>
   Public Class SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)
     Inherits SelectSqlExpressionBase
+    Implements ISubqueryableSelectSqlExpression(Of T1)
 
     ''' <summary>
     ''' Creates new instance of <see cref="SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)"/>.
@@ -2376,6 +2377,14 @@ Namespace Expressions
       If genericType Is GetType(DistinctSelectSqlExpression(Of )) Then Return True
 
       Return False
+    End Function
+
+    ''' <summary>
+    ''' Creates SQL subquery.
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function ToSubquery() As Subquery(Of T1) Implements ISubqueryableSelectSqlExpression(Of T1).ToSubquery
+      Return Me.Builder.CreateSubquery(Of T1)()
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
@@ -24,6 +24,7 @@ Namespace Expressions
   ''' <typeparam name="T14"></typeparam>
   Public Class SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)
     Inherits SelectSqlExpressionBase
+    Implements ISubqueryableSelectSqlExpression(Of T1)
 
     ''' <summary>
     ''' Creates new instance of <see cref="SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)"/>.
@@ -2701,6 +2702,14 @@ Namespace Expressions
       If genericType Is GetType(DistinctSelectSqlExpression(Of )) Then Return True
 
       Return False
+    End Function
+
+    ''' <summary>
+    ''' Creates SQL subquery.
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function ToSubquery() As Subquery(Of T1) Implements ISubqueryableSelectSqlExpression(Of T1).ToSubquery
+      Return Me.Builder.CreateSubquery(Of T1)()
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
@@ -25,6 +25,7 @@ Namespace Expressions
   ''' <typeparam name="T15"></typeparam>
   Public Class SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)
     Inherits SelectSqlExpressionBase
+    Implements ISubqueryableSelectSqlExpression(Of T1)
 
     ''' <summary>
     ''' Creates new instance of <see cref="SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)"/>.
@@ -3048,6 +3049,14 @@ Namespace Expressions
       If genericType Is GetType(DistinctSelectSqlExpression(Of )) Then Return True
 
       Return False
+    End Function
+
+    ''' <summary>
+    ''' Creates SQL subquery.
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function ToSubquery() As Subquery(Of T1) Implements ISubqueryableSelectSqlExpression(Of T1).ToSubquery
+      Return Me.Builder.CreateSubquery(Of T1)()
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
@@ -26,6 +26,7 @@ Namespace Expressions
   ''' <typeparam name="T16"></typeparam>
   Public Class SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)
     Inherits SelectSqlExpressionBase
+    Implements ISubqueryableSelectSqlExpression(Of T1)
 
     ''' <summary>
     ''' Creates new instance of <see cref="SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)"/>.
@@ -3417,6 +3418,14 @@ Namespace Expressions
       If genericType Is GetType(DistinctSelectSqlExpression(Of )) Then Return True
 
       Return False
+    End Function
+
+    ''' <summary>
+    ''' Creates SQL subquery.
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function ToSubquery() As Subquery(Of T1) Implements ISubqueryableSelectSqlExpression(Of T1).ToSubquery
+      Return Me.Builder.CreateSubquery(Of T1)()
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
@@ -27,6 +27,7 @@ Namespace Expressions
   ''' <typeparam name="T17"></typeparam>
   Public Class SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)
     Inherits SelectSqlExpressionBase
+    Implements ISubqueryableSelectSqlExpression(Of T1)
 
     ''' <summary>
     ''' Creates new instance of <see cref="SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)"/>.
@@ -3808,6 +3809,14 @@ Namespace Expressions
       If genericType Is GetType(DistinctSelectSqlExpression(Of )) Then Return True
 
       Return False
+    End Function
+
+    ''' <summary>
+    ''' Creates SQL subquery.
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function ToSubquery() As Subquery(Of T1) Implements ISubqueryableSelectSqlExpression(Of T1).ToSubquery
+      Return Me.Builder.CreateSubquery(Of T1)()
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
@@ -28,6 +28,7 @@ Namespace Expressions
   ''' <typeparam name="T18"></typeparam>
   Public Class SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)
     Inherits SelectSqlExpressionBase
+    Implements ISubqueryableSelectSqlExpression(Of T1)
 
     ''' <summary>
     ''' Creates new instance of <see cref="SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)"/>.
@@ -4221,6 +4222,14 @@ Namespace Expressions
       If genericType Is GetType(DistinctSelectSqlExpression(Of )) Then Return True
 
       Return False
+    End Function
+
+    ''' <summary>
+    ''' Creates SQL subquery.
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function ToSubquery() As Subquery(Of T1) Implements ISubqueryableSelectSqlExpression(Of T1).ToSubquery
+      Return Me.Builder.CreateSubquery(Of T1)()
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
@@ -29,6 +29,7 @@ Namespace Expressions
   ''' <typeparam name="T19"></typeparam>
   Public Class SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)
     Inherits SelectSqlExpressionBase
+    Implements ISubqueryableSelectSqlExpression(Of T1)
 
     ''' <summary>
     ''' Creates new instance of <see cref="SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)"/>.
@@ -4656,6 +4657,14 @@ Namespace Expressions
       If genericType Is GetType(DistinctSelectSqlExpression(Of )) Then Return True
 
       Return False
+    End Function
+
+    ''' <summary>
+    ''' Creates SQL subquery.
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function ToSubquery() As Subquery(Of T1) Implements ISubqueryableSelectSqlExpression(Of T1).ToSubquery
+      Return Me.Builder.CreateSubquery(Of T1)()
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
@@ -30,6 +30,7 @@ Namespace Expressions
   ''' <typeparam name="T20"></typeparam>
   Public Class SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)
     Inherits SelectSqlExpressionBase
+    Implements ISubqueryableSelectSqlExpression(Of T1)
 
     ''' <summary>
     ''' Creates new instance of <see cref="SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)"/>.
@@ -5113,6 +5114,14 @@ Namespace Expressions
       If genericType Is GetType(DistinctSelectSqlExpression(Of )) Then Return True
 
       Return False
+    End Function
+
+    ''' <summary>
+    ''' Creates SQL subquery.
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function ToSubquery() As Subquery(Of T1) Implements ISubqueryableSelectSqlExpression(Of T1).ToSubquery
+      Return Me.Builder.CreateSubquery(Of T1)()
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
@@ -31,6 +31,7 @@ Namespace Expressions
   ''' <typeparam name="T21"></typeparam>
   Public Class SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)
     Inherits SelectSqlExpressionBase
+    Implements ISubqueryableSelectSqlExpression(Of T1)
 
     ''' <summary>
     ''' Creates new instance of <see cref="SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)"/>.
@@ -5592,6 +5593,14 @@ Namespace Expressions
       If genericType Is GetType(DistinctSelectSqlExpression(Of )) Then Return True
 
       Return False
+    End Function
+
+    ''' <summary>
+    ''' Creates SQL subquery.
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function ToSubquery() As Subquery(Of T1) Implements ISubqueryableSelectSqlExpression(Of T1).ToSubquery
+      Return Me.Builder.CreateSubquery(Of T1)()
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
@@ -32,6 +32,7 @@ Namespace Expressions
   ''' <typeparam name="T22"></typeparam>
   Public Class SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)
     Inherits SelectSqlExpressionBase
+    Implements ISubqueryableSelectSqlExpression(Of T1)
 
     ''' <summary>
     ''' Creates new instance of <see cref="SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)"/>.
@@ -6093,6 +6094,14 @@ Namespace Expressions
       If genericType Is GetType(DistinctSelectSqlExpression(Of )) Then Return True
 
       Return False
+    End Function
+
+    ''' <summary>
+    ''' Creates SQL subquery.
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function ToSubquery() As Subquery(Of T1) Implements ISubqueryableSelectSqlExpression(Of T1).ToSubquery
+      Return Me.Builder.CreateSubquery(Of T1)()
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
@@ -33,6 +33,7 @@ Namespace Expressions
   ''' <typeparam name="T23"></typeparam>
   Public Class SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)
     Inherits SelectSqlExpressionBase
+    Implements ISubqueryableSelectSqlExpression(Of T1)
 
     ''' <summary>
     ''' Creates new instance of <see cref="SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23)"/>.
@@ -6616,6 +6617,14 @@ Namespace Expressions
       If genericType Is GetType(DistinctSelectSqlExpression(Of )) Then Return True
 
       Return False
+    End Function
+
+    ''' <summary>
+    ''' Creates SQL subquery.
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function ToSubquery() As Subquery(Of T1) Implements ISubqueryableSelectSqlExpression(Of T1).ToSubquery
+      Return Me.Builder.CreateSubquery(Of T1)()
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
@@ -34,6 +34,7 @@ Namespace Expressions
   ''' <typeparam name="T24"></typeparam>
   Public Class SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)
     Inherits SelectSqlExpressionBase
+    Implements ISubqueryableSelectSqlExpression(Of T1)
 
     ''' <summary>
     ''' Creates new instance of <see cref="SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24)"/>.
@@ -7161,6 +7162,14 @@ Namespace Expressions
       If genericType Is GetType(DistinctSelectSqlExpression(Of )) Then Return True
 
       Return False
+    End Function
+
+    ''' <summary>
+    ''' Creates SQL subquery.
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function ToSubquery() As Subquery(Of T1) Implements ISubqueryableSelectSqlExpression(Of T1).ToSubquery
+      Return Me.Builder.CreateSubquery(Of T1)()
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
@@ -35,6 +35,7 @@ Namespace Expressions
   ''' <typeparam name="T25"></typeparam>
   Public Class SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)
     Inherits SelectSqlExpressionBase
+    Implements ISubqueryableSelectSqlExpression(Of T1)
 
     ''' <summary>
     ''' Creates new instance of <see cref="SelectedSelectSqlExpression(Of T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, T23, T24, T25)"/>.
@@ -7728,6 +7729,14 @@ Namespace Expressions
       If genericType Is GetType(DistinctSelectSqlExpression(Of )) Then Return True
 
       Return False
+    End Function
+
+    ''' <summary>
+    ''' Creates SQL subquery.
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function ToSubquery() As Subquery(Of T1) Implements ISubqueryableSelectSqlExpression(Of T1).ToSubquery
+      Return Me.Builder.CreateSubquery(Of T1)()
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Expressions/WithHintsSelectSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/WithHintsSelectSqlExpression.vb
@@ -55,6 +55,17 @@ Namespace Expressions
     ''' Adds INNER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function Join(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.Inner, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds INNER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function Join(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T, TJoined)
@@ -99,6 +110,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function LeftJoin(Of TJoined)() As JoinSelectSqlExpression(Of T, TJoined)
       Return InternalJoin(Of TJoined)(JoinType.LeftOuter)
+    End Function
+
+    ''' <summary>
+    ''' Adds LEFT OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function LeftJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.LeftOuter, tableSourceFactory, behavior)
     End Function
 
     ''' <summary>
@@ -155,6 +177,17 @@ Namespace Expressions
     ''' Adds RIGHT OUTER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function RightJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.RightOuter, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds RIGHT OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function RightJoin(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T, TJoined)
@@ -205,6 +238,17 @@ Namespace Expressions
     ''' Adds FULL OUTER JOIN clause.
     ''' </summary>
     ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function FullJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinSelectSqlExpression(Of T, TJoined)
+      Return InternalJoin(Of TJoined)(JoinType.FullOuter, tableSourceFactory, behavior)
+    End Function
+
+    ''' <summary>
+    ''' Adds FULL OUTER JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
     ''' <param name="tableSource"></param>
     ''' <returns></returns>
     Public Function FullJoin(Of TJoined)(<DisallowNull> tableSource As FormattableString) As JoinSelectSqlExpression(Of T, TJoined)
@@ -229,6 +273,19 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function CrossJoin(Of TJoined)() As JoinedSelectSqlExpression(Of T, TJoined)
       Return InternalJoin(Of TJoined)(JoinType.CrossJoin, Nothing, {0, 1})
+    End Function
+
+    ''' <summary>
+    ''' Adds CROSS JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Public Function CrossJoin(Of TJoined)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As JoinedSelectSqlExpression(Of T, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, JoinType.CrossJoin, tableSourceFactory, behavior)
+      Me.Builder.AddOn(Of TJoined)(Nothing, {0, 1})
+      Return New JoinedSelectSqlExpression(Of T, TJoined)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>
@@ -277,6 +334,19 @@ Namespace Expressions
     ''' <returns></returns>
     Private Function InternalJoin(Of TJoined)(joinType As JoinType) As JoinSelectSqlExpression(Of T, TJoined)
       Me.Builder.AddJoin(Of TJoined)(joinType)
+      Return New JoinSelectSqlExpression(Of T, TJoined)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds JOIN clause.
+    ''' </summary>
+    ''' <typeparam name="TJoined"></typeparam>
+    ''' <param name="joinType"></param>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    ''' <returns></returns>
+    Private Function InternalJoin(Of TJoined)(joinType As JoinType, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of TJoined)), behavior As NonModelEntityCreationBehavior) As JoinSelectSqlExpression(Of T, TJoined)
+      Me.Builder.AddJoin(Of TJoined)(Me.Executor, joinType, tableSourceFactory, behavior)
       Return New JoinSelectSqlExpression(Of T, TJoined)(Me.Builder, Me.Executor)
     End Function
 

--- a/Source/Source/Yamo/Infrastructure/MemberSetterFactory.vb
+++ b/Source/Source/Yamo/Infrastructure/MemberSetterFactory.vb
@@ -6,26 +6,26 @@ Imports Yamo.Metadata
 Namespace Infrastructure
 
   ''' <summary>
-  ''' Entity member setter factory.<br/>
+  ''' Member setter factory.<br/>
   ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
   ''' </summary>
-  Public Class EntityMemberSetterFactory
+  Public Class MemberSetterFactory
 
     ''' <summary>
     ''' Creates property or field setter.<br/>
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
-    ''' <param name="entityType"></param>
+    ''' <param name="objectType"></param>
     ''' <param name="propertyOrFieldName"></param>
     ''' <param name="valueType"></param>
     ''' <returns></returns>
-    Public Shared Function CreateSetter(<DisallowNull> entityType As Type, <DisallowNull> propertyOrFieldName As String, <DisallowNull> valueType As Type) As Action(Of Object, Object)
-      Dim entityParam = Expression.Parameter(GetType(Object), "entity")
+    Public Shared Function CreateSetter(<DisallowNull> objectType As Type, <DisallowNull> propertyOrFieldName As String, <DisallowNull> valueType As Type) As Action(Of Object, Object)
+      Dim objParam = Expression.Parameter(GetType(Object), "obj")
       Dim valueParam = Expression.Parameter(GetType(Object), "value")
-      Dim parameters = {entityParam, valueParam}
+      Dim parameters = {objParam, valueParam}
 
-      Dim entityCasted = Expression.Convert(entityParam, entityType)
-      Dim prop = Expression.PropertyOrField(entityCasted, propertyOrFieldName)
+      Dim objCasted = Expression.Convert(objParam, objectType)
+      Dim prop = Expression.PropertyOrField(objCasted, propertyOrFieldName)
       Dim valueCasted = Expression.Convert(valueParam, prop.Type)
       Dim propAssign = Expression.Assign(prop, valueCasted)
 
@@ -39,19 +39,19 @@ Namespace Infrastructure
     ''' Creates setter that adds an item to the collection of a property or a field.<br/>
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
-    ''' <param name="entityType"></param>
+    ''' <param name="objectType"></param>
     ''' <param name="propertyOrFieldName"></param>
     ''' <param name="itemType"></param>
     ''' <returns></returns>
-    Public Shared Function CreateCollectionAddSetter(<DisallowNull> entityType As Type, <DisallowNull> propertyOrFieldName As String, <DisallowNull> itemType As Type) As Action(Of Object, Object)
-      Dim entityParam = Expression.Parameter(GetType(Object), "entity")
+    Public Shared Function CreateCollectionAddSetter(<DisallowNull> objectType As Type, <DisallowNull> propertyOrFieldName As String, <DisallowNull> itemType As Type) As Action(Of Object, Object)
+      Dim objParam = Expression.Parameter(GetType(Object), "obj")
       Dim valueParam = Expression.Parameter(GetType(Object), "value")
-      Dim parameters = {entityParam, valueParam}
+      Dim parameters = {objParam, valueParam}
 
-      Dim entityCasted = Expression.Convert(entityParam, entityType)
+      Dim objCasted = Expression.Convert(objParam, objectType)
       Dim valueCasted = Expression.Convert(valueParam, itemType)
 
-      Dim prop = Expression.PropertyOrField(entityCasted, propertyOrFieldName)
+      Dim prop = Expression.PropertyOrField(objCasted, propertyOrFieldName)
       Dim propAdd = Expression.Call(prop, "Add", Nothing, valueCasted)
 
       Dim body = Expression.Block(propAdd)
@@ -64,23 +64,23 @@ Namespace Infrastructure
     ''' Creates property or field setter that initializes a collection.<br/>
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
-    ''' <param name="entityType"></param>
+    ''' <param name="objectType"></param>
     ''' <param name="propertyOrFieldName"></param>
     ''' <param name="collectionType"></param>
     ''' <param name="itemType"></param>
     ''' <returns></returns>
-    Public Shared Function CreateCollectionInitSetter(<DisallowNull> entityType As Type, <DisallowNull> propertyOrFieldName As String, <DisallowNull> collectionType As Type, <DisallowNull> itemType As Type) As Action(Of Object)
-      Dim entityParam = Expression.Parameter(GetType(Object), "entity")
-      Dim parameters = {entityParam}
+    Public Shared Function CreateCollectionInitSetter(<DisallowNull> objectType As Type, <DisallowNull> propertyOrFieldName As String, <DisallowNull> collectionType As Type, <DisallowNull> itemType As Type) As Action(Of Object)
+      Dim objParam = Expression.Parameter(GetType(Object), "obj")
+      Dim parameters = {objParam}
 
-      Dim entityCasted = Expression.Convert(entityParam, entityType)
+      Dim objCasted = Expression.Convert(objParam, objectType)
 
       If collectionType.IsInterface Then
         collectionType = GetType(List(Of )).MakeGenericType(itemType)
       End If
 
       Dim value = Expression.[New](collectionType)
-      Dim prop = Expression.PropertyOrField(entityCasted, propertyOrFieldName)
+      Dim prop = Expression.PropertyOrField(objCasted, propertyOrFieldName)
       Dim propAssign = Expression.Assign(prop, value)
       Dim isNull = Expression.Equal(prop, Expression.Constant(Nothing))
       Dim cond = Expression.IfThen(isNull, propAssign)

--- a/Source/Source/Yamo/Infrastructure/SqlResultReaderFactory.vb
+++ b/Source/Source/Yamo/Infrastructure/SqlResultReaderFactory.vb
@@ -355,7 +355,7 @@ Namespace Infrastructure
 
       If TypeOf sqlResult Is EntitySqlResult Then
         Dim entityProp = Expression.Property(readerDataVar, NameOf(EntitySqlResultReaderData.Entity))
-        Dim includedColumnsProp = Expression.Property(entityProp, NameOf(SqlEntity.IncludedColumns))
+        Dim includedColumnsProp = Expression.Property(entityProp, NameOf(SqlEntityBase.IncludedColumns))
         Dim pkOffsetsProp = Expression.Property(readerDataVar, NameOf(EntitySqlResultReaderData.PKOffsets))
 
         Dim containsPKReaderProp = Expression.Property(readerDataVar, NameOf(EntitySqlResultReaderData.ContainsPKReader))

--- a/Source/Source/Yamo/Internal/MemberSetterCache.vb
+++ b/Source/Source/Yamo/Internal/MemberSetterCache.vb
@@ -6,52 +6,52 @@ Imports Yamo.Metadata
 Namespace Internal
 
   ''' <summary>
-  ''' Entity member setter cache.<br/>
+  ''' Member setter cache.<br/>
   ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
   ''' </summary>
-  Public Class EntityMemberSetterCache
+  Public Class MemberSetterCache
 
     ''' <summary>
     ''' Stores cache instances.<br/>
     ''' <br/>
     ''' Key: <see cref="Model"/> instance.<br/>
-    ''' Value: <see cref="EntityMemberSetterCache"/> instance.
+    ''' Value: <see cref="MemberSetterCache"/> instance.
     ''' </summary>
-    Private Shared m_Instances As Dictionary(Of Model, EntityMemberSetterCache)
+    Private Shared m_Instances As Dictionary(Of Model, MemberSetterCache)
 
     ''' <summary>
     ''' Stores cached setter instances.<br/>
     ''' <br/>
-    ''' Key: entity type, property/field name.<br/>
-    ''' Value: <see cref="Action(Of Object, Object)"/> delegate, where first parameter is entity instance and second parameter is value to be set to a property.
+    ''' Key: object type, property/field name.<br/>
+    ''' Value: <see cref="Action(Of Object, Object)"/> delegate, where first parameter is object instance and second parameter is value to be set to a property.
     ''' </summary>
     Private m_Setters As Dictionary(Of (Type, String), Action(Of Object, Object))
 
     ''' <summary>
     ''' Stores cached collection add setter instances.<br/>
     ''' <br/>
-    ''' Key: entity type, property/field name.<br/>
-    ''' Value: <see cref="Action(Of Object, Object)"/> delegate, where first parameter is entity instance and second parameter is value to be added to a property collection.
+    ''' Key: object type, property/field name.<br/>
+    ''' Value: <see cref="Action(Of Object, Object)"/> delegate, where first parameter is object instance and second parameter is value to be added to a property collection.
     ''' </summary>
     Private m_CollectionAddSetters As Dictionary(Of (Type, String), Action(Of Object, Object))
 
     ''' <summary>
     ''' Stores cached collection init setter instances.<br/>
     ''' <br/>
-    ''' Key: entity type, property/field name.<br/>
-    ''' Value: <see cref="Action(Of Object)"/> delegate, where parameter is entity instance with a property that will be set to a new collection.
+    ''' Key: object type, property/field name.<br/>
+    ''' Value: <see cref="Action(Of Object)"/> delegate, where parameter is object instance with a property that will be set to a new collection.
     ''' </summary>
     Private m_CollectionInitSetters As Dictionary(Of (Type, String), Action(Of Object))
 
     ''' <summary>
-    ''' Initializes <see cref="EntityMemberSetterCache"/> related static data.
+    ''' Initializes <see cref="MemberSetterCache"/> related static data.
     ''' </summary>
     Shared Sub New()
-      m_Instances = New Dictionary(Of Model, EntityMemberSetterCache)
+      m_Instances = New Dictionary(Of Model, MemberSetterCache)
     End Sub
 
     ''' <summary>
-    ''' Creates new instance of <see cref="EntityMemberSetterCache"/>.
+    ''' Creates new instance of <see cref="MemberSetterCache"/>.
     ''' </summary>
     Private Sub New()
       m_Setters = New Dictionary(Of (Type, String), Action(Of Object, Object))
@@ -64,14 +64,14 @@ Namespace Internal
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
     ''' <param name="model"></param>
-    ''' <param name="entityType"></param>
+    ''' <param name="objectType"></param>
     ''' <param name="relationshipNavigation"></param>
     ''' <returns></returns>
-    Public Shared Function GetSetter(<DisallowNull> model As Model, <DisallowNull> entityType As Type, <DisallowNull> relationshipNavigation As RelationshipNavigation) As Action(Of Object, Object)
+    Public Shared Function GetSetter(<DisallowNull> model As Model, <DisallowNull> objectType As Type, <DisallowNull> relationshipNavigation As RelationshipNavigation) As Action(Of Object, Object)
       If TypeOf relationshipNavigation Is ReferenceNavigation Then
-        Return GetInstance(model).GetOrCreateSetter(entityType, relationshipNavigation.PropertyName, relationshipNavigation.RelatedEntityType)
+        Return GetInstance(model).GetOrCreateSetter(objectType, relationshipNavigation.PropertyName, relationshipNavigation.RelatedEntityType)
       ElseIf TypeOf relationshipNavigation Is CollectionNavigation Then
-        Return GetInstance(model).GetOrCreateCollectionAddSetter(entityType, relationshipNavigation.PropertyName, relationshipNavigation.RelatedEntityType)
+        Return GetInstance(model).GetOrCreateCollectionAddSetter(objectType, relationshipNavigation.PropertyName, relationshipNavigation.RelatedEntityType)
       Else
         Throw New NotSupportedException($"Relationship of type '{relationshipNavigation.GetType()}' is not supported.")
       End If
@@ -82,12 +82,12 @@ Namespace Internal
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
     ''' <param name="model"></param>
-    ''' <param name="entityType"></param>
+    ''' <param name="objectType"></param>
     ''' <param name="propertyOrFieldName"></param>
     ''' <param name="valueType"></param>
     ''' <returns></returns>
-    Public Shared Function GetSetter(<DisallowNull> model As Model, <DisallowNull> entityType As Type, <DisallowNull> propertyOrFieldName As String, <DisallowNull> valueType As Type) As Action(Of Object, Object)
-      Return GetInstance(model).GetOrCreateSetter(entityType, propertyOrFieldName, valueType)
+    Public Shared Function GetSetter(<DisallowNull> model As Model, <DisallowNull> objectType As Type, <DisallowNull> propertyOrFieldName As String, <DisallowNull> valueType As Type) As Action(Of Object, Object)
+      Return GetInstance(model).GetOrCreateSetter(objectType, propertyOrFieldName, valueType)
     End Function
 
     ''' <summary>
@@ -95,24 +95,24 @@ Namespace Internal
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
     ''' <param name="model"></param>
-    ''' <param name="entityType"></param>
+    ''' <param name="objectType"></param>
     ''' <param name="collectionNavigation"></param>
     ''' <returns></returns>
-    Public Shared Function GetCollectionInitSetter(<DisallowNull> model As Model, <DisallowNull> entityType As Type, <DisallowNull> collectionNavigation As CollectionNavigation) As Action(Of Object)
-      Return GetInstance(model).GetOrCreateCollectionInitSetter(entityType, collectionNavigation.PropertyName, collectionNavigation.CollectionType, collectionNavigation.RelatedEntityType)
+    Public Shared Function GetCollectionInitSetter(<DisallowNull> model As Model, <DisallowNull> objectType As Type, <DisallowNull> collectionNavigation As CollectionNavigation) As Action(Of Object)
+      Return GetInstance(model).GetOrCreateCollectionInitSetter(objectType, collectionNavigation.PropertyName, collectionNavigation.CollectionType, collectionNavigation.RelatedEntityType)
     End Function
 
     ''' <summary>
-    ''' Gets <see cref="EntityMemberSetterCache"/> cache instance. If it doesn't exist, it is created.
+    ''' Gets <see cref="MemberSetterCache"/> cache instance. If it doesn't exist, it is created.
     ''' </summary>
     ''' <param name="model"></param>
     ''' <returns></returns>
-    Private Shared Function GetInstance(model As Model) As EntityMemberSetterCache
-      Dim instance As EntityMemberSetterCache = Nothing
+    Private Shared Function GetInstance(model As Model) As MemberSetterCache
+      Dim instance As MemberSetterCache = Nothing
 
       SyncLock m_Instances
         If Not m_Instances.TryGetValue(model, instance) Then
-          instance = New EntityMemberSetterCache
+          instance = New MemberSetterCache
           m_Instances.Add(model, instance)
         End If
       End SyncLock
@@ -123,21 +123,21 @@ Namespace Internal
     ''' <summary>
     ''' Gets or creates setter.
     ''' </summary>
-    ''' <param name="entityType"></param>
+    ''' <param name="objectType"></param>
     ''' <param name="propertyOrFieldName"></param>
     ''' <param name="valueType"></param>
     ''' <returns></returns>
-    Private Function GetOrCreateSetter(entityType As Type, propertyOrFieldName As String, valueType As Type) As Action(Of Object, Object)
+    Private Function GetOrCreateSetter(objectType As Type, propertyOrFieldName As String, valueType As Type) As Action(Of Object, Object)
       Dim setter As Action(Of Object, Object) = Nothing
 
-      Dim key = (entityType, propertyOrFieldName)
+      Dim key = (objectType, propertyOrFieldName)
 
       SyncLock m_Setters
         m_Setters.TryGetValue(key, setter)
       End SyncLock
 
       If setter Is Nothing Then
-        setter = EntityMemberSetterFactory.CreateSetter(entityType, propertyOrFieldName, valueType)
+        setter = MemberSetterFactory.CreateSetter(objectType, propertyOrFieldName, valueType)
       Else
         Return setter
       End If
@@ -152,21 +152,21 @@ Namespace Internal
     ''' <summary>
     ''' Gets or creates collection add setter.
     ''' </summary>
-    ''' <param name="entityType"></param>
+    ''' <param name="objectType"></param>
     ''' <param name="propertyOrFieldName"></param>
     ''' <param name="itemType"></param>
     ''' <returns></returns>
-    Private Function GetOrCreateCollectionAddSetter(entityType As Type, propertyOrFieldName As String, itemType As Type) As Action(Of Object, Object)
+    Private Function GetOrCreateCollectionAddSetter(objectType As Type, propertyOrFieldName As String, itemType As Type) As Action(Of Object, Object)
       Dim setter As Action(Of Object, Object) = Nothing
 
-      Dim key = (entityType, propertyOrFieldName)
+      Dim key = (objectType, propertyOrFieldName)
 
       SyncLock m_CollectionAddSetters
         m_CollectionAddSetters.TryGetValue(key, setter)
       End SyncLock
 
       If setter Is Nothing Then
-        setter = EntityMemberSetterFactory.CreateCollectionAddSetter(entityType, propertyOrFieldName, itemType)
+        setter = MemberSetterFactory.CreateCollectionAddSetter(objectType, propertyOrFieldName, itemType)
       Else
         Return setter
       End If
@@ -181,22 +181,22 @@ Namespace Internal
     ''' <summary>
     ''' Gets or creates collection init setter.
     ''' </summary>
-    ''' <param name="entityType"></param>
+    ''' <param name="objectType"></param>
     ''' <param name="propertyOrFieldName"></param>
     ''' <param name="collectionType"></param>
     ''' <param name="itemType"></param>
     ''' <returns></returns>
-    Private Function GetOrCreateCollectionInitSetter(entityType As Type, propertyOrFieldName As String, collectionType As Type, itemType As Type) As Action(Of Object)
+    Private Function GetOrCreateCollectionInitSetter(objectType As Type, propertyOrFieldName As String, collectionType As Type, itemType As Type) As Action(Of Object)
       Dim setter As Action(Of Object) = Nothing
 
-      Dim key = (entityType, propertyOrFieldName)
+      Dim key = (objectType, propertyOrFieldName)
 
       SyncLock m_CollectionInitSetters
         m_CollectionInitSetters.TryGetValue(key, setter)
       End SyncLock
 
       If setter Is Nothing Then
-        setter = EntityMemberSetterFactory.CreateCollectionInitSetter(entityType, propertyOrFieldName, collectionType, itemType)
+        setter = MemberSetterFactory.CreateCollectionInitSetter(objectType, propertyOrFieldName, collectionType, itemType)
       Else
         Return setter
       End If

--- a/Source/Source/Yamo/Internal/Query/AutoModeSqlResultReaderData.vb
+++ b/Source/Source/Yamo/Internal/Query/AutoModeSqlResultReaderData.vb
@@ -1,0 +1,129 @@
+﻿Imports System.Data
+Imports System.Data.Common
+Imports System.Diagnostics.CodeAnalysis
+Imports Yamo.Internal.Query.Metadata
+
+Namespace Internal.Query
+
+  ''' <summary>
+  ''' Represents reader data for SQL entities in automatic select mode.<br/>
+  ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+  ''' </summary>
+  Public Class AutoModeSqlResultReaderData
+
+    ''' <summary>
+    ''' Gets SQL entity.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <returns></returns>
+    Public ReadOnly Property Entity As SqlEntityBase
+
+    ''' <summary>
+    ''' Gets SQL entity.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <returns></returns>
+    Public ReadOnly Property ReaderData As ReaderDataBase
+
+    ''' <summary>
+    ''' Gets whether there are other entities to which this entity is declaring entity.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <returns></returns>
+    Public ReadOnly Property HasRelatedEntities As Boolean
+
+    ''' <summary>
+    ''' Gets indexes of all entities to which this entity is declaring entity.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <returns>Related entities indexes or <see langword="Nothing"/> if <see cref="HasRelatedEntities"/> is <see langword="False"/>.</returns>
+    Public ReadOnly Property RelatedEntities As <MaybeNull> IReadOnlyList(Of Int32)
+
+    ''' <summary>
+    ''' Gets whether there are other entities to which this entity is declaring entity and it is 1:N relationship.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <returns></returns>
+    Public ReadOnly Property HasCollectionNavigation As Boolean
+
+    ''' <summary>
+    ''' Gets collection initializers.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <returns>Collection initializers or <see langword="Nothing"/> if <see cref="HasCollectionNavigation"/> is <see langword="False"/>.</returns>
+    Public ReadOnly Property CollectionInitializers As <MaybeNull> IReadOnlyList(Of Action(Of Object))
+
+    ''' <summary>
+    ''' Gets whether there is a relationship setter.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <returns></returns>
+    Public ReadOnly Property HasRelationshipSetter As Boolean
+
+    ''' <summary>
+    ''' Gets relationship setter.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <returns>Relationship setter or <see langword="Nothing"/> if <see cref="HasRelationshipSetter"/> is <see langword="False"/>.</returns>
+    Public ReadOnly Property RelationshipSetter As <MaybeNull> Action(Of Object, Object) ' declaring entity, related entity (this one);
+
+    ''' <summary>
+    ''' Gets whether there are included results.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <returns></returns>
+    Public ReadOnly Property HasIncludedSqlResults As Boolean
+
+    ''' <summary>
+    ''' Gets reader data for included results.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <returns>Reader data or <see langword="Nothing"/> if <see cref="HasIncludedSqlResults"/> is <see langword="False"/>.</returns>
+    Public ReadOnly Property IncludedSqlResultsReaderData As <MaybeNull> IReadOnlyList(Of IncludedSqlResultReaderData)
+
+    ''' <summary>
+    ''' Creates new instance of <see cref="AutoModeSqlResultReaderData"/>.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <param name="entity"></param>
+    ''' <param name="readerData"></param>
+    Public Sub New(<DisallowNull> entity As SqlEntityBase, <DisallowNull> readerData As ReaderDataBase)
+      Me.New(entity, readerData, Nothing, Nothing, Nothing, Nothing)
+    End Sub
+
+    ''' <summary>
+    ''' Creates new instance of <see cref="AutoModeSqlResultReaderData"/>.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <param name="entity"></param>
+    ''' <param name="readerData"></param>
+    ''' <param name="includedSqlResultsReaderData"></param>
+    Public Sub New(<DisallowNull> entity As SqlEntityBase, <DisallowNull> readerData As ReaderDataBase, includedSqlResultsReaderData As IReadOnlyList(Of IncludedSqlResultReaderData))
+      Me.New(entity, readerData, Nothing, Nothing, Nothing, includedSqlResultsReaderData)
+    End Sub
+
+    ''' <summary>
+    ''' Creates new instance of <see cref="AutoModeSqlResultReaderData"/>.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <param name="entity"></param>
+    ''' <param name="readerData"></param>
+    ''' <param name="relatedEntities"></param>
+    ''' <param name="collectionInitializers"></param>
+    ''' <param name="relationshipSetter"></param>
+    ''' <param name="includedSqlResultsReaderData"></param>
+    Public Sub New(<DisallowNull> entity As SqlEntityBase, <DisallowNull> readerData As ReaderDataBase, relatedEntities As IReadOnlyList(Of Int32), collectionInitializers As IReadOnlyList(Of Action(Of Object)), relationshipSetter As Action(Of Object, Object), includedSqlResultsReaderData As IReadOnlyList(Of IncludedSqlResultReaderData))
+      Me.Entity = entity
+      Me.ReaderData = readerData
+      Me.HasRelatedEntities = relatedEntities IsNot Nothing
+      Me.RelatedEntities = relatedEntities
+      Me.HasCollectionNavigation = collectionInitializers IsNot Nothing
+      Me.CollectionInitializers = collectionInitializers
+      Me.HasRelationshipSetter = relationshipSetter IsNot Nothing
+      Me.RelationshipSetter = relationshipSetter
+      Me.HasIncludedSqlResults = includedSqlResultsReaderData IsNot Nothing
+      Me.IncludedSqlResultsReaderData = includedSqlResultsReaderData
+    End Sub
+
+  End Class
+End Namespace

--- a/Source/Source/Yamo/Internal/Query/AutoModeSqlResultReaderDataCollection.vb
+++ b/Source/Source/Yamo/Internal/Query/AutoModeSqlResultReaderDataCollection.vb
@@ -4,17 +4,17 @@ Imports System.Diagnostics.CodeAnalysis
 Namespace Internal.Query
 
   ''' <summary>
-  ''' Represents reader data for multiple entity values.<br/>
+  ''' Represents reader data for multiple SQL entity values.<br/>
   ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
   ''' </summary>
-  Public Class EntitySqlResultReaderDataCollection
+  Public Class AutoModeSqlResultReaderDataCollection
 
     ''' <summary>
     ''' Gets reader data of entities.<br/>
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
     ''' <returns></returns>
-    Public ReadOnly Property Items As EntitySqlResultReaderData()
+    Public ReadOnly Property Items As AutoModeSqlResultReaderData()
 
     ''' <summary>
     ''' Gets count of entities.<br/>
@@ -36,11 +36,11 @@ Namespace Internal.Query
     Private m_ChainIndexes As List(Of Int32)() ' probably change to something like Boolean() in the future (list is used just for convenience in GetChainKey method - once better hashing API is avaliable, refactor this!)
 
     ''' <summary>
-    ''' Creates new instance of <see cref="EntitySqlResultReaderDataCollection"/>.<br/>
+    ''' Creates new instance of <see cref="AutoModeSqlResultReaderDataCollection"/>.<br/>
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
     ''' <param name="items"></param>
-    Public Sub New(<DisallowNull> items As EntitySqlResultReaderData())
+    Public Sub New(<DisallowNull> items As AutoModeSqlResultReaderData())
       Me.Items = items
       Me.Count = items.Length
       Me.HasCollectionNavigation = items.Any(Function(o) o.HasCollectionNavigation)
@@ -160,12 +160,16 @@ Namespace Internal.Query
       For i = 0 To Me.Count - 1
         Dim readerData = Me.Items(i)
 
-        If readerData.Entity.IsExcludedOrIgnored Then
-          pks(i) = Nothing
-        ElseIf readerData.ContainsPKReader(dataReader, readerData.ReaderIndex, readerData.PKOffsets) Then
-          pks(i) = readerData.PKReader(dataReader, readerData.ReaderIndex, readerData.PKOffsets)
-        Else
-          pks(i) = Nothing
+        pks(i) = Nothing
+
+        If Not readerData.Entity.IsExcludedOrIgnored Then
+          If TypeOf readerData.ReaderData Is EntitySqlResultReaderData Then
+            Dim entityReaderData = DirectCast(readerData.ReaderData, EntitySqlResultReaderData)
+
+            If entityReaderData.ContainsPKReader(dataReader, entityReaderData.ReaderIndex, entityReaderData.PKOffsets) Then
+              pks(i) = entityReaderData.PKReader(dataReader, entityReaderData.ReaderIndex, entityReaderData.PKOffsets)
+            End If
+          End If
         End If
       Next
     End Sub

--- a/Source/Source/Yamo/Internal/Query/EntitySqlResultReaderData.vb
+++ b/Source/Source/Yamo/Internal/Query/EntitySqlResultReaderData.vb
@@ -17,7 +17,7 @@ Namespace Internal.Query
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
     ''' <returns></returns>
-    Public ReadOnly Property Entity As SqlEntity
+    Public ReadOnly Property Entity As EntityBasedSqlEntity
 
     ''' <summary>
     ''' Gets entity reader.<br/>
@@ -48,84 +48,19 @@ Namespace Internal.Query
     Public ReadOnly Property PKReader As <MaybeNull> Func(Of DbDataReader, Int32, Int32(), Object)
 
     ''' <summary>
-    ''' Gets whether there are other entities to which this entity is declaring entity.<br/>
-    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
-    ''' </summary>
-    ''' <returns></returns>
-    Public ReadOnly Property HasRelatedEntities As Boolean
-
-    ''' <summary>
-    ''' Gets indexes of all entities to which this entity is declaring entity.<br/>
-    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
-    ''' </summary>
-    ''' <returns>Related entities indexes or <see langword="Nothing"/> if <see cref="HasRelatedEntities"/> is <see langword="False"/>.</returns>
-    Public ReadOnly Property RelatedEntities As <MaybeNull> IReadOnlyList(Of Int32)
-
-    ''' <summary>
-    ''' Gets whether there are other entities to which this entity is declaring entity and it is 1:N relationship.<br/>
-    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
-    ''' </summary>
-    ''' <returns></returns>
-    Public ReadOnly Property HasCollectionNavigation As Boolean
-
-    ''' <summary>
-    ''' Gets collection initializers.<br/>
-    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
-    ''' </summary>
-    ''' <returns>Collection initializers or <see langword="Nothing"/> if <see cref="HasCollectionNavigation"/> is <see langword="False"/>.</returns>
-    Public ReadOnly Property CollectionInitializers As <MaybeNull> IReadOnlyList(Of Action(Of Object))
-
-    ''' <summary>
-    ''' Gets whether there is a relationship setter.<br/>
-    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
-    ''' </summary>
-    ''' <returns></returns>
-    Public ReadOnly Property HasRelationshipSetter As Boolean
-
-    ''' <summary>
-    ''' Gets relationship setter.<br/>
-    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
-    ''' </summary>
-    ''' <returns>Relationship setter or <see langword="Nothing"/> if <see cref="HasRelationshipSetter"/> is <see langword="False"/>.</returns>
-    Public ReadOnly Property RelationshipSetter As <MaybeNull> Action(Of Object, Object) ' declaring entity, related entity (this one);
-
-    ''' <summary>
-    ''' Gets whether there are included results.<br/>
-    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
-    ''' </summary>
-    ''' <returns></returns>
-    Public ReadOnly Property HasIncludedSqlResults As Boolean
-
-    ''' <summary>
-    ''' Gets reader data for included results.<br/>
-    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
-    ''' </summary>
-    ''' <returns>Reader data or <see langword="Nothing"/> if <see cref="HasIncludedSqlResults"/> is <see langword="False"/>.</returns>
-    Public ReadOnly Property IncludedSqlResultsReaderData As <MaybeNull> IReadOnlyList(Of IncludedSqlResultReaderData)
-
-    ''' <summary>
     ''' Creates new instance of <see cref="EntitySqlResultReaderData"/>.<br/>
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
     ''' <param name="sqlResult"></param>
     ''' <param name="readerIndex"></param>
     ''' <param name="entityReader"></param>
-    ''' <param name="includedSqlResultsReaderData"></param>
-    Public Sub New(<DisallowNull> sqlResult As EntitySqlResult, readerIndex As Int32, <DisallowNull> entityReader As Func(Of DbDataReader, Int32, Boolean(), Object), includedSqlResultsReaderData As IReadOnlyList(Of IncludedSqlResultReaderData))
+    Public Sub New(<DisallowNull> sqlResult As EntitySqlResult, readerIndex As Int32, <DisallowNull> entityReader As Func(Of DbDataReader, Int32, Boolean(), Object))
       MyBase.New(sqlResult, readerIndex)
       Me.Entity = sqlResult.Entity
       Me.Reader = entityReader
       Me.ContainsPKReader = Nothing
       Me.PKOffsets = Nothing
       Me.PKReader = Nothing
-      Me.HasRelatedEntities = False
-      Me.RelatedEntities = Nothing
-      Me.HasCollectionNavigation = False
-      Me.CollectionInitializers = Nothing
-      Me.HasRelationshipSetter = False
-      Me.RelationshipSetter = Nothing
-      Me.HasIncludedSqlResults = includedSqlResultsReaderData IsNot Nothing
-      Me.IncludedSqlResultsReaderData = includedSqlResultsReaderData
     End Sub
 
     ''' <summary>
@@ -144,14 +79,6 @@ Namespace Internal.Query
       Me.ContainsPKReader = containsPKReader
       Me.PKOffsets = pkOffsets
       Me.PKReader = Nothing
-      Me.HasRelatedEntities = False
-      Me.RelatedEntities = Nothing
-      Me.HasCollectionNavigation = False
-      Me.CollectionInitializers = Nothing
-      Me.HasRelationshipSetter = False
-      Me.RelationshipSetter = Nothing
-      Me.HasIncludedSqlResults = False
-      Me.IncludedSqlResultsReaderData = Nothing
     End Sub
 
     ''' <summary>
@@ -164,25 +91,13 @@ Namespace Internal.Query
     ''' <param name="containsPKReader"></param>
     ''' <param name="pkOffsets"></param>
     ''' <param name="pkReader"></param>
-    ''' <param name="relatedEntities"></param>
-    ''' <param name="collectionInitializers"></param>
-    ''' <param name="relationshipSetter"></param>
-    ''' <param name="includedSqlResultsReaderData"></param>
-    Public Sub New(<DisallowNull> sqlResult As EntitySqlResult, readerIndex As Int32, <DisallowNull> entityReader As Func(Of DbDataReader, Int32, Boolean(), Object), containsPKReader As Func(Of DbDataReader, Int32, Int32(), Boolean), pkOffsets As Int32(), pkReader As Func(Of DbDataReader, Int32, Int32(), Object), relatedEntities As IReadOnlyList(Of Int32), collectionInitializers As IReadOnlyList(Of Action(Of Object)), relationshipSetter As Action(Of Object, Object), includedSqlResultsReaderData As IReadOnlyList(Of IncludedSqlResultReaderData))
+    Public Sub New(<DisallowNull> sqlResult As EntitySqlResult, readerIndex As Int32, <DisallowNull> entityReader As Func(Of DbDataReader, Int32, Boolean(), Object), containsPKReader As Func(Of DbDataReader, Int32, Int32(), Boolean), pkOffsets As Int32(), pkReader As Func(Of DbDataReader, Int32, Int32(), Object))
       MyBase.New(sqlResult, readerIndex)
       Me.Entity = sqlResult.Entity
       Me.Reader = entityReader
       Me.ContainsPKReader = containsPKReader
       Me.PKOffsets = pkOffsets
       Me.PKReader = pkReader
-      Me.HasRelatedEntities = relatedEntities IsNot Nothing
-      Me.RelatedEntities = relatedEntities
-      Me.HasCollectionNavigation = collectionInitializers IsNot Nothing
-      Me.CollectionInitializers = collectionInitializers
-      Me.HasRelationshipSetter = relationshipSetter IsNot Nothing
-      Me.RelationshipSetter = relationshipSetter
-      Me.HasIncludedSqlResults = includedSqlResultsReaderData IsNot Nothing
-      Me.IncludedSqlResultsReaderData = includedSqlResultsReaderData
     End Sub
 
   End Class

--- a/Source/Source/Yamo/Internal/Query/ExcludedUnknownSqlResult.vb
+++ b/Source/Source/Yamo/Internal/Query/ExcludedUnknownSqlResult.vb
@@ -1,0 +1,24 @@
+﻿Imports System.Diagnostics.CodeAnalysis
+Imports Yamo.Internal.Query.Metadata
+
+Namespace Internal.Query
+
+  ''' <summary>
+  ''' Represents reader data for values of excluded types with no additional details.<br/>
+  ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+  ''' </summary>
+  Public Class ExcludedUnknownSqlResultReaderData
+    Inherits ReaderDataBase
+
+    ''' <summary>
+    ''' Creates new instance of <see cref="ExcludedUnknownSqlResultReaderData"/>.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <param name="sqlResult"></param>
+    ''' <param name="readerIndex"></param>
+    Public Sub New(<DisallowNull> sqlResult As ExcludedUnknownSqlResult, readerIndex As Int32)
+      MyBase.New(sqlResult, readerIndex)
+    End Sub
+
+  End Class
+End Namespace

--- a/Source/Source/Yamo/Internal/Query/Metadata/DeleteSqlModel.vb
+++ b/Source/Source/Yamo/Internal/Query/Metadata/DeleteSqlModel.vb
@@ -14,10 +14,9 @@ Namespace Internal.Query.Metadata
     ''' Creates new instance of <see cref="DeleteSqlModel"/>.<br/>
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
-    ''' <param name="model"></param>
-    ''' <param name="mainEntityType"></param>
-    Public Sub New(<DisallowNull> model As Model, <DisallowNull> mainEntityType As Type)
-      MyBase.New(model, mainEntityType)
+    ''' <param name="mainEntity"></param>
+    Public Sub New(<DisallowNull> mainEntity As Entity)
+      MyBase.New(mainEntity)
     End Sub
 
   End Class

--- a/Source/Source/Yamo/Internal/Query/Metadata/EntityBasedSqlEntity.vb
+++ b/Source/Source/Yamo/Internal/Query/Metadata/EntityBasedSqlEntity.vb
@@ -1,0 +1,100 @@
+﻿Imports System.Diagnostics.CodeAnalysis
+Imports Yamo.Metadata
+
+Namespace Internal.Query.Metadata
+
+  ''' <summary>
+  ''' Represents SQL related entity data that are based on entity model.<br/>
+  ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+  ''' </summary>
+  Public Class EntityBasedSqlEntity
+    Inherits SqlEntityBase
+
+    ''' <summary>
+    ''' Gets entity.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <returns></returns>
+    Public ReadOnly Property Entity As Entity
+
+    ''' <summary>
+    ''' Gets column aliases.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <returns>Returns <see langword="Nothing"/> if aliases are not used.</returns>
+    Public ReadOnly Property ColumnAliases As <MaybeNull> String()
+
+    ''' <summary>
+    ''' Creates new instance of <see cref="EntityBasedSqlEntity"/>.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <param name="entity"></param>
+    Sub New(<DisallowNull> entity As Entity)
+      Me.New(entity, "", -1)
+    End Sub
+
+    ''' <summary>
+    ''' Creates new instance of <see cref="EntityBasedSqlEntity"/>.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <param name="entity"></param>
+    ''' <param name="tableAlias"></param>
+    ''' <param name="index"></param>
+    Sub New(<DisallowNull> entity As Entity, <DisallowNull> tableAlias As String, index As Int32)
+      MyBase.New(entity.EntityType, tableAlias, index, entity.GetPropertiesCount())
+      Me.Entity = entity
+    End Sub
+
+    ''' <summary>
+    ''' Creates new instance of <see cref="EntityBasedSqlEntity"/>.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <param name="entity"></param>
+    ''' <param name="tableAlias"></param>
+    ''' <param name="index"></param>
+    ''' <param name="relationship"></param>
+    ''' <param name="isIgnored"></param>
+    Sub New(<DisallowNull> entity As Entity, <DisallowNull> tableAlias As String, index As Int32, relationship As SqlEntityRelationship, isIgnored As Boolean)
+      MyBase.New(entity.EntityType, tableAlias, index, entity.GetPropertiesCount(), relationship, isIgnored)
+      Me.Entity = entity
+    End Sub
+
+    ''' <summary>
+    ''' Sets column aliases if they are used.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <param name="aliases"></param>
+    Public Sub SetColumnAliases(<DisallowNull> aliases As String())
+      _ColumnAliases = aliases
+    End Sub
+
+    ''' <summary>
+    ''' Gets column name.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <param name="propertyName"></param>
+    ''' <returns></returns>
+    Public Overrides Function GetColumnName(<DisallowNull> propertyName As String) As String
+      If Me.ColumnAliases Is Nothing Then
+        Return Me.Entity.GetProperty(propertyName).ColumnName
+      Else
+        Return Me.ColumnAliases(Me.Entity.GetProperty(propertyName).Index)
+      End If
+    End Function
+
+    ''' <summary>
+    ''' Gets column name.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <param name="index"></param>
+    ''' <returns></returns>
+    Public Overrides Function GetColumnName(index As Int32) As String
+      If Me.ColumnAliases Is Nothing Then
+        Return Me.Entity.GetProperty(index).ColumnName
+      Else
+        Return Me.ColumnAliases(index)
+      End If
+    End Function
+
+  End Class
+End Namespace

--- a/Source/Source/Yamo/Internal/Query/Metadata/EntitySqlResult.vb
+++ b/Source/Source/Yamo/Internal/Query/Metadata/EntitySqlResult.vb
@@ -14,14 +14,14 @@ Namespace Internal.Query.Metadata
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
     ''' <returns></returns>
-    Public ReadOnly Property Entity As SqlEntity
+    Public ReadOnly Property Entity As EntityBasedSqlEntity
 
     ''' <summary>
     ''' Creates new instance of <see cref="EntitySqlResult"/>.<br/>
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
     ''' <param name="entity"></param>
-    Public Sub New(<DisallowNull> entity As SqlEntity)
+    Public Sub New(<DisallowNull> entity As EntityBasedSqlEntity)
       MyBase.New(entity.Entity.EntityType)
       Me.Entity = entity
     End Sub

--- a/Source/Source/Yamo/Internal/Query/Metadata/ExcludedUnknownSqlResult.vb
+++ b/Source/Source/Yamo/Internal/Query/Metadata/ExcludedUnknownSqlResult.vb
@@ -1,0 +1,32 @@
+﻿Imports System.Diagnostics.CodeAnalysis
+Imports System.Reflection
+
+Namespace Internal.Query.Metadata
+
+  ''' <summary>
+  ''' Represents SQL result of an excluded type with no additional details.<br/>
+  ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+  ''' </summary>
+  Public Class ExcludedUnknownSqlResult
+    Inherits SqlResultBase
+
+    ''' <summary>
+    ''' Creates new instance of <see cref="ExcludedUnknownSqlResult"/>.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <param name="resultType"></param>
+    Public Sub New(<DisallowNull> resultType As Type)
+      MyBase.New(resultType)
+    End Sub
+
+    ''' <summary>
+    ''' Gets count of columns in the resultset.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <returns></returns>
+    Public Overrides Function GetColumnCount() As Int32
+      Return 0
+    End Function
+
+  End Class
+End Namespace

--- a/Source/Source/Yamo/Internal/Query/Metadata/JoinInfo.vb
+++ b/Source/Source/Yamo/Internal/Query/Metadata/JoinInfo.vb
@@ -16,11 +16,25 @@ Namespace Internal.Query.Metadata
     Public ReadOnly Property JoinType As JoinType
 
     ''' <summary>
-    ''' Gets table source.<br/>
+    ''' Gets table source (if used).<br/>
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
     ''' <returns></returns>
     Public ReadOnly Property TableSource As <MaybeNull> String
+
+    ''' <summary>
+    ''' Gets subquery (if used).<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <returns></returns>
+    Public ReadOnly Property Subquery As <MaybeNull> SelectQuery
+
+    ''' <summary>
+    ''' Gets non model entity creation behavior (if used).<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <returns></returns>
+    Public ReadOnly Property NonModelEntityCreationBehavior As NonModelEntityCreationBehavior
 
     ''' <summary>
     ''' Creates new instance of <see cref="JoinInfo"/>.<br/>
@@ -38,8 +52,22 @@ Namespace Internal.Query.Metadata
     ''' <param name="joinType"></param>
     ''' <param name="tableSource"></param>
     Sub New(<DisallowNull> joinType As JoinType, tableSource As String)
+      Me.New(joinType, tableSource, Nothing, NonModelEntityCreationBehavior.NullIfAllColumnsAreNull)
+    End Sub
+
+    ''' <summary>
+    ''' Creates new instance of <see cref="JoinInfo"/>.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <param name="joinType"></param>
+    ''' <param name="tableSource"></param>
+    ''' <param name="subquery"></param>
+    ''' <param name="creationBehavior"></param>
+    Sub New(<DisallowNull> joinType As JoinType, tableSource As String, subquery As SelectQuery, creationBehavior As NonModelEntityCreationBehavior)
       Me.JoinType = joinType
       Me.TableSource = tableSource
+      Me.Subquery = subquery
+      Me.NonModelEntityCreationBehavior = creationBehavior
     End Sub
 
   End Structure

--- a/Source/Source/Yamo/Internal/Query/Metadata/NonModelEntity.vb
+++ b/Source/Source/Yamo/Internal/Query/Metadata/NonModelEntity.vb
@@ -1,0 +1,106 @@
+﻿Imports System.Diagnostics.CodeAnalysis
+Imports Yamo.Metadata
+
+Namespace Internal.Query.Metadata
+
+  ''' <summary>
+  ''' Represents an ad hoc entity that is not part of the database model.<br/>
+  ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+  ''' </summary>
+  Public Class NonModelEntity
+
+    ''' <summary>
+    ''' Gets type representing this entity.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <returns></returns>
+    Public ReadOnly Property EntityType As Type
+
+    ''' <summary>
+    ''' Gets SQL result.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <returns><see langword="Nothing"/> may be returned if object is not fully initialized yet.</returns>
+    Public ReadOnly Property SqlResult As <MaybeNull> SqlResultBase
+
+    ''' <summary>
+    ''' Stores column names by their corresponding property names.
+    ''' </summary>
+    Private m_ColumnsDictionary As Dictionary(Of String, String)
+
+    ''' <summary>
+    ''' Stores column names.
+    ''' </summary>
+    Private m_Columns As List(Of String)
+
+    ''' <summary>
+    ''' Creates new instance of <see cref="NonModelEntity"/>.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <param name="entityType"></param>
+    Public Sub New(<DisallowNull> entityType As Type)
+      Me.EntityType = entityType
+      m_ColumnsDictionary = New Dictionary(Of String, String)
+      m_Columns = New List(Of String)
+    End Sub
+
+    ''' <summary>
+    ''' Gets column name.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <param name="propertyName"></param>
+    ''' <returns></returns>
+    Public Function GetColumnName(<DisallowNull> propertyName As String) As String
+      Return m_ColumnsDictionary(propertyName)
+    End Function
+
+    ''' <summary>
+    ''' Gets column names.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <param name="index"></param>
+    ''' <returns></returns>
+    Public Function GetColumnName(index As Int32) As String
+      Return m_Columns(index)
+    End Function
+
+    ''' <summary>
+    ''' Gets columns count.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <returns></returns>
+    Public Function GetColumnsCount() As Int32
+      Return m_Columns.Count
+    End Function
+
+    ''' <summary>
+    ''' Adds column which value will be used to fill a property of this entity.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <param name="propertyName"></param>
+    ''' <param name="columnName"></param>
+    Public Sub AddColumn(<DisallowNull> propertyName As String, <DisallowNull> columnName As String)
+      m_ColumnsDictionary(propertyName) = columnName
+      m_Columns.Add(columnName)
+    End Sub
+
+    ''' <summary>
+    ''' Adds column which value won't be used to directly fill a property of this entity.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <param name="columnName"></param>
+    Public Sub AddColumn(<DisallowNull> columnName As String)
+      m_Columns.Add(columnName)
+    End Sub
+
+    ''' <summary>
+    ''' Sets SQL result.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <param name="sqlResult"></param>
+    Public Sub SetSqlResult(<DisallowNull> sqlResult As SqlResultBase)
+      Me._SqlResult = sqlResult
+    End Sub
+
+  End Class
+End Namespace

--- a/Source/Source/Yamo/Internal/Query/Metadata/NonModelEntityBasedSqlEntity.vb
+++ b/Source/Source/Yamo/Internal/Query/Metadata/NonModelEntityBasedSqlEntity.vb
@@ -1,0 +1,64 @@
+﻿Imports System.Diagnostics.CodeAnalysis
+Imports Yamo.Metadata
+
+Namespace Internal.Query.Metadata
+
+  ''' <summary>
+  ''' Represents SQL related entity data that are based on non model entity.<br/>
+  ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+  ''' </summary>
+  Public Class NonModelEntityBasedSqlEntity
+    Inherits SqlEntityBase
+
+    ''' <summary>
+    ''' Gets entity.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <returns></returns>
+    Public ReadOnly Property Entity As NonModelEntity
+
+    ''' <summary>
+    ''' Gets entity creation behavior.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <returns></returns>
+    Public ReadOnly Property CreationBehavior As NonModelEntityCreationBehavior
+
+    ''' <summary>
+    ''' Creates new instance of <see cref="EntityBasedSqlEntity"/>.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <param name="entity"></param>
+    ''' <param name="tableAlias"></param>
+    ''' <param name="index"></param>
+    ''' <param name="relationship"></param>
+    ''' <param name="isIgnored"></param>
+    ''' <param name="creationBehavior"></param>
+    Sub New(<DisallowNull> entity As NonModelEntity, <DisallowNull> tableAlias As String, index As Int32, relationship As SqlEntityRelationship, isIgnored As Boolean, creationBehavior As NonModelEntityCreationBehavior)
+      MyBase.New(entity.EntityType, tableAlias, index, entity.GetColumnsCount(), relationship, isIgnored)
+      Me.Entity = entity
+      Me.CreationBehavior = creationBehavior
+    End Sub
+
+    ''' <summary>
+    ''' Gets column name.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <param name="propertyName"></param>
+    ''' <returns></returns>
+    Public Overrides Function GetColumnName(<DisallowNull> propertyName As String) As String
+      Return Me.Entity.GetColumnName(propertyName)
+    End Function
+
+    ''' <summary>
+    ''' Gets column name.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <param name="index"></param>
+    ''' <returns></returns>
+    Public Overrides Function GetColumnName(index As Int32) As String
+      Return Me.Entity.GetColumnName(index)
+    End Function
+
+  End Class
+End Namespace

--- a/Source/Source/Yamo/Internal/Query/Metadata/SqlEntityBase.vb
+++ b/Source/Source/Yamo/Internal/Query/Metadata/SqlEntityBase.vb
@@ -4,19 +4,16 @@ Imports Yamo.Metadata
 Namespace Internal.Query.Metadata
 
   ''' <summary>
-  ''' Represents SQL related entity data.<br/>
+  ''' Base class for SQL related entity data.<br/>
   ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
   ''' </summary>
-  Public Class SqlEntity
-
-    ' TODO: SIP - structure instead?
+  Public MustInherit Class SqlEntityBase
 
     ''' <summary>
-    ''' Gets entity.<br/>
-    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' Gets type of model representing this SQL entity.
     ''' </summary>
     ''' <returns></returns>
-    Public ReadOnly Property Entity As Entity
+    Public ReadOnly Property EntityType As Type
 
     ''' <summary>
     ''' Gets table alias.<br/>
@@ -76,30 +73,22 @@ Namespace Internal.Query.Metadata
     Public ReadOnly Property IncludedSqlResults As <MaybeNull> List(Of SqlEntityIncludedResult)
 
     ''' <summary>
-    ''' Creates new instance of <see cref="SqlEntity"/>.<br/>
+    ''' Creates new instance of <see cref="SqlEntityBase"/>.<br/>
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
-    ''' <param name="entity"></param>
-    Sub New(<DisallowNull> entity As Entity)
-      Me.New(entity, "", -1)
-    End Sub
-
-    ''' <summary>
-    ''' Creates new instance of <see cref="SqlEntity"/>.<br/>
-    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
-    ''' </summary>
-    ''' <param name="entity"></param>
+    ''' <param name="entityType"></param>
     ''' <param name="tableAlias"></param>
     ''' <param name="index"></param>
-    Sub New(<DisallowNull> entity As Entity, <DisallowNull> tableAlias As String, index As Int32)
-      Me.Entity = entity
+    ''' <param name="columnsCount"></param>
+    Sub New(<DisallowNull> entityType As Type, <DisallowNull> tableAlias As String, index As Int32, columnsCount As Int32)
+      Me.EntityType = entityType
       Me.TableAlias = tableAlias
       Me.Index = index
       Me.Relationship = Nothing
       Me.IsExcluded = False
       Me.IsIgnored = False
 
-      Dim lastIndex = Me.Entity.GetPropertiesCount() - 1
+      Dim lastIndex = columnsCount - 1
       Dim includedColumns = New Boolean(lastIndex) {}
 
       For i = 0 To lastIndex
@@ -111,16 +100,17 @@ Namespace Internal.Query.Metadata
     End Sub
 
     ''' <summary>
-    ''' Creates new instance of <see cref="SqlEntity"/>.<br/>
+    ''' Creates new instance of <see cref="SqlEntityBase"/>.<br/>
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
-    ''' <param name="entity"></param>
+    ''' <param name="entityType"></param>
     ''' <param name="tableAlias"></param>
     ''' <param name="index"></param>
+    ''' <param name="columnsCount"></param>
     ''' <param name="relationship"></param>
     ''' <param name="isIgnored"></param>
-    Sub New(<DisallowNull> entity As Entity, <DisallowNull> tableAlias As String, index As Int32, relationship As SqlEntityRelationship, isIgnored As Boolean)
-      Me.New(entity, tableAlias, index)
+    Sub New(<DisallowNull> entityType As Type, <DisallowNull> tableAlias As String, index As Int32, columnsCount As Int32, relationship As SqlEntityRelationship, isIgnored As Boolean)
+      Me.New(entityType, tableAlias, index, columnsCount)
       Me.Relationship = relationship
       Me.IsIgnored = isIgnored
     End Sub
@@ -141,6 +131,22 @@ Namespace Internal.Query.Metadata
     Public Sub Exclude()
       Me._IsExcluded = True
     End Sub
+
+    ''' <summary>
+    ''' Gets column name.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <param name="propertyName"></param>
+    ''' <returns></returns>
+    Public MustOverride Function GetColumnName(<DisallowNull> propertyName As String) As String
+
+    ''' <summary>
+    ''' Gets column name.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <param name="index"></param>
+    ''' <returns></returns>
+    Public MustOverride Function GetColumnName(index As Int32) As String
 
     ''' <summary>
     ''' Gets count of included columns. Only columns representing entity properties are counted, not columns representing included result(s).<br/>

--- a/Source/Source/Yamo/Internal/Query/Metadata/SqlEntityRelationship.vb
+++ b/Source/Source/Yamo/Internal/Query/Metadata/SqlEntityRelationship.vb
@@ -16,7 +16,7 @@ Namespace Internal.Query.Metadata
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
     ''' <returns></returns>
-    Public ReadOnly Property DeclaringEntity As SqlEntity
+    Public ReadOnly Property DeclaringEntity As SqlEntityBase
 
     ''' <summary>
     ''' Gets relationship navigation.<br/>
@@ -58,7 +58,7 @@ Namespace Internal.Query.Metadata
     ''' </summary>
     ''' <param name="declaringEntity"></param>
     ''' <param name="relationshipNavigation"></param>
-    Sub New(<DisallowNull> declaringEntity As SqlEntity, <DisallowNull> relationshipNavigation As RelationshipNavigation)
+    Sub New(<DisallowNull> declaringEntity As SqlEntityBase, <DisallowNull> relationshipNavigation As RelationshipNavigation)
       Me.DeclaringEntity = declaringEntity
       Me.RelationshipNavigation = relationshipNavigation
 

--- a/Source/Source/Yamo/Internal/Query/Metadata/SqlModelBase.vb
+++ b/Source/Source/Yamo/Internal/Query/Metadata/SqlModelBase.vb
@@ -10,57 +10,62 @@ Namespace Internal.Query.Metadata
   Public MustInherit Class SqlModelBase
 
     ''' <summary>
-    ''' Gets model.<br/>
-    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
-    ''' </summary>
-    ''' <returns></returns>
-    Public ReadOnly Property Model As Model
-
-    ''' <summary>
     ''' Gets main SQL entity.<br/>
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
     ''' <returns></returns>
-    Public ReadOnly Property MainEntity As SqlEntity
-      Get
-        Return Me.Entities(0)
-      End Get
-    End Property
+    Public ReadOnly Property MainEntity As EntityBasedSqlEntity
 
     ''' <summary>
-    ''' Gets SQL entities.
+    ''' Gets SQL entities.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
     ''' <returns></returns>
-    Protected ReadOnly Property Entities As List(Of SqlEntity)
+    Protected ReadOnly Property Entities As List(Of SqlEntityBase)
 
     ''' <summary>
     ''' Creates new instance of <see cref="SqlModelBase"/>.<br/>
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
-    ''' <param name="model"></param>
-    ''' <param name="mainEntityType"></param>
-    Public Sub New(<DisallowNull> model As Model, <DisallowNull> mainEntityType As Type)
-      Me.Model = model
-      Me.Entities = New List(Of SqlEntity)
+    ''' <param name="mainEntity"></param>
+    Public Sub New(<DisallowNull> mainEntity As Entity)
+      Me.Entities = New List(Of SqlEntityBase)
 
-      Dim entity = Me.Model.GetEntity(mainEntityType)
       Dim tableAlias = "T0"
 
-      Me.Entities.Add(New SqlEntity(entity, tableAlias, 0))
+      Me.MainEntity = New EntityBasedSqlEntity(mainEntity, tableAlias, 0)
+      Me.Entities.Add(Me.MainEntity)
     End Sub
 
     ''' <summary>
     ''' Adds SQL entity used in the query.
     ''' </summary>
-    ''' <param name="entityType"></param>
+    ''' <param name="entity"></param>
     ''' <param name="relationship"></param>
     ''' <param name="isIgnored"></param>
     ''' <returns></returns>
-    Protected Function AddEntity(<DisallowNull> entityType As Type, relationship As SqlEntityRelationship, isIgnored As Boolean) As SqlEntity
-      Dim entity = Me.Model.GetEntity(entityType)
+    Protected Function AddEntity(<DisallowNull> entity As Entity, relationship As SqlEntityRelationship, isIgnored As Boolean) As EntityBasedSqlEntity
       Dim index = Me.Entities.Count
       Dim tableAlias = "T" & index.ToString(Globalization.CultureInfo.InvariantCulture)
-      Dim sqlEntity = New SqlEntity(entity, tableAlias, index, relationship, isIgnored)
+      Dim sqlEntity = New EntityBasedSqlEntity(entity, tableAlias, index, relationship, isIgnored)
+
+      Me.Entities.Add(sqlEntity)
+
+      Return sqlEntity
+    End Function
+
+    ''' <summary>
+    ''' Adds SQL entity used in the query.
+    ''' </summary>
+    ''' <param name="entity"></param>
+    ''' <param name="relationship"></param>
+    ''' <param name="isIgnored"></param>
+    ''' <param name="creationBehavior"></param>
+    ''' <returns></returns>
+    Protected Function AddEntity(<DisallowNull> entity As NonModelEntity, relationship As SqlEntityRelationship, isIgnored As Boolean, creationBehavior As NonModelEntityCreationBehavior) As NonModelEntityBasedSqlEntity
+      Dim index = Me.Entities.Count
+      Dim tableAlias = "T" & index.ToString(Globalization.CultureInfo.InvariantCulture)
+      Dim sqlEntity = New NonModelEntityBasedSqlEntity(entity, tableAlias, index, relationship, isIgnored, creationBehavior)
 
       Me.Entities.Add(sqlEntity)
 
@@ -73,7 +78,7 @@ Namespace Internal.Query.Metadata
     ''' </summary>
     ''' <param name="index"></param>
     ''' <returns></returns>
-    Public Function GetEntity(index As Int32) As SqlEntity
+    Public Function GetEntity(index As Int32) As SqlEntityBase
       Return Me.Entities(index)
     End Function
 
@@ -82,7 +87,7 @@ Namespace Internal.Query.Metadata
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
     ''' <returns></returns>
-    Public Function GetLastEntity() As SqlEntity
+    Public Function GetLastEntity() As SqlEntityBase
       Return Me.Entities.Last()
     End Function
 
@@ -91,12 +96,12 @@ Namespace Internal.Query.Metadata
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
     ''' <returns></returns>
-    Public Function GetEntities() As SqlEntity()
+    Public Function GetEntities() As SqlEntityBase()
       Return Me.Entities.ToArray()
     End Function
 
     ''' <summary>
-    ''' Get entities count.<br/>
+    ''' Gets entities count.<br/>
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
     ''' <returns></returns>

--- a/Source/Source/Yamo/Internal/Query/Metadata/UpdateSqlModel.vb
+++ b/Source/Source/Yamo/Internal/Query/Metadata/UpdateSqlModel.vb
@@ -14,10 +14,9 @@ Namespace Internal.Query.Metadata
     ''' Creates new instance of <see cref="UpdateSqlModel"/>.<br/>
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
-    ''' <param name="model"></param>
-    ''' <param name="mainEntityType"></param>
-    Public Sub New(<DisallowNull> model As Model, <DisallowNull> mainEntityType As Type)
-      MyBase.New(model, mainEntityType)
+    ''' <param name="mainEntity"></param>
+    Public Sub New(<DisallowNull> mainEntity As Entity)
+      MyBase.New(mainEntity)
     End Sub
 
   End Class

--- a/Source/Source/Yamo/Internal/SqlExpressionVisitor.vb
+++ b/Source/Source/Yamo/Internal/SqlExpressionVisitor.vb
@@ -103,6 +103,11 @@ Namespace Internal
     Private m_CustomSqlResultItemIndex As Int32
 
     ''' <summary>
+    ''' Stores non model entity.
+    ''' </summary>
+    Private m_NonModelEntity As NonModelEntity
+
+    ''' <summary>
     ''' Stores stack of nodes.
     ''' </summary>
     Private m_Stack As Stack(Of NodeInfo)
@@ -143,6 +148,7 @@ Namespace Internal
       m_CurrentLikeParameterFormat = Nothing
       m_CustomSqlResult = Nothing
       m_CustomSqlResultItemIndex = 0
+      m_NonModelEntity = Nothing
       m_Stack.Clear()
     End Sub
 
@@ -180,8 +186,9 @@ Namespace Internal
     ''' <param name="expression"></param>
     ''' <param name="entityIndexHints"><see langword="Nothing"/> for <see cref="ExpressionParametersType.IJoin"/> and not <see langword="Nothing"/> for <see cref="ExpressionParametersType.Entities"/>.</param>
     ''' <param name="parameterIndex"></param>
+    ''' <param name="createNonModelEntity"></param>
     ''' <returns></returns>
-    Public Function TranslateCustomSelect(<DisallowNull> expression As Expression, entityIndexHints As Int32(), parameterIndex As Int32) As (SqlString As SqlString, SqlResult As SqlResultBase)
+    Public Function TranslateCustomSelect(<DisallowNull> expression As Expression, entityIndexHints As Int32(), parameterIndex As Int32, createNonModelEntity As Boolean) As (SqlString As SqlString, SqlResult As SqlResultBase, NonModelEntity As NonModelEntity)
       If TypeOf expression IsNot LambdaExpression Then
         Throw New ArgumentException("Expression must be of type LambdaExpression.")
       End If
@@ -190,11 +197,19 @@ Namespace Internal
 
       Initialize(lambda, ExpressionTranslateMode.CustomSelect, entityIndexHints, parameterIndex, -1, True, True)
 
+      If createNonModelEntity Then
+        m_NonModelEntity = New NonModelEntity(lambda.ReturnType)
+      End If
+
       VisitInCustomSelectOrIncludeMode(lambda.Body)
 
       m_ExpressionParameters = Nothing
 
-      Return (New SqlString(m_Sql.ToString(), m_Parameters), m_CustomSqlResult)
+      If createNonModelEntity Then
+        m_NonModelEntity.SetSqlResult(m_CustomSqlResult)
+      End If
+
+      Return (New SqlString(m_Sql.ToString(), m_Parameters), m_CustomSqlResult, m_NonModelEntity)
     End Function
 
     ''' <summary>
@@ -963,7 +978,7 @@ Namespace Internal
         m_Sql.Append(", ")
       End If
 
-      Dim resultItems = ProcessItemsInCustomSelectOrIncludeMode(items, isInCustomSelectMode)
+      Dim resultItems = ProcessItemsInCustomSelectOrIncludeMode(items, isInCustomSelectMode, NewExpressionType.AdHoc, True, members)
 
       adHocTypeSqlResult.SetMembers(members, resultItems)
 
@@ -983,11 +998,11 @@ Namespace Internal
         m_Sql.Append(Evaluate(node.Arguments(0)))
         Return node
       ElseIf Helpers.Types.IsValueTuple(type) Then
-        Return VisitNewValueTupleOrAnonymousOrAdHocType(node, NewExpressionType.ValueTuple)
+        Return VisitNewValueTupleOrAnonymousOrAdHocType(node, NewExpressionType.ValueTuple, True)
       ElseIf Helpers.Types.IsAnonymousType(type) Then
-        Return VisitNewValueTupleOrAnonymousOrAdHocType(node, NewExpressionType.Anonymous)
+        Return VisitNewValueTupleOrAnonymousOrAdHocType(node, NewExpressionType.Anonymous, True)
       Else
-        Return VisitNewValueTupleOrAnonymousOrAdHocType(node, NewExpressionType.AdHoc)
+        Return VisitNewValueTupleOrAnonymousOrAdHocType(node, NewExpressionType.AdHoc, False)
       End If
     End Function
 
@@ -996,8 +1011,9 @@ Namespace Internal
     ''' </summary>
     ''' <param name="node"></param>
     ''' <param name="newType"></param>
+    ''' <param name="canUseMembersForNonModelEntity"></param>
     ''' <returns></returns>
-    Private Function VisitNewValueTupleOrAnonymousOrAdHocType(node As NewExpression, newType As NewExpressionType) As Expression
+    Private Function VisitNewValueTupleOrAnonymousOrAdHocType(node As NewExpression, newType As NewExpressionType, canUseMembersForNonModelEntity As Boolean) As Expression
       If Helpers.Types.IsNullable(node.Type) Then
         m_Stack.Peek().IsNullableConstructor = True
         Return Visit(node.Arguments(0))
@@ -1018,7 +1034,7 @@ Namespace Internal
       Dim isInIncludeMode = m_Mode = ExpressionTranslateMode.Include
 
       If isInCustomSelectMode OrElse isInIncludeMode Then
-        Dim items = ProcessItemsInCustomSelectOrIncludeMode(args, isInCustomSelectMode)
+        Dim items = ProcessItemsInCustomSelectOrIncludeMode(args, isInCustomSelectMode, newType, canUseMembersForNonModelEntity, node.Members)
 
         If isValueTuple Then
           Dim isNullable = IsNestedConstructorOfNullableValueTupleTypeSqlResult()
@@ -1063,8 +1079,11 @@ Namespace Internal
     ''' </summary>
     ''' <param name="items"></param>
     ''' <param name="isInCustomSelectMode"></param>
+    ''' <param name="newType"></param>
+    ''' <param name="canUseMembersForNonModelEntity"></param>
+    ''' <param name="members"></param>
     ''' <returns></returns>
-    Private Function ProcessItemsInCustomSelectOrIncludeMode(items As IReadOnlyList(Of Expression), isInCustomSelectMode As Boolean) As SqlResultBase()
+    Private Function ProcessItemsInCustomSelectOrIncludeMode(items As IReadOnlyList(Of Expression), isInCustomSelectMode As Boolean, newType As NewExpressionType, canUseMembersForNonModelEntity As Boolean, members As IReadOnlyList(Of MemberInfo)) As SqlResultBase()
       Dim count = items.Count
 
       Dim resultItems = New SqlResultBase(count - 1) {}
@@ -1074,7 +1093,7 @@ Namespace Internal
       For i = 0 To count - 1
         Dim arg = items(i)
         Dim type = arg.Type
-        Dim entity = entities.FirstOrDefault(Function(x) x.Entity.EntityType = type)
+        Dim entity = entities.OfType(Of EntityBasedSqlEntity).FirstOrDefault(Function(x) x.EntityType = type)
         Dim isEntity = entity IsNot Nothing
         Dim columnIndex = m_CustomSqlResultItemIndex
 
@@ -1086,8 +1105,13 @@ Namespace Internal
           resultItems(i) = New EntitySqlResult(entity)
         Else
           Dim columnAlias = If(isInCustomSelectMode, CreateColumnAlias(columnIndex), CreateIncludeColumnAlias(columnIndex))
-          m_Sql.Append(" ")
-          m_Builder.DialectProvider.Formatter.AppendIdentifier(m_Sql, columnAlias)
+
+          If m_NonModelEntity Is Nothing OrElse Not canUseMembersForNonModelEntity Then
+            AppendColumnAliasWithSpace(columnAlias)
+          Else
+            AppendColumnAliasWithSpace(columnAlias, newType, members, i)
+          End If
+
           resultItems(i) = New ScalarValueSqlResult(type)
         End If
 
@@ -1184,19 +1208,22 @@ Namespace Internal
       Visit(node)
 
       Dim type = node.Type
-      Dim entity = m_Model.GetEntities().FirstOrDefault(Function(x) x.Entity.EntityType = type)
+      Dim entity = m_Model.GetEntities().FirstOrDefault(Function(x) x.EntityType = type)
 
       Dim isInCustomSelectMode = m_Mode = ExpressionTranslateMode.CustomSelect
 
       If entity Is Nothing Then
         ' simple scalar value
         Dim columnAlias = If(isInCustomSelectMode, CreateColumnAlias(0), CreateIncludeColumnAlias(0))
-        m_Sql.Append(" ")
-        m_Builder.DialectProvider.Formatter.AppendIdentifier(m_Sql, columnAlias)
+        AppendColumnAliasWithSpace(columnAlias)
         m_CustomSqlResult = New ScalarValueSqlResult(type)
       Else
         ' whole entity
-        m_CustomSqlResult = New EntitySqlResult(entity)
+        If TypeOf entity IsNot EntityBasedSqlEntity Then
+          Throw New NotSupportedException($"Unsupported type '{type}' in custom select.")
+        End If
+
+        m_CustomSqlResult = New EntitySqlResult(DirectCast(entity, EntityBasedSqlEntity))
       End If
 
       Return node
@@ -1374,31 +1401,71 @@ Namespace Internal
     End Sub
 
     ''' <summary>
+    ''' Appends column alias.
+    ''' </summary>
+    ''' <param name="columnAlias"></param>
+    Private Sub AppendColumnAliasWithSpace(columnAlias As String)
+      m_Sql.Append(" ")
+      m_Builder.DialectProvider.Formatter.AppendIdentifier(m_Sql, columnAlias)
+
+      If m_NonModelEntity IsNot Nothing Then
+        m_NonModelEntity.AddColumn(columnAlias)
+      End If
+    End Sub
+
+    ''' <summary>
+    ''' Appends column alias.
+    ''' </summary>
+    ''' <param name="columnAlias"></param>
+    ''' <param name="newType"></param>
+    ''' <param name="members"></param>
+    ''' <param name="memberIndex"></param>
+    Private Sub AppendColumnAliasWithSpace(columnAlias As String, newType As NewExpressionType, members As IReadOnlyList(Of MemberInfo), memberIndex As Int32)
+      m_Sql.Append(" ")
+      m_Builder.DialectProvider.Formatter.AppendIdentifier(m_Sql, columnAlias)
+
+      If m_NonModelEntity IsNot Nothing Then
+        Dim propertyName As String
+
+        If newType = NewExpressionType.ValueTuple Then
+          ' NOTE: for large value tuples, this won't work properly, because of nesting.
+          ' We could throw an exception here. But that would be limiting. Returning such large value tuple
+          ' will work and so will accessing Item1 - Item7 members later in the query. Problem only occurs
+          ' when nested member (wrongly translated to Item8+) will be accessed in the expression later.
+          ' Then, there will be an exception.
+          propertyName = "Item" & (memberIndex + 1).ToString(Globalization.CultureInfo.InvariantCulture)
+        Else
+          propertyName = members(memberIndex).Name
+        End If
+
+        m_NonModelEntity.AddColumn(propertyName, columnAlias)
+      End If
+    End Sub
+
+    ''' <summary>
     ''' Appends entity member access.
     ''' </summary>
     ''' <param name="entityIndex"></param>
     ''' <param name="propertyName"></param>
     Private Sub AppendEntityMemberAccess(entityIndex As Int32, propertyName As String)
       Dim entity = m_Model.GetEntity(entityIndex)
-      Dim isIgnored = entity.IsIgnored
-      Dim prop = entity.Entity.GetProperty(propertyName)
 
-      If isIgnored Then
+      If entity.IsIgnored Then
         ' NOTE: currently, we append NULL if table is ignored. This could be solved better for SELECT clauses.
         ' We could omit column in SQL and instead of using reader, set value directly to Nothing (default).
         m_Sql.Append("NULL")
       ElseIf Not m_UseTableNamesOrAliases Then
-        m_Builder.DialectProvider.Formatter.AppendIdentifier(m_Sql, prop.ColumnName)
+        m_Builder.DialectProvider.Formatter.AppendIdentifier(m_Sql, entity.GetColumnName(propertyName))
       ElseIf m_UseAliases Then
-        Dim tableAlias = m_Model.GetEntity(entity.Index).TableAlias
-        m_Builder.DialectProvider.Formatter.AppendIdentifier(m_Sql, tableAlias)
+        m_Builder.DialectProvider.Formatter.AppendIdentifier(m_Sql, entity.TableAlias)
         m_Sql.Append(".")
-        m_Builder.DialectProvider.Formatter.AppendIdentifier(m_Sql, prop.ColumnName)
+        m_Builder.DialectProvider.Formatter.AppendIdentifier(m_Sql, entity.GetColumnName(propertyName))
       Else
+        Throw New InvalidOperationException("Calling AppendEntityMemberAccess is not supported in this context.")
         ' NOTE: this is not used right now
-        m_Builder.DialectProvider.Formatter.AppendIdentifier(m_Sql, entity.Entity.TableName, entity.Entity.Schema)
-        m_Sql.Append(".")
-        m_Builder.DialectProvider.Formatter.AppendIdentifier(m_Sql, prop.ColumnName)
+        'm_Builder.DialectProvider.Formatter.AppendIdentifier(m_Sql, entity.Entity.TableName, entity.Entity.Schema)
+        'm_Sql.Append(".")
+        'm_Builder.DialectProvider.Formatter.AppendIdentifier(m_Sql, entity.GetColumnName(propertyName))
       End If
     End Sub
 
@@ -1420,12 +1487,11 @@ Namespace Internal
       Dim isInIncludeMode = m_Mode = ExpressionTranslateMode.Include
 
       Dim isIgnored = entity.IsIgnored
-      Dim properties = entity.Entity.GetProperties()
       Dim columnCount = entity.GetColumnCount(isInIncludeMode)
       Dim columnIndex = 0
 
-      For propertyIndex = 0 To properties.Count - 1
-        If entity.IncludedColumns(propertyIndex) Then
+      For i = 0 To entity.IncludedColumns.Length - 1
+        If entity.IncludedColumns(i) Then
           If isIgnored Then
             ' NOTE: currently, we append NULL if table is ignored. This could be solved better for SELECT clauses.
             ' We could omit columns in SQL and instead of using entity reader, set value directly to Nothing (default).
@@ -1433,17 +1499,15 @@ Namespace Internal
           Else
             m_Builder.DialectProvider.Formatter.AppendIdentifier(m_Sql, entity.TableAlias)
             m_Sql.Append(".")
-            m_Builder.DialectProvider.Formatter.AppendIdentifier(m_Sql, properties(propertyIndex).ColumnName)
+            m_Builder.DialectProvider.Formatter.AppendIdentifier(m_Sql, entity.GetColumnName(i))
           End If
 
           If isInCustomSelectMode Then
             Dim columnAlias = CreateColumnAlias(m_CustomSqlResultItemIndex, columnIndex)
-            m_Sql.Append(" ")
-            m_Builder.DialectProvider.Formatter.AppendIdentifier(m_Sql, columnAlias)
+            AppendColumnAliasWithSpace(columnAlias)
           ElseIf isInIncludeMode Then
             Dim columnAlias = CreateIncludeColumnAlias(m_CustomSqlResultItemIndex, columnIndex)
-            m_Sql.Append(" ")
-            m_Builder.DialectProvider.Formatter.AppendIdentifier(m_Sql, columnAlias)
+            AppendColumnAliasWithSpace(columnAlias)
           End If
 
           columnIndex += 1

--- a/Source/Source/Yamo/Internal/SqlResultReader.vb
+++ b/Source/Source/Yamo/Internal/SqlResultReader.vb
@@ -1,0 +1,37 @@
+﻿Imports System.Data.Common
+Imports System.Diagnostics.CodeAnalysis
+
+Namespace Internal
+
+  ''' <summary>
+  ''' Sql result reader.<br/>
+  ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+  ''' </summary>
+  Public Class SqlResultReader
+
+    ''' <summary>
+    ''' Creates new instance of <see cref="SqlResultReader"/>.
+    ''' </summary>
+    Private Sub New()
+    End Sub
+
+    ''' <summary>
+    ''' Checks whether there is at least one column that doesn't contain <see cref="DBNull"/> value.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <param name="dataReader"></param>
+    ''' <param name="readerIndex"></param>
+    ''' <param name="columnCount"></param>
+    ''' <returns></returns>
+    Public Shared Function ContainsNonNullColumn(<DisallowNull> dataReader As DbDataReader, readerIndex As Int32, columnCount As Int32) As Boolean
+      For i = readerIndex To readerIndex + columnCount - 1
+        If Not dataReader.IsDBNull(i) Then
+          Return True
+        End If
+      Next
+
+      Return False
+    End Function
+
+  End Class
+End Namespace

--- a/Source/Source/Yamo/Metadata/Entity.vb
+++ b/Source/Source/Yamo/Metadata/Entity.vb
@@ -98,6 +98,15 @@ Namespace Metadata
     End Function
 
     ''' <summary>
+    ''' Gets property of this entity.
+    ''' </summary>
+    ''' <param name="index"></param>
+    ''' <returns></returns>
+    Public Function GetProperty(index As Int32) As [Property]
+      Return m_Properties(index)
+    End Function
+
+    ''' <summary>
     ''' Gets all properties defined on this entity.
     ''' </summary>
     ''' <returns></returns>
@@ -110,7 +119,7 @@ Namespace Metadata
     ''' </summary>
     ''' <returns></returns>
     Public Function GetKeyProperties() As IReadOnlyList(Of [Property])
-      Return m_Properties.Where(Function(t) t.IsKey).ToArray()
+      Return m_Properties.Where(Function(x) x.IsKey).ToArray()
     End Function
 
     ''' <summary>
@@ -118,7 +127,7 @@ Namespace Metadata
     ''' </summary>
     ''' <returns></returns>
     Public Function GetNonKeyProperties() As IReadOnlyList(Of [Property])
-      Return m_Properties.Where(Function(t) Not t.IsKey).ToArray()
+      Return m_Properties.Where(Function(x) Not x.IsKey).ToArray()
     End Function
 
     ''' <summary>
@@ -126,7 +135,7 @@ Namespace Metadata
     ''' </summary>
     ''' <returns></returns>
     Public Function GetSetOnInsertProperties() As IReadOnlyList(Of [Property])
-      Return m_Properties.Where(Function(t) t.SetOnInsert).ToArray()
+      Return m_Properties.Where(Function(x) x.SetOnInsert).ToArray()
     End Function
 
     ''' <summary>
@@ -134,7 +143,7 @@ Namespace Metadata
     ''' </summary>
     ''' <returns></returns>
     Public Function GetSetOnUpdateProperties() As IReadOnlyList(Of [Property])
-      Return m_Properties.Where(Function(t) t.SetOnUpdate).ToArray()
+      Return m_Properties.Where(Function(x) x.SetOnUpdate).ToArray()
     End Function
 
     ''' <summary>
@@ -142,7 +151,7 @@ Namespace Metadata
     ''' </summary>
     ''' <returns></returns>
     Public Function GetSetOnDeleteProperties() As IReadOnlyList(Of [Property])
-      Return m_Properties.Where(Function(t) t.SetOnDelete).ToArray()
+      Return m_Properties.Where(Function(x) x.SetOnDelete).ToArray()
     End Function
 
     ''' <summary>
@@ -150,7 +159,7 @@ Namespace Metadata
     ''' </summary>
     ''' <returns></returns>
     Public Function GetIdentityOrDefaultValueProperties() As IReadOnlyList(Of [Property])
-      Return m_Properties.Where(Function(t) t.IsIdentity OrElse t.HasDefaultValue).ToArray()
+      Return m_Properties.Where(Function(x) x.IsIdentity OrElse x.HasDefaultValue).ToArray()
     End Function
 
     ''' <summary>
@@ -166,7 +175,7 @@ Namespace Metadata
     ''' </summary>
     ''' <returns></returns>
     Public Function GetKeyPropertiesCount() As Int32
-      Return m_Properties.Where(Function(p) p.IsKey).Count()
+      Return m_Properties.Where(Function(x) x.IsKey).Count()
     End Function
 
     ''' <summary>
@@ -218,7 +227,7 @@ Namespace Metadata
     ''' <param name="relatedEntityType"></param>
     ''' <returns></returns>
     Public Function GetRelationshipNavigations(<DisallowNull> relatedEntityType As Type) As IReadOnlyList(Of RelationshipNavigation)
-      Return m_RelationshipNavigations.Values.Where(Function(r) r.RelatedEntityType = relatedEntityType).ToArray()
+      Return m_RelationshipNavigations.Values.Where(Function(x) x.RelatedEntityType = relatedEntityType).ToArray()
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/NonModelEntityCreationBehavior.vb
+++ b/Source/Source/Yamo/NonModelEntityCreationBehavior.vb
@@ -1,0 +1,14 @@
+﻿''' <summary>
+''' Defines how should non model entity instances be created since we cannot detect their presence in the resultset based on the primary key.<br/>
+''' Note that non model entity probably won't have relationship defined in model either and hence instances will be created only if relationship is defined explicitly using As() method.
+''' </summary>
+Public Enum NonModelEntityCreationBehavior
+  ''' <summary>
+  ''' Do not create an instance unless there is at least one related column value in the resultset that doesn't equal to <see cref="DBNull"/>.
+  ''' </summary>
+  NullIfAllColumnsAreNull = 0
+  ''' <summary>
+  ''' Always create an instance, even if all related columns in the resultset contain <see cref="DBNull"/> value.
+  ''' </summary>
+  AlwaysCreateInstance = 1
+End Enum

--- a/Source/Source/Yamo/Subquery.vb
+++ b/Source/Source/Yamo/Subquery.vb
@@ -1,0 +1,24 @@
+Imports System.Diagnostics.CodeAnalysis
+Imports Yamo.Internal.Query
+
+''' <summary>
+''' A <see cref="Subquery(Of T)"/> instance represents SQL subquery.
+''' </summary>
+''' <typeparam name="T"></typeparam>
+Public Class Subquery(Of T)
+
+  ''' <summary>
+  ''' SQL subquery.
+  ''' </summary>
+  ''' <returns></returns>
+  Friend ReadOnly Property Query As SelectQuery
+
+  ''' <summary>
+  ''' Creates new instance of <see cref="Subquery(Of T)"/>.
+  ''' </summary>
+  ''' <param name="query"></param>
+  Friend Sub New(query As SelectQuery)
+    Me.Query = query
+  End Sub
+
+End Class

--- a/Source/Source/Yamo/SubqueryContext.vb
+++ b/Source/Source/Yamo/SubqueryContext.vb
@@ -1,0 +1,70 @@
+Imports System.Diagnostics.CodeAnalysis
+Imports Yamo.Expressions
+Imports Yamo.Internal.Query
+
+''' <summary>
+''' A <see cref="SubqueryContext"/> instance represents a context for creating SQL subquery.
+''' </summary>
+Public Class SubqueryContext
+
+  ''' <summary>
+  ''' Gets context.
+  ''' </summary>
+  ''' <returns></returns>
+  Friend ReadOnly Property DbContext As DbContext
+
+  ''' <summary>
+  ''' Gets query executor.
+  ''' </summary>
+  ''' <returns></returns>
+  Friend ReadOnly Property Executor As QueryExecutor
+
+  ''' <summary>
+  ''' Gets parameter index offset.
+  ''' </summary>
+  ''' <returns></returns>
+  Friend ReadOnly Property ParameterIndexOffset As Int32
+
+  ''' <summary>
+  ''' Initializes a new instance of <see cref="SubqueryContext"/>.
+  ''' </summary>
+  ''' <param name="context"></param>
+  ''' <param name="executor"></param>
+  ''' <param name="parameterIndexOffset"></param>
+  Friend Sub New(context As DbContext, executor As QueryExecutor, parameterIndexOffset As Int32)
+    Me.DbContext = context
+    Me.Executor = executor
+    Me.ParameterIndexOffset = parameterIndexOffset
+  End Sub
+
+  ''' <summary>
+  ''' Starts building SQL SELECT statement.
+  ''' </summary>
+  ''' <typeparam name="T"></typeparam>
+  ''' <returns></returns>
+  Public Function From(Of T)() As SelectSqlExpression(Of T)
+    Return New SelectSqlExpression(Of T)(Me)
+  End Function
+
+  ''' <summary>
+  ''' Starts building SQL SELECT statement.
+  ''' </summary>
+  ''' <typeparam name="T"></typeparam>
+  ''' <param name="tableSource"></param>
+  ''' <returns></returns>
+  Public Function From(Of T)(<DisallowNull> tableSource As FormattableString) As SelectSqlExpression(Of T)
+    Return New SelectSqlExpression(Of T)(Me, tableSource)
+  End Function
+
+  ''' <summary>
+  ''' Starts building SQL SELECT statement.
+  ''' </summary>
+  ''' <typeparam name="T"></typeparam>
+  ''' <param name="tableSource"></param>
+  ''' <param name="parameters"></param>
+  ''' <returns></returns>
+  Public Function From(Of T)(<DisallowNull> tableSource As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SelectSqlExpression(Of T)
+    Return New SelectSqlExpression(Of T)(Me, tableSource, parameters)
+  End Function
+
+End Class

--- a/Source/Test/Yamo.Test.SQLite/Tests/SelectWithExplicitRelationship.vb
+++ b/Source/Test/Yamo.Test.SQLite/Tests/SelectWithExplicitRelationship.vb
@@ -1,0 +1,14 @@
+﻿Imports Yamo.Test
+
+Namespace Tests
+
+  <TestClass()>
+  Public Class SelectWithExplicitRelationship
+    Inherits Yamo.Test.Tests.SelectWithExplicitRelationship
+
+    Protected Overrides Function CreateTestEnvironment() As ITestEnvironment
+      Return SQLiteTestEnvironment.Create()
+    End Function
+
+  End Class
+End Namespace

--- a/Source/Test/Yamo.Test.SQLite/Tests/SelectWithJoinSubqueryTests.vb
+++ b/Source/Test/Yamo.Test.SQLite/Tests/SelectWithJoinSubqueryTests.vb
@@ -1,0 +1,14 @@
+﻿Imports Yamo.Test
+
+Namespace Tests
+
+  <TestClass()>
+  Public Class SelectWithJoinSubqueryTests
+    Inherits Yamo.Test.Tests.SelectWithJoinSubqueryTests
+
+    Protected Overrides Function CreateTestEnvironment() As ITestEnvironment
+      Return SQLiteTestEnvironment.Create()
+    End Function
+
+  End Class
+End Namespace

--- a/Source/Test/Yamo.Test.SqlServer/Tests/SelectWithExplicitRelationship.vb
+++ b/Source/Test/Yamo.Test.SqlServer/Tests/SelectWithExplicitRelationship.vb
@@ -1,0 +1,14 @@
+﻿Imports Yamo.Test
+
+Namespace Tests
+
+  <TestClass()>
+  Public Class SelectWithExplicitRelationship
+    Inherits Yamo.Test.Tests.SelectWithExplicitRelationship
+
+    Protected Overrides Function CreateTestEnvironment() As ITestEnvironment
+      Return SqlServerTestEnvironment.Create()
+    End Function
+
+  End Class
+End Namespace

--- a/Source/Test/Yamo.Test.SqlServer/Tests/SelectWithJoinSubqueryTests.vb
+++ b/Source/Test/Yamo.Test.SqlServer/Tests/SelectWithJoinSubqueryTests.vb
@@ -1,0 +1,14 @@
+﻿Imports Yamo.Test
+
+Namespace Tests
+
+  <TestClass()>
+  Public Class SelectWithJoinSubqueryTests
+    Inherits Yamo.Test.Tests.SelectWithJoinSubqueryTests
+
+    Protected Overrides Function CreateTestEnvironment() As ITestEnvironment
+      Return SqlServerTestEnvironment.Create()
+    End Function
+
+  End Class
+End Namespace

--- a/Source/Test/Yamo.Test/Model/Article.vb
+++ b/Source/Test/Yamo.Test/Model/Article.vb
@@ -24,6 +24,8 @@
 
     Public Property Tag As Object
 
+    Public Property Tags As List(Of Object)
+
     Public Overrides Function Equals(obj As Object) As Boolean
       If obj Is Nothing OrElse TypeOf obj IsNot Article Then
         Return False

--- a/Source/Test/Yamo.Test/Model/NonModelObject.vb
+++ b/Source/Test/Yamo.Test/Model/NonModelObject.vb
@@ -6,7 +6,9 @@
 
     Public Property BooleanValue As Boolean
 
-    Public Property StringValue As String
+    Public Property StringValue1 As String
+
+    Public Property StringValue2 As String
 
     Public Property IntValue As Int32
 
@@ -26,9 +28,9 @@
       Me.BooleanValue = booleanValue
     End Sub
 
-    Public Sub New(guidValue As Guid, stringValue As String, nullableDecimalValue As Decimal?)
+    Public Sub New(guidValue As Guid, stringValue1 As String, nullableDecimalValue As Decimal?)
       Me.GuidValue = guidValue
-      Me.StringValue = stringValue
+      Me.StringValue1 = stringValue1
       Me.NullableDecimalValue = nullableDecimalValue
     End Sub
 
@@ -42,6 +44,16 @@
       Me.Label = label
     End Sub
 
+    Public Sub New(intValue As Int32, stringValue1 As String, stringValue2 As String)
+      Me.IntValue = intValue
+      Me.StringValue1 = stringValue1
+      Me.StringValue2 = stringValue2
+    End Sub
+
+    Public Sub New(stringValue2 As String)
+      Me.StringValue2 = stringValue2
+    End Sub
+
     Public Overrides Function Equals(obj As Object) As Boolean
       If obj Is Nothing OrElse TypeOf obj IsNot NonModelObject Then
         Return False
@@ -50,7 +62,8 @@
 
         If Not Object.Equals(Me.GuidValue, o.GuidValue) Then Return False
         If Not Object.Equals(Me.BooleanValue, o.BooleanValue) Then Return False
-        If Not Object.Equals(Me.StringValue, o.StringValue) Then Return False
+        If Not Object.Equals(Me.StringValue1, o.StringValue1) Then Return False
+        If Not Object.Equals(Me.StringValue2, o.StringValue2) Then Return False
         If Not Object.Equals(Me.IntValue, o.IntValue) Then Return False
         If Not Object.Equals(Me.NullableDecimalValue, o.NullableDecimalValue) Then Return False
 
@@ -59,7 +72,7 @@
     End Function
 
     Public Overrides Function GetHashCode() As Int32
-      Return HashCode.Combine(Me.GuidValue, Me.BooleanValue, Me.StringValue, Me.IntValue, Me.NullableDecimalValue)
+      Return HashCode.Combine(Me.GuidValue, Me.BooleanValue, Me.StringValue1, Me.StringValue2, Me.IntValue, Me.NullableDecimalValue)
     End Function
 
   End Class

--- a/Source/Test/Yamo.Test/Model/NonModelObjectWithPropertyModifiedTracking.vb
+++ b/Source/Test/Yamo.Test/Model/NonModelObjectWithPropertyModifiedTracking.vb
@@ -1,0 +1,50 @@
+﻿Namespace Model
+
+  Public Class NonModelObjectWithPropertyModifiedTracking
+    Inherits PropertyModifiedTrackingBase
+
+    Private m_IntValue As Int32
+    Public Property IntValue() As Int32
+      Get
+        Return m_IntValue
+      End Get
+      Set(ByVal value As Int32)
+        If Not m_IntValue = value Then
+          m_IntValue = value
+          MarkPropertyAsModified(NameOf(Me.IntValue))
+        End If
+      End Set
+    End Property
+
+    Private m_StringValue As String
+    Public Property StringValue() As String
+      Get
+        Return m_StringValue
+      End Get
+      Set(ByVal value As String)
+        If Not String.Equals(m_StringValue, value) Then
+          m_StringValue = value
+          MarkPropertyAsModified(NameOf(Me.StringValue))
+        End If
+      End Set
+    End Property
+
+    Public Overrides Function Equals(obj As Object) As Boolean
+      If obj Is Nothing OrElse TypeOf obj IsNot NonModelObjectWithPropertyModifiedTracking Then
+        Return False
+      Else
+        Dim o = DirectCast(obj, NonModelObjectWithPropertyModifiedTracking)
+
+        If Not Object.Equals(Me.IntValue, o.IntValue) Then Return False
+        If Not Object.Equals(Me.StringValue, o.StringValue) Then Return False
+
+        Return True
+      End If
+    End Function
+
+    Public Overrides Function GetHashCode() As Int32
+      Return HashCode.Combine(Me.IntValue, Me.StringValue)
+    End Function
+
+  End Class
+End Namespace

--- a/Source/Test/Yamo.Test/Tests/CustomSelectTests.vb
+++ b/Source/Test/Yamo.Test/Tests/CustomSelectTests.vb
@@ -2031,7 +2031,7 @@ Namespace Tests
         ' select non-model type with simple values using member init
         Dim result1 = db.From(Of ItemWithAllSupportedValues).
                          Where(Function(x) x.Id = item2.Id).
-                         Select(Function(x) New NonModelObject With {.GuidValue = x.UniqueidentifierColumn, .StringValue = x.Nvarchar50Column, .NullableDecimalValue = x.Numeric10and3ColumnNull}).
+                         Select(Function(x) New NonModelObject With {.GuidValue = x.UniqueidentifierColumn, .StringValue1 = x.Nvarchar50Column, .NullableDecimalValue = x.Numeric10and3ColumnNull}).
                          FirstOrDefault()
         Assert.AreEqual(New NonModelObject(item2.UniqueidentifierColumn, item2.Nvarchar50Column, item2.Numeric10and3ColumnNull), result1)
 
@@ -2075,22 +2075,22 @@ Namespace Tests
         ' select non-model type with simple values using combination of constructor and member init
         Dim result7 = db.From(Of ItemWithAllSupportedValues).
                          Where(Function(x) x.Id = item2.Id).
-                         Select(Function(x) New NonModelObject(x.UniqueidentifierColumn, x.BitColumn) With {.StringValue = x.Nvarchar50Column, .ItemWithAllSupportedValues = x, .NullableDecimalValue = x.Numeric15and0ColumnNull}).
+                         Select(Function(x) New NonModelObject(x.UniqueidentifierColumn, x.BitColumn) With {.StringValue1 = x.Nvarchar50Column, .ItemWithAllSupportedValues = x, .NullableDecimalValue = x.Numeric15and0ColumnNull}).
                          FirstOrDefault()
-        Assert.AreEqual(New NonModelObject(item2.UniqueidentifierColumn, item2.BitColumn) With {.StringValue = item2.Nvarchar50Column, .ItemWithAllSupportedValues = item2, .NullableDecimalValue = item2.Numeric15and0ColumnNull}, result7)
+        Assert.AreEqual(New NonModelObject(item2.UniqueidentifierColumn, item2.BitColumn) With {.StringValue1 = item2.Nvarchar50Column, .ItemWithAllSupportedValues = item2, .NullableDecimalValue = item2.Numeric15and0ColumnNull}, result7)
         Assert.AreEqual(item2, result7.ItemWithAllSupportedValues)
 
         ' select non-model type with simple values, but no row is returned
         Dim result8 = db.From(Of ItemWithAllSupportedValues).
                          Where(Function(x) x.Id = Guid.NewGuid).
-                         Select(Function(x) New NonModelObject With {.GuidValue = x.UniqueidentifierColumn, .StringValue = x.Nvarchar50Column, .NullableDecimalValue = x.Numeric10and3ColumnNull}).
+                         Select(Function(x) New NonModelObject With {.GuidValue = x.UniqueidentifierColumn, .StringValue1 = x.Nvarchar50Column, .NullableDecimalValue = x.Numeric10and3ColumnNull}).
                          FirstOrDefault()
         Assert.AreEqual(Nothing, result8)
 
         ' select non-model types
         Dim result9 = db.From(Of ItemWithAllSupportedValues).
                          OrderBy(Function(x) x.IntColumn).
-                         Select(Function(x) New NonModelObject With {.GuidValue = x.UniqueidentifierColumn, .StringValue = x.Nvarchar50Column, .NullableDecimalValue = x.Numeric10and3ColumnNull}).
+                         Select(Function(x) New NonModelObject With {.GuidValue = x.UniqueidentifierColumn, .StringValue1 = x.Nvarchar50Column, .NullableDecimalValue = x.Numeric10and3ColumnNull}).
                          ToList()
         Assert.AreEqual(3, result9.Count)
         Assert.AreEqual(New NonModelObject(item1.UniqueidentifierColumn, item1.Nvarchar50Column, item1.Numeric10and3ColumnNull), result9(0))
@@ -2101,7 +2101,7 @@ Namespace Tests
         Dim result10 = db.From(Of ItemWithAllSupportedValues).
                           Where(Function(x) x.Id = Guid.NewGuid).
                           OrderBy(Function(x) x.IntColumn).
-                          Select(Function(x) New NonModelObject With {.GuidValue = x.UniqueidentifierColumn, .StringValue = x.Nvarchar50Column, .NullableDecimalValue = x.Numeric10and3ColumnNull}).
+                          Select(Function(x) New NonModelObject With {.GuidValue = x.UniqueidentifierColumn, .StringValue1 = x.Nvarchar50Column, .NullableDecimalValue = x.Numeric10and3ColumnNull}).
                           ToList()
         Assert.AreEqual(0, result10.Count)
       End Using

--- a/Source/Test/Yamo.Test/Tests/SelectColumnsTests.vb
+++ b/Source/Test/Yamo.Test/Tests/SelectColumnsTests.vb
@@ -9,7 +9,7 @@ Namespace Tests
     Protected Const English As String = "en"
 
     <TestMethod()>
-    Public Overridable Sub SelectWithDefinedRelationshipUsingSelectAllColumnsBehavior()
+    Public Overridable Sub SelectWithModelDefinedRelationshipUsingSelectAllColumnsBehavior()
       Dim article = Me.ModelFactory.CreateArticle(1)
       Dim labelEn = Me.ModelFactory.CreateLabel("", 1, English)
 
@@ -33,11 +33,12 @@ Namespace Tests
 
         EnsureColumnsArePresent(sql, articleEntity)
         EnsureColumnsArePresent(sql, labelEntity)
+        EnsureColumnsCount(sql, articleEntity.GetPropertiesCount() + labelEntity.GetPropertiesCount())
       End Using
     End Sub
 
     <TestMethod()>
-    Public Overridable Sub SelectWithAdHocRelationshipUsingSelectAllColumnsBehavior()
+    Public Overridable Sub SelectWithExplicitRelationshipUsingSelectAllColumnsBehavior()
       Dim article = Me.ModelFactory.CreateArticle(1)
       Dim item = Me.ModelFactory.CreateItemWithAllSupportedValuesWithEmptyValues()
       item.IntColumn = article.Id
@@ -52,7 +53,8 @@ Namespace Tests
         Assert.IsFalse(db.Model.GetEntity(article.GetType()).GetRelationshipNavigations(item.GetType()).Any())
 
         Dim result = db.From(Of Article).
-                        Join(Of ItemWithAllSupportedValues)(Function(j) j.T1.Id = j.T2.IntColumn).As(Function(x) x.Tag).
+                        Join(Of ItemWithAllSupportedValues)(Function(j) j.T1.Id = j.T2.IntColumn).
+                        As(Function(x) x.Tag).
                         SelectAll(SelectColumnsBehavior.SelectAllColumns).FirstOrDefault()
 
         Assert.AreEqual(article, result)
@@ -62,6 +64,7 @@ Namespace Tests
 
         EnsureColumnsArePresent(sql, articleEntity)
         EnsureColumnsArePresent(sql, itemEntity)
+        EnsureColumnsCount(sql, articleEntity.GetPropertiesCount() + itemEntity.GetPropertiesCount())
       End Using
     End Sub
 
@@ -90,6 +93,115 @@ Namespace Tests
 
         EnsureColumnsArePresent(sql, articleEntity)
         EnsureColumnsArePresent(sql, itemEntity)
+        EnsureColumnsCount(sql, articleEntity.GetPropertiesCount() + itemEntity.GetPropertiesCount())
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithExplicitRelationshipUsingSubqueryAndSelectAllColumnsBehavior()
+      Dim article = Me.ModelFactory.CreateArticle(1)
+      Dim item = Me.ModelFactory.CreateItemWithAllSupportedValuesWithEmptyValues()
+      item.IntColumn = article.Id
+      item.Nvarchar50Column = "foo"
+
+      InsertItems(article, item)
+
+      Using db = CreateDbContext()
+        Dim articleEntity = db.Model.GetEntity(article.GetType())
+        Dim itemEntity = db.Model.GetEntity(item.GetType())
+
+        Dim result = db.From(Of Article).
+                        Join(Function(c)
+                               Return c.From(Of ItemWithAllSupportedValues).
+                                        Select(Function(x) New With {Key .IntValue = x.IntColumn, Key .StringValue = x.Nvarchar50Column})
+                             End Function).
+                        On(Function(j) j.T1.Id = j.T2.IntValue).
+                        As(Function(x) x.Tag).
+                        SelectAll(SelectColumnsBehavior.SelectAllColumns).FirstOrDefault()
+
+        Assert.AreEqual(article, result)
+        Assert.AreEqual(New With {Key .IntValue = item.IntColumn, Key .StringValue = item.Nvarchar50Column}, result.Tag)
+
+        Dim sql = db.GetLastCommandText()
+
+        EnsureColumnsArePresent(sql, articleEntity)
+        EnsureColumnsCount(sql, articleEntity.GetPropertiesCount() + 2)
+        EnsureColumnsCountInSubquery(sql, 2)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithoutDefinedRelationshipUsingSubqueryAndSelectAllColumnsBehavior()
+      Dim article = Me.ModelFactory.CreateArticle(1)
+      Dim item = Me.ModelFactory.CreateItemWithAllSupportedValuesWithEmptyValues()
+      item.IntColumn = article.Id
+      item.Nvarchar50Column = "foo"
+
+      InsertItems(article, item)
+
+      Using db = CreateDbContext()
+        Dim articleEntity = db.Model.GetEntity(article.GetType())
+        Dim itemEntity = db.Model.GetEntity(item.GetType())
+
+        Dim result = db.From(Of Article).
+                        Join(Function(c)
+                               Return c.From(Of ItemWithAllSupportedValues).
+                                        Select(Function(x) New With {Key .IntValue = x.IntColumn, Key .StringValue = x.Nvarchar50Column})
+                             End Function).
+                        On(Function(j) j.T1.Id = j.T2.IntValue).
+                        SelectAll(SelectColumnsBehavior.SelectAllColumns).FirstOrDefault()
+
+        Assert.AreEqual(article, result)
+
+        Dim sql = db.GetLastCommandText()
+
+        EnsureColumnsArePresent(sql, articleEntity)
+        EnsureColumnsCount(sql, articleEntity.GetPropertiesCount() + 2)
+        EnsureColumnsCountInSubquery(sql, 2)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectUsingSubqueryWithJoinsThatIsUsingSelectAllColumnsBehavior()
+      Dim article = Me.ModelFactory.CreateArticle(1)
+      Dim articlePart1 = Me.ModelFactory.CreateArticlePart(1001, 1)
+      Dim articlePart2 = Me.ModelFactory.CreateArticlePart(1002, 1)
+      Dim articlePart1LabelEn = Me.ModelFactory.CreateLabel("", 1001, English)
+      Dim articlePart2LabelEn = Me.ModelFactory.CreateLabel("", 1002, English)
+      Dim item = Me.ModelFactory.CreateItemWithAllSupportedValuesWithEmptyValues()
+      item.IntColumn = article.Id
+
+      InsertItems(article, articlePart1, articlePart2, articlePart1LabelEn, articlePart2LabelEn, item)
+
+      Using db = CreateDbContext()
+        Dim articleEntity = db.Model.GetEntity(article.GetType())
+        Dim articlePartEntity = db.Model.GetEntity(articlePart1.GetType())
+        Dim labelEntity = db.Model.GetEntity(articlePart1LabelEn.GetType())
+        Dim itemEntity = db.Model.GetEntity(item.GetType())
+
+        Dim result = db.From(Of Article).
+                        Join(Function(c)
+                               Return c.From(Of ArticlePart).
+                                        LeftJoin(Of Label)(Function(j) j.T1.Id = j.T2.Id).
+                                        SelectAll(SelectColumnsBehavior.SelectAllColumns)
+                             End Function).
+                        On(Function(j) j.T1.Id = j.T2.ArticleId).
+                        Join(Of ItemWithAllSupportedValues)(Function(j) j.T1.Id = j.T3.IntColumn).As(Function(x) x.Tag).
+                        SelectAll().FirstOrDefault(CollectionNavigationFillBehavior.ProcessAllRows)
+
+        Assert.AreEqual(article, result)
+        CollectionAssert.AreEqual({articlePart1, articlePart2}, result.Parts)
+        Assert.IsTrue(result.Parts.All(Function(x) x.Label Is Nothing))
+        Assert.AreEqual(item, result.Tag)
+
+        Dim sql = db.GetLastCommandText()
+
+        EnsureColumnsArePresent(sql, articleEntity)
+        EnsureColumnsArePresent(sql, itemEntity)
+        EnsureColumnsCount(sql, articleEntity.GetPropertiesCount() + articlePartEntity.GetPropertiesCount() + itemEntity.GetPropertiesCount())
+        EnsureColumnsArePresentInSubquery(sql, articlePartEntity)
+        EnsureColumnsArePresentInSubquery(sql, labelEntity)
+        EnsureColumnsCountInSubquery(sql, articlePartEntity.GetPropertiesCount() + labelEntity.GetPropertiesCount())
       End Using
     End Sub
 
@@ -118,11 +230,12 @@ Namespace Tests
 
         EnsureColumnsArePresent(sql, articleEntity)
         EnsureColumnsAreNotPresent(sql, labelEntity)
+        EnsureColumnsCount(sql, articleEntity.GetPropertiesCount())
       End Using
     End Sub
 
     <TestMethod()>
-    Public Overridable Sub SelectWithDefinedRelationshipUsingExcludeNonRequiredColumnsBehavior()
+    Public Overridable Sub SelectWithModelDefinedRelationshipUsingExcludeNonRequiredColumnsBehavior()
       Dim article = Me.ModelFactory.CreateArticle(1)
       Dim labelEn = Me.ModelFactory.CreateLabel("", 1, English)
 
@@ -146,11 +259,34 @@ Namespace Tests
 
         EnsureColumnsArePresent(sql, articleEntity)
         EnsureColumnsArePresent(sql, labelEntity)
+        EnsureColumnsCount(sql, articleEntity.GetPropertiesCount() + labelEntity.GetPropertiesCount())
+      End Using
+
+      ' same as above, but assume behavior is not explicitly set
+      Using db = CreateDbContext()
+        Dim articleEntity = db.Model.GetEntity(article.GetType())
+        Dim labelEntity = db.Model.GetEntity(labelEn.GetType())
+
+        ' ensure relationship is defined
+        Assert.IsNotNull(articleEntity.GetRelationshipNavigation(NameOf(article.Label)))
+
+        Dim result = db.From(Of Article).
+                        Join(Of Label)(Function(j) j.T1.Id = j.T2.Id).
+                        SelectAll().FirstOrDefault()
+
+        Assert.AreEqual(article, result)
+        Assert.AreEqual(labelEn, result.Label)
+
+        Dim sql = db.GetLastCommandText()
+
+        EnsureColumnsArePresent(sql, articleEntity)
+        EnsureColumnsArePresent(sql, labelEntity)
+        EnsureColumnsCount(sql, articleEntity.GetPropertiesCount() + labelEntity.GetPropertiesCount())
       End Using
     End Sub
 
     <TestMethod()>
-    Public Overridable Sub SelectWithAdHocRelationshipUsingExcludeNonRequiredColumnsBehavior()
+    Public Overridable Sub SelectWithExplicitRelationshipUsingExcludeNonRequiredColumnsBehavior()
       Dim article = Me.ModelFactory.CreateArticle(1)
       Dim item = Me.ModelFactory.CreateItemWithAllSupportedValuesWithEmptyValues()
       item.IntColumn = article.Id
@@ -165,7 +301,8 @@ Namespace Tests
         Assert.IsFalse(db.Model.GetEntity(article.GetType()).GetRelationshipNavigations(item.GetType()).Any())
 
         Dim result = db.From(Of Article).
-                        Join(Of ItemWithAllSupportedValues)(Function(j) j.T1.Id = j.T2.IntColumn).As(Function(x) x.Tag).
+                        Join(Of ItemWithAllSupportedValues)(Function(j) j.T1.Id = j.T2.IntColumn).
+                        As(Function(x) x.Tag).
                         SelectAll(SelectColumnsBehavior.ExcludeNonRequiredColumns).FirstOrDefault()
 
         Assert.AreEqual(article, result)
@@ -175,6 +312,30 @@ Namespace Tests
 
         EnsureColumnsArePresent(sql, articleEntity)
         EnsureColumnsArePresent(sql, itemEntity)
+        EnsureColumnsCount(sql, articleEntity.GetPropertiesCount() + itemEntity.GetPropertiesCount())
+      End Using
+
+      ' same as above, but assume behavior is not explicitly set
+      Using db = CreateDbContext()
+        Dim articleEntity = db.Model.GetEntity(article.GetType())
+        Dim itemEntity = db.Model.GetEntity(item.GetType())
+
+        ' ensure relationship is not defined
+        Assert.IsFalse(db.Model.GetEntity(article.GetType()).GetRelationshipNavigations(item.GetType()).Any())
+
+        Dim result = db.From(Of Article).
+                        Join(Of ItemWithAllSupportedValues)(Function(j) j.T1.Id = j.T2.IntColumn).
+                        As(Function(x) x.Tag).
+                        SelectAll().FirstOrDefault()
+
+        Assert.AreEqual(article, result)
+        Assert.AreEqual(item, result.Tag)
+
+        Dim sql = db.GetLastCommandText()
+
+        EnsureColumnsArePresent(sql, articleEntity)
+        EnsureColumnsArePresent(sql, itemEntity)
+        EnsureColumnsCount(sql, articleEntity.GetPropertiesCount() + itemEntity.GetPropertiesCount())
       End Using
     End Sub
 
@@ -203,6 +364,214 @@ Namespace Tests
 
         EnsureColumnsArePresent(sql, articleEntity)
         EnsureColumnsAreNotPresent(sql, itemEntity)
+        EnsureColumnsCount(sql, articleEntity.GetPropertiesCount())
+      End Using
+
+      ' same as above, but assume behavior is not explicitly set
+      Using db = CreateDbContext()
+        Dim articleEntity = db.Model.GetEntity(article.GetType())
+        Dim itemEntity = db.Model.GetEntity(item.GetType())
+
+        ' ensure relationship is not defined
+        Assert.IsFalse(db.Model.GetEntity(article.GetType()).GetRelationshipNavigations(item.GetType()).Any())
+
+        Dim result = db.From(Of Article).
+                        Join(Of ItemWithAllSupportedValues)(Function(j) j.T1.Id = j.T2.IntColumn).
+                        SelectAll().FirstOrDefault()
+
+        Assert.AreEqual(article, result)
+
+        Dim sql = db.GetLastCommandText()
+
+        EnsureColumnsArePresent(sql, articleEntity)
+        EnsureColumnsAreNotPresent(sql, itemEntity)
+        EnsureColumnsCount(sql, articleEntity.GetPropertiesCount())
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithExplicitRelationshipUsingSubqueryAndExcludeNonRequiredColumnsBehavior()
+      Dim article = Me.ModelFactory.CreateArticle(1)
+      Dim item = Me.ModelFactory.CreateItemWithAllSupportedValuesWithEmptyValues()
+      item.IntColumn = article.Id
+      item.Nvarchar50Column = "foo"
+
+      InsertItems(article, item)
+
+      Using db = CreateDbContext()
+        Dim articleEntity = db.Model.GetEntity(article.GetType())
+        Dim itemEntity = db.Model.GetEntity(item.GetType())
+
+        Dim result = db.From(Of Article).
+                        Join(Function(c)
+                               Return c.From(Of ItemWithAllSupportedValues).
+                                        Select(Function(x) New With {Key .IntValue = x.IntColumn, Key .StringValue = x.Nvarchar50Column})
+                             End Function).
+                        On(Function(j) j.T1.Id = j.T2.IntValue).
+                        As(Function(x) x.Tag).
+                        SelectAll(SelectColumnsBehavior.ExcludeNonRequiredColumns).FirstOrDefault()
+
+        Assert.AreEqual(article, result)
+        Assert.AreEqual(New With {Key .IntValue = item.IntColumn, Key .StringValue = item.Nvarchar50Column}, result.Tag)
+
+        Dim sql = db.GetLastCommandText()
+
+        EnsureColumnsArePresent(sql, articleEntity)
+        EnsureColumnsCount(sql, articleEntity.GetPropertiesCount() + 2)
+        EnsureColumnsCountInSubquery(sql, 2)
+      End Using
+
+      ' same as above, but assume behavior is not explicitly set
+      Using db = CreateDbContext()
+        Dim articleEntity = db.Model.GetEntity(article.GetType())
+        Dim itemEntity = db.Model.GetEntity(item.GetType())
+
+        Dim result = db.From(Of Article).
+                        Join(Function(c)
+                               Return c.From(Of ItemWithAllSupportedValues).
+                                        Select(Function(x) New With {Key .IntValue = x.IntColumn, Key .StringValue = x.Nvarchar50Column})
+                             End Function).
+                        On(Function(j) j.T1.Id = j.T2.IntValue).
+                        As(Function(x) x.Tag).
+                        SelectAll().FirstOrDefault()
+
+        Assert.AreEqual(article, result)
+        Assert.AreEqual(New With {Key .IntValue = item.IntColumn, Key .StringValue = item.Nvarchar50Column}, result.Tag)
+
+        Dim sql = db.GetLastCommandText()
+
+        EnsureColumnsArePresent(sql, articleEntity)
+        EnsureColumnsCount(sql, articleEntity.GetPropertiesCount() + 2)
+        EnsureColumnsCountInSubquery(sql, 2)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithoutDefinedRelationshipUsingSubqueryAndExcludeNonRequiredColumnsBehavior()
+      Dim article = Me.ModelFactory.CreateArticle(1)
+      Dim item = Me.ModelFactory.CreateItemWithAllSupportedValuesWithEmptyValues()
+      item.IntColumn = article.Id
+      item.Nvarchar50Column = "foo"
+
+      InsertItems(article, item)
+
+      Using db = CreateDbContext()
+        Dim articleEntity = db.Model.GetEntity(article.GetType())
+        Dim itemEntity = db.Model.GetEntity(item.GetType())
+
+        Dim result = db.From(Of Article).
+                        Join(Function(c)
+                               Return c.From(Of ItemWithAllSupportedValues).
+                                        Select(Function(x) New With {Key .IntValue = x.IntColumn, Key .StringValue = x.Nvarchar50Column})
+                             End Function).
+                        On(Function(j) j.T1.Id = j.T2.IntValue).
+                        SelectAll(SelectColumnsBehavior.ExcludeNonRequiredColumns).FirstOrDefault()
+
+        Assert.AreEqual(article, result)
+
+        Dim sql = db.GetLastCommandText()
+
+        EnsureColumnsArePresent(sql, articleEntity)
+        EnsureColumnsCount(sql, articleEntity.GetPropertiesCount())
+        EnsureColumnsCountInSubquery(sql, 2)
+      End Using
+
+      ' same as above, but assume behavior is not explicitly set
+      Using db = CreateDbContext()
+        Dim articleEntity = db.Model.GetEntity(article.GetType())
+        Dim itemEntity = db.Model.GetEntity(item.GetType())
+
+        Dim result = db.From(Of Article).
+                        Join(Function(c)
+                               Return c.From(Of ItemWithAllSupportedValues).
+                                        Select(Function(x) New With {Key .IntValue = x.IntColumn, Key .StringValue = x.Nvarchar50Column})
+                             End Function).
+                        On(Function(j) j.T1.Id = j.T2.IntValue).
+                        SelectAll().FirstOrDefault()
+
+        Assert.AreEqual(article, result)
+
+        Dim sql = db.GetLastCommandText()
+
+        EnsureColumnsArePresent(sql, articleEntity)
+        EnsureColumnsCount(sql, articleEntity.GetPropertiesCount())
+        EnsureColumnsCountInSubquery(sql, 2)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectUsingSubqueryWithJoinsThatIsUsingExcludeNonRequiredColumnsBehavior()
+      Dim article = Me.ModelFactory.CreateArticle(1)
+      Dim articlePart1 = Me.ModelFactory.CreateArticlePart(1001, 1)
+      Dim articlePart2 = Me.ModelFactory.CreateArticlePart(1002, 1)
+      Dim articlePart1LabelEn = Me.ModelFactory.CreateLabel("", 1001, English)
+      Dim articlePart2LabelEn = Me.ModelFactory.CreateLabel("", 1002, English)
+      Dim item = Me.ModelFactory.CreateItemWithAllSupportedValuesWithEmptyValues()
+      item.IntColumn = article.Id
+
+      InsertItems(article, articlePart1, articlePart2, articlePart1LabelEn, articlePart2LabelEn, item)
+
+      Using db = CreateDbContext()
+        Dim articleEntity = db.Model.GetEntity(article.GetType())
+        Dim articlePartEntity = db.Model.GetEntity(articlePart1.GetType())
+        Dim labelEntity = db.Model.GetEntity(articlePart1LabelEn.GetType())
+        Dim itemEntity = db.Model.GetEntity(item.GetType())
+
+        Dim result = db.From(Of Article).
+                        Join(Function(c)
+                               Return c.From(Of ArticlePart).
+                                        LeftJoin(Of Label)(Function(j) j.T1.Id = j.T2.Id).
+                                        SelectAll(SelectColumnsBehavior.ExcludeNonRequiredColumns)
+                             End Function).
+                        On(Function(j) j.T1.Id = j.T2.ArticleId).
+                        Join(Of ItemWithAllSupportedValues)(Function(j) j.T1.Id = j.T3.IntColumn).As(Function(x) x.Tag).
+                        SelectAll().FirstOrDefault(CollectionNavigationFillBehavior.ProcessAllRows)
+
+        Assert.AreEqual(article, result)
+        CollectionAssert.AreEqual({articlePart1, articlePart2}, result.Parts)
+        Assert.IsTrue(result.Parts.All(Function(x) x.Label Is Nothing))
+        Assert.AreEqual(item, result.Tag)
+
+        Dim sql = db.GetLastCommandText()
+
+        EnsureColumnsArePresent(sql, articleEntity)
+        EnsureColumnsArePresent(sql, itemEntity)
+        EnsureColumnsCount(sql, articleEntity.GetPropertiesCount() + articlePartEntity.GetPropertiesCount() + itemEntity.GetPropertiesCount())
+        EnsureColumnsArePresentInSubquery(sql, articlePartEntity)
+        EnsureColumnsAreNotPresentInSubquery(sql, labelEntity)
+        EnsureColumnsCountInSubquery(sql, articlePartEntity.GetPropertiesCount())
+      End Using
+
+      ' same as above, but assume behavior is not explicitly set
+      Using db = CreateDbContext()
+        Dim articleEntity = db.Model.GetEntity(article.GetType())
+        Dim articlePartEntity = db.Model.GetEntity(articlePart1.GetType())
+        Dim labelEntity = db.Model.GetEntity(articlePart1LabelEn.GetType())
+        Dim itemEntity = db.Model.GetEntity(item.GetType())
+
+        Dim result = db.From(Of Article).
+                        Join(Function(c)
+                               Return c.From(Of ArticlePart).
+                                        LeftJoin(Of Label)(Function(j) j.T1.Id = j.T2.Id).
+                                        SelectAll()
+                             End Function).
+                        On(Function(j) j.T1.Id = j.T2.ArticleId).
+                        Join(Of ItemWithAllSupportedValues)(Function(j) j.T1.Id = j.T3.IntColumn).As(Function(x) x.Tag).
+                        SelectAll().FirstOrDefault(CollectionNavigationFillBehavior.ProcessAllRows)
+
+        Assert.AreEqual(article, result)
+        CollectionAssert.AreEqual({articlePart1, articlePart2}, result.Parts)
+        Assert.IsTrue(result.Parts.All(Function(x) x.Label Is Nothing))
+        Assert.AreEqual(item, result.Tag)
+
+        Dim sql = db.GetLastCommandText()
+
+        EnsureColumnsArePresent(sql, articleEntity)
+        EnsureColumnsArePresent(sql, itemEntity)
+        EnsureColumnsCount(sql, articleEntity.GetPropertiesCount() + articlePartEntity.GetPropertiesCount() + itemEntity.GetPropertiesCount())
+        EnsureColumnsArePresentInSubquery(sql, articlePartEntity)
+        EnsureColumnsAreNotPresentInSubquery(sql, labelEntity)
+        EnsureColumnsCountInSubquery(sql, articlePartEntity.GetPropertiesCount())
       End Using
     End Sub
 
@@ -231,11 +600,47 @@ Namespace Tests
 
         EnsureColumnsArePresent(sql, articleEntity)
         EnsureColumnsAreNotPresent(sql, labelEntity)
+        EnsureColumnsCount(sql, articleEntity.GetPropertiesCount())
+      End Using
+
+      ' same as above, but assume behavior is not explicitly set
+      Using db = CreateDbContext()
+        Dim articleEntity = db.Model.GetEntity(article.GetType())
+        Dim labelEntity = db.Model.GetEntity(labelEn.GetType())
+
+        ' ensure relationship is defined
+        Assert.IsNotNull(articleEntity.GetRelationshipNavigation(NameOf(article.Label)))
+
+        Dim result = db.From(Of Article).
+                        Join(Of Label)(Function(j) j.T1.Id = j.T2.Id).
+                        SelectAll().ExcludeT2().FirstOrDefault()
+
+        Assert.AreEqual(article, result)
+        Assert.IsNull(result.Label)
+
+        Dim sql = db.GetLastCommandText()
+
+        EnsureColumnsArePresent(sql, articleEntity)
+        EnsureColumnsAreNotPresent(sql, labelEntity)
+        EnsureColumnsCount(sql, articleEntity.GetPropertiesCount())
       End Using
     End Sub
 
     Private Sub EnsureColumnsArePresent(sql As String, entity As Entity)
       sql = GetColumnsPartFromQuery(sql)
+
+      For Each prop In entity.GetProperties()
+        If prop.ColumnName = "Id" Then
+          ' skip id, because it's not unique (ugly workaround)
+          Continue For
+        End If
+
+        Assert.IsTrue(sql.Contains(prop.ColumnName))
+      Next
+    End Sub
+
+    Private Sub EnsureColumnsArePresentInSubquery(sql As String, entity As Entity)
+      sql = GetSubqueryColumnsPartFromQuery(sql)
 
       For Each prop In entity.GetProperties()
         If prop.ColumnName = "Id" Then
@@ -260,9 +665,46 @@ Namespace Tests
       Next
     End Sub
 
+    Private Sub EnsureColumnsAreNotPresentInSubquery(sql As String, entity As Entity)
+      sql = GetSubqueryColumnsPartFromQuery(sql)
+
+      For Each prop In entity.GetProperties()
+        If prop.ColumnName = "Id" Then
+          ' skip id, because it's not unique (ugly workaround)
+          Continue For
+        End If
+
+        Assert.IsFalse(sql.Contains(prop.ColumnName))
+      Next
+    End Sub
+
+    Private Sub EnsureColumnsCount(sql As String, expectedColumnsCount As Int32)
+      sql = GetColumnsPartFromQuery(sql)
+      Assert.AreEqual(expectedColumnsCount, sql.Split(",").Length)
+    End Sub
+
+    Private Sub EnsureColumnsCountInSubquery(sql As String, expectedColumnsCount As Int32)
+      sql = GetSubqueryColumnsPartFromQuery(sql)
+      Assert.AreEqual(expectedColumnsCount, sql.Split(",").Length)
+    End Sub
+
     Private Shared Function GetColumnsPartFromQuery(sql As String) As String
       Dim startToken = "SELECT"
       Dim endToken = "FROM"
+
+      Dim startIndex = sql.IndexOf(startToken)
+      Dim endIndex = sql.IndexOf(endToken)
+
+      Return sql.Substring(startIndex + startToken.Length, endIndex - startIndex - startToken.Length)
+    End Function
+
+    Private Shared Function GetSubqueryColumnsPartFromQuery(sql As String) As String
+      Dim startToken = "SELECT"
+      Dim endToken = "FROM"
+
+      Dim trimIndex = sql.IndexOf(endToken)
+
+      sql = sql.Substring(trimIndex + endToken.Length)
 
       Dim startIndex = sql.IndexOf(startToken)
       Dim endIndex = sql.IndexOf(endToken)

--- a/Source/Test/Yamo.Test/Tests/SelectWithConditionTests.vb
+++ b/Source/Test/Yamo.Test/Tests/SelectWithConditionTests.vb
@@ -1457,6 +1457,158 @@ Namespace Tests
     End Sub
 
     <TestMethod()>
+    Public Overridable Sub SelectWithConditionalJoinUsingSubquery()
+      Dim article1 = Me.ModelFactory.CreateArticle(1)
+      Dim article2 = Me.ModelFactory.CreateArticle(2)
+      Dim article3 = Me.ModelFactory.CreateArticle(3)
+
+      Dim label1En = Me.ModelFactory.CreateLabel("", 1, English)
+      Dim label2En = Me.ModelFactory.CreateLabel("", 2, English)
+      Dim label3En = Me.ModelFactory.CreateLabel("", 3, English)
+
+      Dim label1De = Me.ModelFactory.CreateLabel("", 1, German)
+      Dim label2De = Me.ModelFactory.CreateLabel("", 2, German)
+      Dim label3De = Me.ModelFactory.CreateLabel("", 3, German)
+
+      InsertItems(article1, article2, article3, label1En, label2En, label3En, label1De, label2De, label3De)
+
+      Dim anonLabel1En = New With {Key .Id = label1En.Id, Key .Description = label1En.Description}
+      Dim anonLabel2En = New With {Key .Id = label2En.Id, Key .Description = label2En.Description}
+      Dim anonLabel3En = New With {Key .Id = label3En.Id, Key .Description = label3En.Description}
+      Dim anonLabel1De = New With {Key .Id = label1De.Id, Key .Description = label1De.Description}
+      Dim anonLabel2De = New With {Key .Id = label2De.Id, Key .Description = label2De.Description}
+      Dim anonLabel3De = New With {Key .Id = label3De.Id, Key .Description = label3De.Description}
+
+      ' condition is true, apply true part
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        If(True,
+                        [then]:=Function(exp)
+                                  Return exp.Join(Function(c)
+                                                    Return c.From(Of Label).
+                                                             Where(Function(x) x.Language = English).
+                                                             Select(Function(x) New With {Key .Id = x.Id, Key .Description = x.Description})
+                                                  End Function).
+                                             On(Function(j) j.T1.Id = j.T2.Id)
+                                End Function
+                        ).
+                        As(Function(x) x.Tag).
+                        OrderBy(Function(j) j.T1.Id).
+                        SelectAll().
+                        Include(Sub(j) j.T1.LabelDescription = j.T2.Description).
+                        ToList()
+
+        CollectionAssert.AreEqual({article1, article2, article3}, result)
+        Assert.AreEqual(label1En.Description, result(0).LabelDescription)
+        Assert.AreEqual(anonLabel1En, result(0).Tag)
+        Assert.AreEqual(label2En.Description, result(1).LabelDescription)
+        Assert.AreEqual(anonLabel2En, result(1).Tag)
+        Assert.AreEqual(label3En.Description, result(2).LabelDescription)
+        Assert.AreEqual(anonLabel3En, result(2).Tag)
+      End Using
+
+      ' condition is false, apply nothing
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        If(False,
+                        [then]:=Function(exp)
+                                  Return exp.Join(Function(c)
+                                                    Return c.From(Of Label).
+                                                             Where(Function(x) x.Language = English).
+                                                             Select(Function(x) New With {Key .Id = x.Id, Key .Description = x.Description})
+                                                  End Function).
+                                             On(Function(j) j.T1.Id = j.T2.Id)
+                                End Function
+                        ).
+                        As(Function(x) x.Tag).
+                        OrderBy(Function(j) j.T1.Id).
+                        SelectAll().
+                        Include(Sub(j) j.T1.LabelDescription = j.T2.Description).
+                        ToList()
+
+        CollectionAssert.AreEqual({article1, article2, article3}, result)
+        Assert.IsNull(result(0).LabelDescription)
+        Assert.IsNull(result(0).Tag)
+        Assert.IsNull(result(1).LabelDescription)
+        Assert.IsNull(result(1).Tag)
+        Assert.IsNull(result(2).LabelDescription)
+        Assert.IsNull(result(2).Tag)
+      End Using
+
+      ' condition is true, apply true part
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        If(True,
+                        [then]:=Function(exp)
+                                  Return exp.Join(Function(c)
+                                                    Return c.From(Of Label).
+                                                             Where(Function(x) x.Language = English).
+                                                             Select(Function(x) New With {Key .Id = x.Id, Key .Description = x.Description})
+                                                  End Function).
+                                             On(Function(j) j.T1.Id = j.T2.Id)
+                                End Function,
+                        otherwise:=Function(exp)
+                                     Return exp.Join(Function(c)
+                                                       Return c.From(Of Label).
+                                                                Where(Function(x) x.Language = German).
+                                                                Select(Function(x) New With {Key .Id = x.Id, Key .Description = x.Description})
+                                                     End Function).
+                                             On(Function(j) j.T1.Id = j.T2.Id)
+                                   End Function
+                        ).
+                        As(Function(x) x.Tag).
+                        OrderBy(Function(j) j.T1.Id).
+                        SelectAll().
+                        Include(Sub(j) j.T1.LabelDescription = j.T2.Description).
+                        ToList()
+
+        CollectionAssert.AreEqual({article1, article2, article3}, result)
+        Assert.AreEqual(label1En.Description, result(0).LabelDescription)
+        Assert.AreEqual(anonLabel1En, result(0).Tag)
+        Assert.AreEqual(label2En.Description, result(1).LabelDescription)
+        Assert.AreEqual(anonLabel2En, result(1).Tag)
+        Assert.AreEqual(label3En.Description, result(2).LabelDescription)
+        Assert.AreEqual(anonLabel3En, result(2).Tag)
+      End Using
+
+      ' condition is false, apply false part
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        If(False,
+                        [then]:=Function(exp)
+                                  Return exp.Join(Function(c)
+                                                    Return c.From(Of Label).
+                                                             Where(Function(x) x.Language = English).
+                                                             Select(Function(x) New With {Key .Id = x.Id, Key .Description = x.Description})
+                                                  End Function).
+                                             On(Function(j) j.T1.Id = j.T2.Id)
+                                End Function,
+                        otherwise:=Function(exp)
+                                     Return exp.Join(Function(c)
+                                                       Return c.From(Of Label).
+                                                                Where(Function(x) x.Language = German).
+                                                                Select(Function(x) New With {Key .Id = x.Id, Key .Description = x.Description})
+                                                     End Function).
+                                             On(Function(j) j.T1.Id = j.T2.Id)
+                                   End Function
+                        ).
+                        As(Function(x) x.Tag).
+                        OrderBy(Function(j) j.T1.Id).
+                        SelectAll().
+                        Include(Sub(j) j.T1.LabelDescription = j.T2.Description).
+                        ToList()
+
+        CollectionAssert.AreEqual({article1, article2, article3}, result)
+        Assert.AreEqual(label1De.Description, result(0).LabelDescription)
+        Assert.AreEqual(anonLabel1De, result(0).Tag)
+        Assert.AreEqual(label2De.Description, result(1).LabelDescription)
+        Assert.AreEqual(anonLabel2De, result(1).Tag)
+        Assert.AreEqual(label3De.Description, result(2).LabelDescription)
+        Assert.AreEqual(anonLabel3De, result(2).Tag)
+      End Using
+    End Sub
+
+    <TestMethod()>
     Public Overridable Sub SelectWithConditionalWhere()
       Dim items = CreateItems()
 

--- a/Source/Test/Yamo.Test/Tests/SelectWithExplicitRelationship.vb
+++ b/Source/Test/Yamo.Test/Tests/SelectWithExplicitRelationship.vb
@@ -1,0 +1,778 @@
+﻿Imports Yamo.Test.Model
+
+Namespace Tests
+
+  Public MustInherit Class SelectWithExplicitRelationship
+    Inherits BaseIntegrationTests
+
+    Protected Const English As String = "en"
+
+    Protected Const German As String = "de"
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithExplicitRelationships()
+      Dim linkedItem1 = Me.ModelFactory.CreateLinkedItem(1, Nothing)
+      Dim linkedItem2 = Me.ModelFactory.CreateLinkedItem(2, 1)
+
+      Dim linkedItem1Child1 = Me.ModelFactory.CreateLinkedItemChild(1, 1)
+      Dim linkedItem1Child2 = Me.ModelFactory.CreateLinkedItemChild(2, 1)
+      Dim linkedItem1Child3 = Me.ModelFactory.CreateLinkedItemChild(3, 1)
+
+      InsertItems(linkedItem1, linkedItem2)
+      InsertItems(linkedItem1Child1, linkedItem1Child2, linkedItem1Child3)
+
+      ' relationship is not defined in model
+      Using db = CreateDbContext()
+        Dim result = db.From(Of LinkedItem).
+                        Join(Of LinkedItem)(Function(j) j.T1.Id = j.T2.PreviousId.Value).As(Function(x) x.NextItem).
+                        Join(Of LinkedItemChild)(Function(j) j.T1.Id = j.T3.LinkedItemId).As(Function(j) j.T1.Children).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(1, result.Count)
+
+        Dim linkedItem1Result = result.First()
+        Assert.AreEqual(linkedItem1, linkedItem1Result)
+        Assert.IsNotNull(linkedItem1Result.NextItem)
+        Assert.AreEqual(linkedItem2, linkedItem1Result.NextItem)
+        Assert.AreEqual(3, linkedItem1Result.Children.Count)
+        Assert.IsNotNull(linkedItem1Result.Children.SingleOrDefault(Function(x) x.Id = 1))
+        Assert.IsNotNull(linkedItem1Result.Children.SingleOrDefault(Function(x) x.Id = 2))
+        Assert.IsNotNull(linkedItem1Result.Children.SingleOrDefault(Function(x) x.Id = 3))
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithExplicitReferenceRelationshipSettingValueFromSubqueryOfTypeEntityUsingNullIfAllColumnsAreNullBehavior()
+      Dim article1 = Me.ModelFactory.CreateArticle(1)
+      Dim article2 = Me.ModelFactory.CreateArticle(2)
+      Dim article3 = Me.ModelFactory.CreateArticle(3)
+
+      Dim label1En = Me.ModelFactory.CreateLabel("", 1, English)
+      Dim label2De = Me.ModelFactory.CreateLabel("", 2, German)
+      Dim label3En = Me.ModelFactory.CreateLabel("", 3, English)
+      Dim label3De = Me.ModelFactory.CreateLabel("", 3, German)
+
+      InsertItems(article1, article2, article3, label1En, label2De, label3En, label3De)
+
+      ' NonModelEntityCreationBehavior should not have any effect here
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        LeftJoin(Function(c)
+                                   Return c.From(Of Label).
+                                            Where(Function(x) x.Language = English).
+                                            SelectAll()
+                                 End Function, NonModelEntityCreationBehavior.NullIfAllColumnsAreNull).
+                        On(Function(j) j.T1.Id = j.T2.Id).
+                        As(Function(x) x.Tag).
+                        OrderBy(Function(j) j.T1.Id).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(3, result.Count)
+        Assert.AreEqual(article1, result(0))
+        Assert.IsNull(result(0).Label)
+        Assert.AreEqual(label1En, result(0).Tag)
+        Assert.AreEqual(article2, result(1))
+        Assert.IsNull(result(1).Label)
+        Assert.IsNull(result(1).Tag)
+        Assert.AreEqual(article3, result(2))
+        Assert.IsNull(result(2).Label)
+        Assert.AreEqual(label3En, result(2).Tag)
+      End Using
+
+      ' same as above, but assume behavior is not explicitly set
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        LeftJoin(Function(c)
+                                   Return c.From(Of Label).
+                                            Where(Function(x) x.Language = English).
+                                            SelectAll()
+                                 End Function).
+                        On(Function(j) j.T1.Id = j.T2.Id).
+                        As(Function(x) x.Tag).
+                        OrderBy(Function(j) j.T1.Id).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(3, result.Count)
+        Assert.AreEqual(article1, result(0))
+        Assert.IsNull(result(0).Label)
+        Assert.AreEqual(label1En, result(0).Tag)
+        Assert.AreEqual(article2, result(1))
+        Assert.IsNull(result(1).Label)
+        Assert.IsNull(result(1).Tag)
+        Assert.AreEqual(article3, result(2))
+        Assert.IsNull(result(2).Label)
+        Assert.AreEqual(label3En, result(2).Tag)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithExplicitReferenceRelationshipSettingValueFromSubqueryOfTypeEntityUsingAlwaysCreateInstanceBehavior()
+      Dim article1 = Me.ModelFactory.CreateArticle(1)
+      Dim article2 = Me.ModelFactory.CreateArticle(2)
+      Dim article3 = Me.ModelFactory.CreateArticle(3)
+
+      Dim label1En = Me.ModelFactory.CreateLabel("", 1, English)
+      Dim label2De = Me.ModelFactory.CreateLabel("", 2, German)
+      Dim label3En = Me.ModelFactory.CreateLabel("", 3, English)
+      Dim label3De = Me.ModelFactory.CreateLabel("", 3, German)
+
+      InsertItems(article1, article2, article3, label1En, label2De, label3En, label3De)
+
+      ' NonModelEntityCreationBehavior should not have any effect here
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        LeftJoin(Function(c)
+                                   Return c.From(Of Label).
+                                            Where(Function(x) x.Language = English).
+                                            SelectAll()
+                                 End Function, NonModelEntityCreationBehavior.AlwaysCreateInstance).
+                        On(Function(j) j.T1.Id = j.T2.Id).
+                        As(Function(x) x.Tag).
+                        OrderBy(Function(j) j.T1.Id).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(3, result.Count)
+        Assert.AreEqual(article1, result(0))
+        Assert.IsNull(result(0).Label)
+        Assert.AreEqual(label1En, result(0).Tag)
+        Assert.AreEqual(article2, result(1))
+        Assert.IsNull(result(1).Label)
+        Assert.IsNull(result(1).Tag)
+        Assert.AreEqual(article3, result(2))
+        Assert.IsNull(result(2).Label)
+        Assert.AreEqual(label3En, result(2).Tag)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithExplicitCollectionRelationshipSettingValueFromSubqueryOfTypeEntityUsingNullIfAllColumnsAreNullBehavior()
+      Dim article1 = Me.ModelFactory.CreateArticle(1)
+      Dim article2 = Me.ModelFactory.CreateArticle(2)
+      Dim article3 = Me.ModelFactory.CreateArticle(3)
+
+      Dim label1En = Me.ModelFactory.CreateLabel("", 1, English)
+      Dim label3En = Me.ModelFactory.CreateLabel("", 3, English)
+      Dim label3De = Me.ModelFactory.CreateLabel("", 3, German)
+
+      InsertItems(article1, article2, article3, label1En, label3En, label3De)
+
+      ' NonModelEntityCreationBehavior should not have any effect here
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        LeftJoin(Function(c)
+                                   Return c.From(Of Label).
+                                            SelectAll()
+                                 End Function, NonModelEntityCreationBehavior.NullIfAllColumnsAreNull).
+                        On(Function(j) j.T1.Id = j.T2.Id).
+                        As(Function(x) x.Tags).
+                        OrderBy(Function(j) j.T1.Id).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(3, result.Count)
+        Assert.AreEqual(article1, result(0))
+        CollectionAssert.AreEquivalent({label1En}, result(0).Tags)
+        Assert.AreEqual(article2, result(1))
+        Assert.AreEqual(0, result(1).Tags.Count)
+        Assert.AreEqual(article3, result(2))
+        CollectionAssert.AreEquivalent({label3En, label3De}, result(2).Tags)
+      End Using
+
+      ' same as above, but assume behavior is not explicitly set
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        LeftJoin(Function(c)
+                                   Return c.From(Of Label).
+                                            SelectAll()
+                                 End Function).
+                        On(Function(j) j.T1.Id = j.T2.Id).
+                        As(Function(x) x.Tags).
+                        OrderBy(Function(j) j.T1.Id).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(3, result.Count)
+        Assert.AreEqual(article1, result(0))
+        CollectionAssert.AreEquivalent({label1En}, result(0).Tags)
+        Assert.AreEqual(article2, result(1))
+        Assert.AreEqual(0, result(1).Tags.Count)
+        Assert.AreEqual(article3, result(2))
+        CollectionAssert.AreEquivalent({label3En, label3De}, result(2).Tags)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithExplicitCollectionRelationshipSettingValueFromSubqueryOfTypeEntityUsingAlwaysCreateInstanceBehavior()
+      Dim article1 = Me.ModelFactory.CreateArticle(1)
+      Dim article2 = Me.ModelFactory.CreateArticle(2)
+      Dim article3 = Me.ModelFactory.CreateArticle(3)
+
+      Dim label1En = Me.ModelFactory.CreateLabel("", 1, English)
+      Dim label3En = Me.ModelFactory.CreateLabel("", 3, English)
+      Dim label3De = Me.ModelFactory.CreateLabel("", 3, German)
+
+      InsertItems(article1, article2, article3, label1En, label3En, label3De)
+
+      ' NonModelEntityCreationBehavior should not have any effect here
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        LeftJoin(Function(c)
+                                   Return c.From(Of Label).
+                                            SelectAll()
+                                 End Function, NonModelEntityCreationBehavior.AlwaysCreateInstance).
+                        On(Function(j) j.T1.Id = j.T2.Id).
+                        As(Function(x) x.Tags).
+                        OrderBy(Function(j) j.T1.Id).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(3, result.Count)
+        Assert.AreEqual(article1, result(0))
+        CollectionAssert.AreEquivalent({label1En}, result(0).Tags)
+        Assert.AreEqual(article2, result(1))
+        Assert.AreEqual(0, result(1).Tags.Count)
+        Assert.AreEqual(article3, result(2))
+        CollectionAssert.AreEquivalent({label3En, label3De}, result(2).Tags)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithExplicitReferenceRelationshipSettingValueFromSubqueryOfTypeAnonymousTypeUsingNullIfAllColumnsAreNullBehavior()
+      Dim article1 = Me.ModelFactory.CreateArticle(1)
+      Dim article2 = Me.ModelFactory.CreateArticle(2)
+      Dim article3 = Me.ModelFactory.CreateArticle(3)
+
+      Dim label1En = Me.ModelFactory.CreateLabel("", 1, English)
+      Dim label2De = Me.ModelFactory.CreateLabel("", 2, German)
+      Dim label3En = Me.ModelFactory.CreateLabel("", 3, English)
+      Dim label3De = Me.ModelFactory.CreateLabel("", 3, German)
+
+      InsertItems(article1, article2, article3, label1En, label2De, label3En, label3De)
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        LeftJoin(Function(c)
+                                   Return c.From(Of Label).
+                                            Where(Function(x) x.Language = English).
+                                            Select(Function(x) New With {Key .Id = x.Id, Key .Description = x.Description})
+                                 End Function, NonModelEntityCreationBehavior.NullIfAllColumnsAreNull).
+                        On(Function(j) j.T1.Id = j.T2.Id).
+                        As(Function(x) x.Tag).
+                        OrderBy(Function(j) j.T1.Id).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(3, result.Count)
+        Assert.AreEqual(article1, result(0))
+        Assert.AreEqual(New With {Key .Id = label1En.Id, Key .Description = label1En.Description}, result(0).Tag)
+        Assert.AreEqual(article2, result(1))
+        Assert.IsNull(result(1).Tag)
+        Assert.AreEqual(article3, result(2))
+        Assert.AreEqual(New With {Key .Id = label3En.Id, Key .Description = label3En.Description}, result(2).Tag)
+      End Using
+
+      ' same as above, but assume behavior is not explicitly set
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        LeftJoin(Function(c)
+                                   Return c.From(Of Label).
+                                            Where(Function(x) x.Language = English).
+                                            Select(Function(x) New With {Key .Id = x.Id, Key .Description = x.Description})
+                                 End Function).
+                        On(Function(j) j.T1.Id = j.T2.Id).
+                        As(Function(x) x.Tag).
+                        OrderBy(Function(j) j.T1.Id).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(3, result.Count)
+        Assert.AreEqual(article1, result(0))
+        Assert.AreEqual(New With {Key .Id = label1En.Id, Key .Description = label1En.Description}, result(0).Tag)
+        Assert.AreEqual(article2, result(1))
+        Assert.IsNull(result(1).Tag)
+        Assert.AreEqual(article3, result(2))
+        Assert.AreEqual(New With {Key .Id = label3En.Id, Key .Description = label3En.Description}, result(2).Tag)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithExplicitReferenceRelationshipSettingValueFromSubqueryOfTypeAnonymousTypeUsingAlwaysCreateInstanceBehavior()
+      Dim article1 = Me.ModelFactory.CreateArticle(1)
+      Dim article2 = Me.ModelFactory.CreateArticle(2)
+      Dim article3 = Me.ModelFactory.CreateArticle(3)
+
+      Dim label1En = Me.ModelFactory.CreateLabel("", 1, English)
+      Dim label2De = Me.ModelFactory.CreateLabel("", 2, German)
+      Dim label3En = Me.ModelFactory.CreateLabel("", 3, English)
+      Dim label3De = Me.ModelFactory.CreateLabel("", 3, German)
+
+      InsertItems(article1, article2, article3, label1En, label2De, label3En, label3De)
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        LeftJoin(Function(c)
+                                   Return c.From(Of Label).
+                                            Where(Function(x) x.Language = English).
+                                            Select(Function(x) New With {Key .Id = x.Id, Key .Description = x.Description})
+                                 End Function, NonModelEntityCreationBehavior.AlwaysCreateInstance).
+                        On(Function(j) j.T1.Id = j.T2.Id).
+                        As(Function(x) x.Tag).
+                        OrderBy(Function(j) j.T1.Id).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(3, result.Count)
+        Assert.AreEqual(article1, result(0))
+        Assert.AreEqual(New With {Key .Id = label1En.Id, Key .Description = label1En.Description}, result(0).Tag)
+        Assert.AreEqual(article2, result(1))
+        Assert.AreEqual(New With {Key .Id = 0, Key .Description = CType(Nothing, String)}, result(1).Tag)
+        Assert.AreEqual(article3, result(2))
+        Assert.AreEqual(New With {Key .Id = label3En.Id, Key .Description = label3En.Description}, result(2).Tag)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithExplicitCollectionRelationshipSettingValueFromSubqueryOfTypeAnonymousTypeUsingNullIfAllColumnsAreNullBehavior()
+      Dim article1 = Me.ModelFactory.CreateArticle(1)
+      Dim article2 = Me.ModelFactory.CreateArticle(2)
+      Dim article3 = Me.ModelFactory.CreateArticle(3)
+
+      Dim label1En = Me.ModelFactory.CreateLabel("", 1, English)
+      Dim label3En = Me.ModelFactory.CreateLabel("", 3, English)
+      Dim label3De = Me.ModelFactory.CreateLabel("", 3, German)
+
+      InsertItems(article1, article2, article3, label1En, label3En, label3De)
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        LeftJoin(Function(c)
+                                   Return c.From(Of Label).
+                                            Select(Function(x) New With {Key .Id = x.Id, Key .Description = x.Description})
+                                 End Function, NonModelEntityCreationBehavior.NullIfAllColumnsAreNull).
+                        On(Function(j) j.T1.Id = j.T2.Id).
+                        As(Function(x) x.Tags).
+                        OrderBy(Function(j) j.T1.Id).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(3, result.Count)
+        Assert.AreEqual(article1, result(0))
+        CollectionAssert.AreEquivalent({New With {Key .Id = label1En.Id, Key .Description = label1En.Description}}, result(0).Tags)
+        Assert.AreEqual(article2, result(1))
+        Assert.AreEqual(0, result(1).Tags.Count)
+        Assert.AreEqual(article3, result(2))
+        CollectionAssert.AreEquivalent({New With {Key .Id = label3En.Id, Key .Description = label3En.Description}, New With {Key .Id = label3De.Id, Key .Description = label3De.Description}}, result(2).Tags)
+      End Using
+
+      ' same as above, but assume behavior is not explicitly set
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        LeftJoin(Function(c)
+                                   Return c.From(Of Label).
+                                            Select(Function(x) New With {Key .Id = x.Id, Key .Description = x.Description})
+                                 End Function).
+                        On(Function(j) j.T1.Id = j.T2.Id).
+                        As(Function(x) x.Tags).
+                        OrderBy(Function(j) j.T1.Id).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(3, result.Count)
+        Assert.AreEqual(article1, result(0))
+        CollectionAssert.AreEquivalent({New With {Key .Id = label1En.Id, Key .Description = label1En.Description}}, result(0).Tags)
+        Assert.AreEqual(article2, result(1))
+        Assert.AreEqual(0, result(1).Tags.Count)
+        Assert.AreEqual(article3, result(2))
+        CollectionAssert.AreEquivalent({New With {Key .Id = label3En.Id, Key .Description = label3En.Description}, New With {Key .Id = label3De.Id, Key .Description = label3De.Description}}, result(2).Tags)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithExplicitCollectionRelationshipSettingValueFromSubqueryOfTypeAnonymousTypeUsingAlwaysCreateInstanceBehavior()
+      Dim article1 = Me.ModelFactory.CreateArticle(1)
+      Dim article2 = Me.ModelFactory.CreateArticle(2)
+      Dim article3 = Me.ModelFactory.CreateArticle(3)
+
+      Dim label1En = Me.ModelFactory.CreateLabel("", 1, English)
+      Dim label3En = Me.ModelFactory.CreateLabel("", 3, English)
+      Dim label3De = Me.ModelFactory.CreateLabel("", 3, German)
+
+      InsertItems(article1, article2, article3, label1En, label3En, label3De)
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        LeftJoin(Function(c)
+                                   Return c.From(Of Label).
+                                            Select(Function(x) New With {Key .Id = x.Id, Key .Description = x.Description})
+                                 End Function, NonModelEntityCreationBehavior.AlwaysCreateInstance).
+                        On(Function(j) j.T1.Id = j.T2.Id).
+                        As(Function(x) x.Tags).
+                        OrderBy(Function(j) j.T1.Id).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(3, result.Count)
+        Assert.AreEqual(article1, result(0))
+        CollectionAssert.AreEquivalent({New With {Key .Id = label1En.Id, Key .Description = label1En.Description}}, result(0).Tags)
+        Assert.AreEqual(article2, result(1))
+        CollectionAssert.AreEquivalent({New With {Key .Id = 0, Key .Description = CType(Nothing, String)}}, result(1).Tags)
+        Assert.AreEqual(article3, result(2))
+        CollectionAssert.AreEquivalent({New With {Key .Id = label3En.Id, Key .Description = label3En.Description}, New With {Key .Id = label3De.Id, Key .Description = label3De.Description}}, result(2).Tags)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithExplicitReferenceRelationshipSettingValueFromSubqueryOfTypeValueTupleUsingNullIfAllColumnsAreNullBehavior()
+      Dim article1 = Me.ModelFactory.CreateArticle(1)
+      Dim article2 = Me.ModelFactory.CreateArticle(2)
+      Dim article3 = Me.ModelFactory.CreateArticle(3)
+
+      Dim label1En = Me.ModelFactory.CreateLabel("", 1, English)
+      Dim label2De = Me.ModelFactory.CreateLabel("", 2, German)
+      Dim label3En = Me.ModelFactory.CreateLabel("", 3, English)
+      Dim label3De = Me.ModelFactory.CreateLabel("", 3, German)
+
+      InsertItems(article1, article2, article3, label1En, label2De, label3En, label3De)
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        LeftJoin(Function(c)
+                                   Return c.From(Of Label).
+                                            Where(Function(x) x.Language = English).
+                                            Select(Function(x) (Id:=x.Id, Description:=x.Description))
+                                 End Function, NonModelEntityCreationBehavior.NullIfAllColumnsAreNull).
+                        On(Function(j) j.T1.Id = j.T2.Id).
+                        As(Function(x) x.Tag).
+                        OrderBy(Function(j) j.T1.Id).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(3, result.Count)
+        Assert.AreEqual(article1, result(0))
+        Assert.AreEqual((label1En.Id, label1En.Description), result(0).Tag)
+        Assert.AreEqual(article2, result(1))
+        Assert.IsNull(result(1).Tag)
+        Assert.AreEqual(article3, result(2))
+        Assert.AreEqual((label3En.Id, label3En.Description), result(2).Tag)
+      End Using
+
+      ' same as above, but assume behavior is not explicitly set
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        LeftJoin(Function(c)
+                                   Return c.From(Of Label).
+                                            Where(Function(x) x.Language = English).
+                                            Select(Function(x) (Id:=x.Id, Description:=x.Description))
+                                 End Function).
+                        On(Function(j) j.T1.Id = j.T2.Id).
+                        As(Function(x) x.Tag).
+                        OrderBy(Function(j) j.T1.Id).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(3, result.Count)
+        Assert.AreEqual(article1, result(0))
+        Assert.AreEqual((label1En.Id, label1En.Description), result(0).Tag)
+        Assert.AreEqual(article2, result(1))
+        Assert.IsNull(result(1).Tag)
+        Assert.AreEqual(article3, result(2))
+        Assert.AreEqual((label3En.Id, label3En.Description), result(2).Tag)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithExplicitReferenceRelationshipSettingValueFromSubqueryOfTypeValueTupleUsingAlwaysCreateInstanceBehavior()
+      Dim article1 = Me.ModelFactory.CreateArticle(1)
+      Dim article2 = Me.ModelFactory.CreateArticle(2)
+      Dim article3 = Me.ModelFactory.CreateArticle(3)
+
+      Dim label1En = Me.ModelFactory.CreateLabel("", 1, English)
+      Dim label2De = Me.ModelFactory.CreateLabel("", 2, German)
+      Dim label3En = Me.ModelFactory.CreateLabel("", 3, English)
+      Dim label3De = Me.ModelFactory.CreateLabel("", 3, German)
+
+      InsertItems(article1, article2, article3, label1En, label2De, label3En, label3De)
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        LeftJoin(Function(c)
+                                   Return c.From(Of Label).
+                                            Where(Function(x) x.Language = English).
+                                            Select(Function(x) (Id:=x.Id, Description:=x.Description))
+                                 End Function, NonModelEntityCreationBehavior.AlwaysCreateInstance).
+                        On(Function(j) j.T1.Id = j.T2.Id).
+                        As(Function(x) x.Tag).
+                        OrderBy(Function(j) j.T1.Id).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(3, result.Count)
+        Assert.AreEqual(article1, result(0))
+        Assert.AreEqual((label1En.Id, label1En.Description), result(0).Tag)
+        Assert.AreEqual(article2, result(1))
+        Assert.AreEqual(ValueTuple.Create(Of Int32, String)(0, Nothing), result(1).Tag)
+        Assert.AreEqual(article3, result(2))
+        Assert.AreEqual((label3En.Id, label3En.Description), result(2).Tag)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithExplicitCollectionRelationshipSettingValueFromSubqueryOfTypeValueTupleUsingNullIfAllColumnsAreNullBehavior()
+      Dim article1 = Me.ModelFactory.CreateArticle(1)
+      Dim article2 = Me.ModelFactory.CreateArticle(2)
+      Dim article3 = Me.ModelFactory.CreateArticle(3)
+
+      Dim label1En = Me.ModelFactory.CreateLabel("", 1, English)
+      Dim label3En = Me.ModelFactory.CreateLabel("", 3, English)
+      Dim label3De = Me.ModelFactory.CreateLabel("", 3, German)
+
+      InsertItems(article1, article2, article3, label1En, label3En, label3De)
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        LeftJoin(Function(c)
+                                   Return c.From(Of Label).
+                                            Select(Function(x) (Id:=x.Id, Description:=x.Description))
+                                 End Function, NonModelEntityCreationBehavior.NullIfAllColumnsAreNull).
+                        On(Function(j) j.T1.Id = j.T2.Id).
+                        As(Function(x) x.Tags).
+                        OrderBy(Function(j) j.T1.Id).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(3, result.Count)
+        Assert.AreEqual(article1, result(0))
+        CollectionAssert.AreEquivalent({(label1En.Id, label1En.Description)}, result(0).Tags)
+        Assert.AreEqual(article2, result(1))
+        Assert.AreEqual(0, result(1).Tags.Count)
+        Assert.AreEqual(article3, result(2))
+        CollectionAssert.AreEquivalent({(label3En.Id, label3En.Description), (label3De.Id, label3De.Description)}, result(2).Tags)
+      End Using
+
+      ' same as above, but assume behavior is not explicitly set
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        LeftJoin(Function(c)
+                                   Return c.From(Of Label).
+                                            Select(Function(x) (Id:=x.Id, Description:=x.Description))
+                                 End Function).
+                        On(Function(j) j.T1.Id = j.T2.Id).
+                        As(Function(x) x.Tags).
+                        OrderBy(Function(j) j.T1.Id).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(3, result.Count)
+        Assert.AreEqual(article1, result(0))
+        CollectionAssert.AreEquivalent({(label1En.Id, label1En.Description)}, result(0).Tags)
+        Assert.AreEqual(article2, result(1))
+        Assert.AreEqual(0, result(1).Tags.Count)
+        Assert.AreEqual(article3, result(2))
+        CollectionAssert.AreEquivalent({(label3En.Id, label3En.Description), (label3De.Id, label3De.Description)}, result(2).Tags)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithExplicitCollectionRelationshipSettingValueFromSubqueryOfTypeValueTupleUsingAlwaysCreateInstanceBehavior()
+      Dim article1 = Me.ModelFactory.CreateArticle(1)
+      Dim article2 = Me.ModelFactory.CreateArticle(2)
+      Dim article3 = Me.ModelFactory.CreateArticle(3)
+
+      Dim label1En = Me.ModelFactory.CreateLabel("", 1, English)
+      Dim label3En = Me.ModelFactory.CreateLabel("", 3, English)
+      Dim label3De = Me.ModelFactory.CreateLabel("", 3, German)
+
+      InsertItems(article1, article2, article3, label1En, label3En, label3De)
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        LeftJoin(Function(c)
+                                   Return c.From(Of Label).
+                                            Select(Function(x) (Id:=x.Id, Description:=x.Description))
+                                 End Function, NonModelEntityCreationBehavior.AlwaysCreateInstance).
+                        On(Function(j) j.T1.Id = j.T2.Id).
+                        As(Function(x) x.Tags).
+                        OrderBy(Function(j) j.T1.Id).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(3, result.Count)
+        Assert.AreEqual(article1, result(0))
+        CollectionAssert.AreEquivalent({(label1En.Id, label1En.Description)}, result(0).Tags)
+        Assert.AreEqual(article2, result(1))
+        CollectionAssert.AreEquivalent({ValueTuple.Create(Of Int32, String)(0, Nothing)}, result(1).Tags)
+        Assert.AreEqual(article3, result(2))
+        CollectionAssert.AreEquivalent({(label3En.Id, label3En.Description), (label3De.Id, label3De.Description)}, result(2).Tags)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithExplicitReferenceRelationshipSettingValueFromSubqueryOfTypeAdHocTypeUsingNullIfAllColumnsAreNullBehavior()
+      Dim article1 = Me.ModelFactory.CreateArticle(1)
+      Dim article2 = Me.ModelFactory.CreateArticle(2)
+      Dim article3 = Me.ModelFactory.CreateArticle(3)
+
+      Dim label1En = Me.ModelFactory.CreateLabel("", 1, English)
+      Dim label2De = Me.ModelFactory.CreateLabel("", 2, German)
+      Dim label3En = Me.ModelFactory.CreateLabel("", 3, English)
+      Dim label3De = Me.ModelFactory.CreateLabel("", 3, German)
+
+      InsertItems(article1, article2, article3, label1En, label2De, label3En, label3De)
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        LeftJoin(Function(c)
+                                   Return c.From(Of Label).
+                                            Where(Function(x) x.Language = English).
+                                            Select(Function(x) New NonModelObject() With {.IntValue = x.Id, .StringValue1 = x.Description})
+                                 End Function, NonModelEntityCreationBehavior.NullIfAllColumnsAreNull).
+                        On(Function(j) j.T1.Id = j.T2.IntValue).
+                        As(Function(x) x.Tag).
+                        OrderBy(Function(j) j.T1.Id).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(3, result.Count)
+        Assert.AreEqual(article1, result(0))
+        Assert.AreEqual(New NonModelObject() With {.IntValue = label1En.Id, .StringValue1 = label1En.Description}, result(0).Tag)
+        Assert.AreEqual(article2, result(1))
+        Assert.IsNull(result(1).Tag)
+        Assert.AreEqual(article3, result(2))
+        Assert.AreEqual(New NonModelObject() With {.IntValue = label3En.Id, .StringValue1 = label3En.Description}, result(2).Tag)
+      End Using
+
+      ' same as above, but assume behavior is not explicitly set
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        LeftJoin(Function(c)
+                                   Return c.From(Of Label).
+                                            Where(Function(x) x.Language = English).
+                                            Select(Function(x) New NonModelObject() With {.IntValue = x.Id, .StringValue1 = x.Description})
+                                 End Function).
+                        On(Function(j) j.T1.Id = j.T2.IntValue).
+                        As(Function(x) x.Tag).
+                        OrderBy(Function(j) j.T1.Id).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(3, result.Count)
+        Assert.AreEqual(article1, result(0))
+        Assert.AreEqual(New NonModelObject() With {.IntValue = label1En.Id, .StringValue1 = label1En.Description}, result(0).Tag)
+        Assert.AreEqual(article2, result(1))
+        Assert.IsNull(result(1).Tag)
+        Assert.AreEqual(article3, result(2))
+        Assert.AreEqual(New NonModelObject() With {.IntValue = label3En.Id, .StringValue1 = label3En.Description}, result(2).Tag)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithExplicitReferenceRelationshipSettingValueFromSubqueryOfTypeAdHocTypeUsingAlwaysCreateInstanceBehavior()
+      Dim article1 = Me.ModelFactory.CreateArticle(1)
+      Dim article2 = Me.ModelFactory.CreateArticle(2)
+      Dim article3 = Me.ModelFactory.CreateArticle(3)
+
+      Dim label1En = Me.ModelFactory.CreateLabel("", 1, English)
+      Dim label2De = Me.ModelFactory.CreateLabel("", 2, German)
+      Dim label3En = Me.ModelFactory.CreateLabel("", 3, English)
+      Dim label3De = Me.ModelFactory.CreateLabel("", 3, German)
+
+      InsertItems(article1, article2, article3, label1En, label2De, label3En, label3De)
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        LeftJoin(Function(c)
+                                   Return c.From(Of Label).
+                                            Where(Function(x) x.Language = English).
+                                            Select(Function(x) New NonModelObject() With {.IntValue = x.Id, .StringValue1 = x.Description})
+                                 End Function, NonModelEntityCreationBehavior.AlwaysCreateInstance).
+                        On(Function(j) j.T1.Id = j.T2.IntValue).
+                        As(Function(x) x.Tag).
+                        OrderBy(Function(j) j.T1.Id).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(3, result.Count)
+        Assert.AreEqual(article1, result(0))
+        Assert.AreEqual(New NonModelObject() With {.IntValue = label1En.Id, .StringValue1 = label1En.Description}, result(0).Tag)
+        Assert.AreEqual(article2, result(1))
+        Assert.AreEqual(New NonModelObject() With {.IntValue = 0, .StringValue1 = Nothing}, result(1).Tag)
+        Assert.AreEqual(article3, result(2))
+        Assert.AreEqual(New NonModelObject() With {.IntValue = label3En.Id, .StringValue1 = label3En.Description}, result(2).Tag)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithExplicitCollectionRelationshipSettingValueFromSubqueryOfTypeAdHocTypeUsingNullIfAllColumnsAreNullBehavior()
+      Dim article1 = Me.ModelFactory.CreateArticle(1)
+      Dim article2 = Me.ModelFactory.CreateArticle(2)
+      Dim article3 = Me.ModelFactory.CreateArticle(3)
+
+      Dim label1En = Me.ModelFactory.CreateLabel("", 1, English)
+      Dim label3En = Me.ModelFactory.CreateLabel("", 3, English)
+      Dim label3De = Me.ModelFactory.CreateLabel("", 3, German)
+
+      InsertItems(article1, article2, article3, label1En, label3En, label3De)
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        LeftJoin(Function(c)
+                                   Return c.From(Of Label).
+                                            Select(Function(x) New NonModelObject() With {.IntValue = x.Id, .StringValue1 = x.Description})
+                                 End Function, NonModelEntityCreationBehavior.NullIfAllColumnsAreNull).
+                        On(Function(j) j.T1.Id = j.T2.IntValue).
+                        As(Function(x) x.Tags).
+                        OrderBy(Function(j) j.T1.Id).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(3, result.Count)
+        Assert.AreEqual(article1, result(0))
+        CollectionAssert.AreEquivalent({New NonModelObject() With {.IntValue = label1En.Id, .StringValue1 = label1En.Description}}, result(0).Tags)
+        Assert.AreEqual(article2, result(1))
+        Assert.AreEqual(0, result(1).Tags.Count)
+        Assert.AreEqual(article3, result(2))
+        CollectionAssert.AreEquivalent({New NonModelObject() With {.IntValue = label3En.Id, .StringValue1 = label3En.Description}, New NonModelObject() With {.IntValue = label3De.Id, .StringValue1 = label3De.Description}}, result(2).Tags)
+      End Using
+
+      ' same as above, but assume behavior is not explicitly set
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        LeftJoin(Function(c)
+                                   Return c.From(Of Label).
+                                            Select(Function(x) New NonModelObject() With {.IntValue = x.Id, .StringValue1 = x.Description})
+                                 End Function, NonModelEntityCreationBehavior.NullIfAllColumnsAreNull).
+                        On(Function(j) j.T1.Id = j.T2.IntValue).
+                        As(Function(x) x.Tags).
+                        OrderBy(Function(j) j.T1.Id).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(3, result.Count)
+        Assert.AreEqual(article1, result(0))
+        CollectionAssert.AreEquivalent({New NonModelObject() With {.IntValue = label1En.Id, .StringValue1 = label1En.Description}}, result(0).Tags)
+        Assert.AreEqual(article2, result(1))
+        Assert.AreEqual(0, result(1).Tags.Count)
+        Assert.AreEqual(article3, result(2))
+        CollectionAssert.AreEquivalent({New NonModelObject() With {.IntValue = label3En.Id, .StringValue1 = label3En.Description}, New NonModelObject() With {.IntValue = label3De.Id, .StringValue1 = label3De.Description}}, result(2).Tags)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithExplicitCollectionRelationshipSettingValueFromSubqueryOfTypeAdHocTypeUsingAlwaysCreateInstanceBehavior()
+      Dim article1 = Me.ModelFactory.CreateArticle(1)
+      Dim article2 = Me.ModelFactory.CreateArticle(2)
+      Dim article3 = Me.ModelFactory.CreateArticle(3)
+
+      Dim label1En = Me.ModelFactory.CreateLabel("", 1, English)
+      Dim label3En = Me.ModelFactory.CreateLabel("", 3, English)
+      Dim label3De = Me.ModelFactory.CreateLabel("", 3, German)
+
+      InsertItems(article1, article2, article3, label1En, label3En, label3De)
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        LeftJoin(Function(c)
+                                   Return c.From(Of Label).
+                                            Select(Function(x) New NonModelObject() With {.IntValue = x.Id, .StringValue1 = x.Description})
+                                 End Function, NonModelEntityCreationBehavior.AlwaysCreateInstance).
+                        On(Function(j) j.T1.Id = j.T2.IntValue).
+                        As(Function(x) x.Tags).
+                        OrderBy(Function(j) j.T1.Id).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(3, result.Count)
+        Assert.AreEqual(article1, result(0))
+        CollectionAssert.AreEquivalent({New NonModelObject() With {.IntValue = label1En.Id, .StringValue1 = label1En.Description}}, result(0).Tags)
+        Assert.AreEqual(article2, result(1))
+        CollectionAssert.AreEquivalent({New NonModelObject() With {.IntValue = 0, .StringValue1 = Nothing}}, result(1).Tags)
+        Assert.AreEqual(article3, result(2))
+        CollectionAssert.AreEquivalent({New NonModelObject() With {.IntValue = label3En.Id, .StringValue1 = label3En.Description}, New NonModelObject() With {.IntValue = label3De.Id, .StringValue1 = label3De.Description}}, result(2).Tags)
+      End Using
+    End Sub
+
+  End Class
+End Namespace

--- a/Source/Test/Yamo.Test/Tests/SelectWithIncludeTests.vb
+++ b/Source/Test/Yamo.Test/Tests/SelectWithIncludeTests.vb
@@ -570,5 +570,255 @@ Namespace Tests
       End Using
     End Sub
 
+    <TestMethod()>
+    Public Overridable Sub SelectWithIncludeValueFromSubqueryOfTypeEntity()
+      Dim article1 = Me.ModelFactory.CreateArticle(1, 100D)
+      Dim article2 = Me.ModelFactory.CreateArticle(2, 200D)
+
+      Dim label1En = Me.ModelFactory.CreateLabel("", 1, English, "Article 1")
+
+      InsertItems(article1, article2, label1En)
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        LeftJoin(Function(c)
+                                   Return c.From(Of Label).
+                                            Where(Function(x) x.Language = English).
+                                            SelectAll()
+                                 End Function).
+                        On(Function(j) j.T1.Id = j.T2.Id).
+                        OrderBy(Function(j) j.T1.Id).
+                        SelectAll().
+                        ExcludeT2().
+                        Include(Sub(j) j.T1.LabelDescription = j.T2.Description).
+                        ToList()
+
+        Assert.AreEqual(2, result.Count)
+        Assert.AreEqual(article1, result(0)) ' this only checks "model" properties
+        Assert.AreEqual(label1En.Description, result(0).LabelDescription)
+        Assert.IsNull(result(0).Label)
+        Assert.AreEqual(article2, result(1)) ' this only checks "model" properties
+        Assert.IsNull(result(1).LabelDescription)
+        Assert.IsNull(result(1).Label)
+      End Using
+
+      ' same as above, but include whole subquery result
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        LeftJoin(Function(c)
+                                   Return c.From(Of Label).
+                                            Where(Function(x) x.Language = English).
+                                            SelectAll()
+                                 End Function).
+                        On(Function(j) j.T1.Id = j.T2.Id).
+                        OrderBy(Function(j) j.T1.Id).
+                        SelectAll().
+                        Include(Sub(j) j.T1.LabelDescription = j.T2.Description).
+                        ToList()
+
+        Assert.AreEqual(2, result.Count)
+        Assert.AreEqual(article1, result(0)) ' this only checks "model" properties
+        Assert.AreEqual(label1En.Description, result(0).LabelDescription)
+        Assert.AreEqual(label1En, result(0).Label)
+        Assert.AreEqual(article2, result(1)) ' this only checks "model" properties
+        Assert.IsNull(result(1).LabelDescription)
+        Assert.IsNull(result(1).Label)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithIncludeValueFromSubqueryOfTypeAnonymousType()
+      Dim article1 = Me.ModelFactory.CreateArticle(1, 100D)
+      Dim article2 = Me.ModelFactory.CreateArticle(2, 200D)
+
+      Dim label1En = Me.ModelFactory.CreateLabel("", 1, English, "Article 1")
+
+      InsertItems(article1, article2, label1En)
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        LeftJoin(Function(c)
+                                   Return c.From(Of Label).
+                                            Where(Function(x) x.Language = English).
+                                            Select(Function(x) New With {Key .Id = x.Id, Key .Description = x.Description})
+                                 End Function).
+                        On(Function(j) j.T1.Id = j.T2.Id).
+                        OrderBy(Function(j) j.T1.Id).
+                        SelectAll().
+                        Include(Sub(j) j.T1.LabelDescription = j.T2.Description).
+                        ToList()
+
+        Assert.AreEqual(2, result.Count)
+        Assert.AreEqual(article1, result(0)) ' this only checks "model" properties
+        Assert.AreEqual(label1En.Description, result(0).LabelDescription)
+        Assert.AreEqual(article2, result(1)) ' this only checks "model" properties
+        Assert.IsNull(result(1).LabelDescription)
+      End Using
+
+      ' same as above, but include whole subquery result
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        LeftJoin(Function(c)
+                                   Return c.From(Of Label).
+                                            Where(Function(x) x.Language = English).
+                                            Select(Function(x) New With {Key .Id = x.Id, Key .Description = x.Description})
+                                 End Function).
+                        On(Function(j) j.T1.Id = j.T2.Id).
+                        As(Function(x) x.Tag).
+                        OrderBy(Function(j) j.T1.Id).
+                        SelectAll().
+                        Include(Sub(j) j.T1.LabelDescription = j.T2.Description).
+                        ToList()
+
+        Assert.AreEqual(2, result.Count)
+        Assert.AreEqual(article1, result(0)) ' this only checks "model" properties
+        Assert.AreEqual(label1En.Description, result(0).LabelDescription)
+        Assert.AreEqual(New With {Key .Id = label1En.Id, Key .Description = label1En.Description}, result(0).Tag)
+        Assert.AreEqual(article2, result(1)) ' this only checks "model" properties
+        Assert.IsNull(result(1).LabelDescription)
+        Assert.IsNull(result(1).Tag)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithIncludeValueFromSubqueryOfTypeValueTuple()
+      Dim article1 = Me.ModelFactory.CreateArticle(1, 100D)
+      Dim article2 = Me.ModelFactory.CreateArticle(2, 200D)
+
+      Dim label1En = Me.ModelFactory.CreateLabel("", 1, English, "Article 1")
+
+      InsertItems(article1, article2, label1En)
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        LeftJoin(Function(c)
+                                   Return c.From(Of Label).
+                                            Where(Function(x) x.Language = English).
+                                            Select(Function(x) (Id:=x.Id, Description:=x.Description))
+                                 End Function).
+                        On(Function(j) j.T1.Id = j.T2.Id).
+                        OrderBy(Function(j) j.T1.Id).
+                        SelectAll().
+                        Include(Sub(j) j.T1.LabelDescription = j.T2.Description).
+                        ToList()
+
+        Assert.AreEqual(2, result.Count)
+        Assert.AreEqual(article1, result(0)) ' this only checks "model" properties
+        Assert.AreEqual(label1En.Description, result(0).LabelDescription)
+        Assert.AreEqual(article2, result(1)) ' this only checks "model" properties
+        Assert.IsNull(result(1).LabelDescription)
+      End Using
+
+      ' same as above, but include whole subquery result
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        LeftJoin(Function(c)
+                                   Return c.From(Of Label).
+                                            Where(Function(x) x.Language = English).
+                                            Select(Function(x) (Id:=x.Id, Description:=x.Description))
+                                 End Function).
+                        On(Function(j) j.T1.Id = j.T2.Id).
+                        As(Function(x) x.Tag).
+                        OrderBy(Function(j) j.T1.Id).
+                        SelectAll().
+                        Include(Sub(j) j.T1.LabelDescription = j.T2.Description).
+                        ToList()
+
+        Assert.AreEqual(2, result.Count)
+        Assert.AreEqual(article1, result(0)) ' this only checks "model" properties
+        Assert.AreEqual(label1En.Description, result(0).LabelDescription)
+        Assert.AreEqual((label1En.Id, label1En.Description), result(0).Tag)
+        Assert.AreEqual(article2, result(1)) ' this only checks "model" properties
+        Assert.IsNull(result(1).LabelDescription)
+        Assert.IsNull(result(1).Tag)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithIncludeValueFromSubqueryOfTypeAdHocType()
+      Dim article1 = Me.ModelFactory.CreateArticle(1, 100D)
+      Dim article2 = Me.ModelFactory.CreateArticle(2, 200D)
+
+      Dim label1En = Me.ModelFactory.CreateLabel("", 1, English, "Article 1")
+
+      InsertItems(article1, article2, label1En)
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        LeftJoin(Function(c)
+                                   Return c.From(Of Label).
+                                            Where(Function(x) x.Language = English).
+                                            Select(Function(x) New NonModelObject() With {.IntValue = x.Id, .StringValue1 = x.Description})
+                                 End Function).
+                        On(Function(j) j.T1.Id = j.T2.IntValue).
+                        OrderBy(Function(j) j.T1.Id).
+                        SelectAll().
+                        Include(Sub(j) j.T1.LabelDescription = j.T2.StringValue1).
+                        ToList()
+
+        Assert.AreEqual(2, result.Count)
+        Assert.AreEqual(article1, result(0)) ' this only checks "model" properties
+        Assert.AreEqual(label1En.Description, result(0).LabelDescription)
+        Assert.AreEqual(article2, result(1)) ' this only checks "model" properties
+        Assert.IsNull(result(1).LabelDescription)
+      End Using
+
+      ' same as above, but include whole subquery result
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        LeftJoin(Function(c)
+                                   Return c.From(Of Label).
+                                            Where(Function(x) x.Language = English).
+                                            Select(Function(x) New NonModelObject() With {.IntValue = x.Id, .StringValue1 = x.Description})
+                                 End Function).
+                        On(Function(j) j.T1.Id = j.T2.IntValue).
+                        As(Function(x) x.Tag).
+                        OrderBy(Function(j) j.T1.Id).
+                        SelectAll().
+                        Include(Sub(j) j.T1.LabelDescription = j.T2.StringValue1).
+                        ToList()
+
+        Assert.AreEqual(2, result.Count)
+        Assert.AreEqual(article1, result(0)) ' this only checks "model" properties
+        Assert.AreEqual(label1En.Description, result(0).LabelDescription)
+        Assert.AreEqual(New NonModelObject() With {.IntValue = label1En.Id, .StringValue1 = label1En.Description}, result(0).Tag)
+        Assert.AreEqual(article2, result(1)) ' this only checks "model" properties
+        Assert.IsNull(result(1).LabelDescription)
+        Assert.IsNull(result(1).Tag)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithIncludeValueDirectlyInSubquery()
+      Dim article1 = Me.ModelFactory.CreateArticle(1, 100D)
+      Dim article2 = Me.ModelFactory.CreateArticle(2, 200D)
+
+      Dim label1En = Me.ModelFactory.CreateLabel("", 1, English, "Article 1")
+
+      InsertItems(article1, article2, label1En)
+
+      Try
+        Using db = CreateDbContext()
+          Dim result = db.From(Of Article).
+                        LeftJoin(Function(c)
+                                   Return c.From(Of Label).
+                                            Where(Function(x) x.Language = English).
+                                            SelectAll().
+                                            Include(Sub(x) x.Tag = x.Description)
+                                 End Function).
+                        On(Function(j) j.T1.Id = j.T2.Id).
+                        OrderBy(Function(j) j.T1.Id).
+                        SelectAll().
+                        ToList()
+
+          Assert.Fail()
+        End Using
+      Catch ex As NotSupportedException
+        ' expected
+      Catch ex As Exception
+        Assert.Fail()
+      End Try
+    End Sub
+
   End Class
 End Namespace

--- a/Source/Test/Yamo.Test/Tests/SelectWithJoinSubqueryTests.vb
+++ b/Source/Test/Yamo.Test/Tests/SelectWithJoinSubqueryTests.vb
@@ -1,0 +1,239 @@
+﻿Imports Yamo.Test.Model
+
+Namespace Tests
+
+  Public MustInherit Class SelectWithJoinSubqueryTests
+    Inherits BaseIntegrationTests
+
+    Protected Const English As String = "en"
+
+    Protected Const German As String = "de"
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithSubqueryOfTypeEntity()
+      Dim article1 = Me.ModelFactory.CreateArticle(1)
+      Dim article2 = Me.ModelFactory.CreateArticle(2)
+      Dim article3 = Me.ModelFactory.CreateArticle(3)
+
+      Dim label1En = Me.ModelFactory.CreateLabel("", 1, English, "ddd")
+      Dim label2De = Me.ModelFactory.CreateLabel("", 2, German, "ccc")
+      Dim label3En = Me.ModelFactory.CreateLabel("", 3, English, "bbb")
+      Dim label3De = Me.ModelFactory.CreateLabel("", 3, German, "aaa")
+
+      InsertItems(article1, article2, article3, label1En, label2De, label3En, label3De)
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        Join(Of Label)(Function(c)
+                                         Return c.From(Of Label).
+                                                  Where(Function(x) x.Language = English).
+                                                  SelectAll()
+                                       End Function).
+                        On(Function(a, l) a.Id = l.Id).
+                        OrderBy(Function(l) l.Description).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(2, result.Count)
+        Assert.AreEqual(article3, result(0))
+        Assert.AreEqual(label3En, result(0).Label)
+        Assert.AreEqual(article1, result(1))
+        Assert.AreEqual(label1En, result(1).Label)
+      End Using
+
+      ' same as above, but use IJoin
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        Join(Of Label)(Function(c)
+                                         Return c.From(Of Label).
+                                                  Where(Function(x) x.Language = English).
+                                                  SelectAll()
+                                       End Function).
+                        On(Function(j) j.T1.Id = j.T2.Id).
+                        OrderBy(Function(j) j.T2.Description).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(2, result.Count)
+        Assert.AreEqual(article3, result(0))
+        Assert.AreEqual(label3En, result(0).Label)
+        Assert.AreEqual(article1, result(1))
+        Assert.AreEqual(label1En, result(1).Label)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithSubqueryOfTypeAnonymousType()
+      Dim article1 = Me.ModelFactory.CreateArticle(1)
+      Dim article2 = Me.ModelFactory.CreateArticle(2)
+      Dim article3 = Me.ModelFactory.CreateArticle(3)
+
+      Dim label1En = Me.ModelFactory.CreateLabel("", 1, English, "ddd")
+      Dim label2De = Me.ModelFactory.CreateLabel("", 2, German, "ccc")
+      Dim label3En = Me.ModelFactory.CreateLabel("", 3, English, "bbb")
+      Dim label3De = Me.ModelFactory.CreateLabel("", 3, German, "aaa")
+
+      InsertItems(article1, article2, article3, label1En, label2De, label3En, label3De)
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        Join(Function(c)
+                               Return c.From(Of Label).
+                                        Where(Function(x) x.Language = English).
+                                        Select(Function(x) New With {.Id = x.Id, .Description = x.Description})
+                             End Function).
+                        On(Function(a, l) a.Id = l.Id).
+                        OrderBy(Function(l) l.Description).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(2, result.Count)
+        Assert.AreEqual(article3, result(0))
+        Assert.AreEqual(article1, result(1))
+      End Using
+
+      ' same as above, but use IJoin
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        Join(Function(c)
+                               Return c.From(Of Label).
+                                        Where(Function(x) x.Language = English).
+                                        Select(Function(x) New With {.Id = x.Id, .Description = x.Description})
+                             End Function).
+                        On(Function(j) j.T1.Id = j.T2.Id).
+                        OrderBy(Function(j) j.T2.Description).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(2, result.Count)
+        Assert.AreEqual(article3, result(0))
+        Assert.AreEqual(article1, result(1))
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithSubqueryOfTypeValueTuple()
+      Dim article1 = Me.ModelFactory.CreateArticle(1)
+      Dim article2 = Me.ModelFactory.CreateArticle(2)
+      Dim article3 = Me.ModelFactory.CreateArticle(3)
+
+      Dim label1En = Me.ModelFactory.CreateLabel("", 1, English, "ddd")
+      Dim label2De = Me.ModelFactory.CreateLabel("", 2, German, "ccc")
+      Dim label3En = Me.ModelFactory.CreateLabel("", 3, English, "bbb")
+      Dim label3De = Me.ModelFactory.CreateLabel("", 3, German, "aaa")
+
+      InsertItems(article1, article2, article3, label1En, label2De, label3En, label3De)
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        Join(Function(c)
+                               Return c.From(Of Label).
+                                        Where(Function(x) x.Language = English).
+                                        Select(Function(x) (Id:=x.Id, Description:=x.Description))
+                             End Function).
+                        On(Function(a, l) a.Id = l.Id).
+                        OrderBy(Function(l) l.Description).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(2, result.Count)
+        Assert.AreEqual(article3, result(0))
+        Assert.AreEqual(article1, result(1))
+      End Using
+
+      ' same as above, but use IJoin
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        Join(Function(c)
+                               Return c.From(Of Label).
+                                        Where(Function(x) x.Language = English).
+                                        Select(Function(x) (Id:=x.Id, Description:=x.Description))
+                             End Function).
+                        On(Function(j) j.T1.Id = j.T2.Id).
+                        OrderBy(Function(j) j.T2.Description).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(2, result.Count)
+        Assert.AreEqual(article3, result(0))
+        Assert.AreEqual(article1, result(1))
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithSubqueryOfTypeAdHocType()
+      Dim article1 = Me.ModelFactory.CreateArticle(1)
+      Dim article2 = Me.ModelFactory.CreateArticle(2)
+      Dim article3 = Me.ModelFactory.CreateArticle(3)
+
+      Dim label1En = Me.ModelFactory.CreateLabel("", 1, English, "ddd")
+      Dim label2De = Me.ModelFactory.CreateLabel("", 2, German, "ccc")
+      Dim label3En = Me.ModelFactory.CreateLabel("", 3, English, "bbb")
+      Dim label3De = Me.ModelFactory.CreateLabel("", 3, German, "aaa")
+
+      InsertItems(article1, article2, article3, label1En, label2De, label3En, label3De)
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        Join(Function(c)
+                               Return c.From(Of Label).
+                                        Where(Function(x) x.Language = English).
+                                        Select(Function(x) New NonModelObject(x.Language) With {.IntValue = x.Id, .StringValue1 = x.Description})
+                             End Function).
+                        On(Function(a, l) a.Id = l.IntValue).
+                        OrderBy(Function(l) l.StringValue1).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(2, result.Count)
+        Assert.AreEqual(article3, result(0))
+        Assert.AreEqual(article1, result(1))
+      End Using
+
+      ' same as above, but use IJoin
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        Join(Function(c)
+                               Return c.From(Of Label).
+                                        Where(Function(x) x.Language = English).
+                                        Select(Function(x) New NonModelObject(x.Language) With {.IntValue = x.Id, .StringValue1 = x.Description})
+                             End Function).
+                        On(Function(j) j.T1.Id = j.T2.IntValue).
+                        OrderBy(Function(j) j.T2.StringValue1).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(2, result.Count)
+        Assert.AreEqual(article3, result(0))
+        Assert.AreEqual(article1, result(1))
+      End Using
+
+      ' use property with unknown column mapping
+      Try
+        Using db = CreateDbContext()
+          Dim result = db.From(Of Article).
+                          Join(Function(c)
+                                 Return c.From(Of Label).
+                                          Where(Function(x) x.Language = English).
+                                          Select(Function(x) New NonModelObject(x.Id, x.Description, x.Language))
+                               End Function).
+                          On(Function(a, l) a.Id = l.IntValue).
+                          OrderBy(Function(l) l.StringValue1).
+                          SelectAll().ToList()
+        End Using
+        Assert.Fail()
+      Catch ex As Exception
+      End Try
+
+      ' same as above, but use IJoin
+      Try
+        Using db = CreateDbContext()
+          Dim result = db.From(Of Article).
+                          Join(Function(c)
+                                 Return c.From(Of Label).
+                                          Where(Function(x) x.Language = English).
+                                          Select(Function(x) New NonModelObject(x.Id, x.Description, x.Language))
+                               End Function).
+                          On(Function(j) j.T1.Id = j.T2.IntValue).
+                          OrderBy(Function(j) j.T2.StringValue1).
+                          SelectAll().ToList()
+        End Using
+        Assert.Fail()
+      Catch ex As Exception
+      End Try
+    End Sub
+
+  End Class
+End Namespace

--- a/Source/Test/Yamo.Test/Tests/SelectWithJoinTests.vb
+++ b/Source/Test/Yamo.Test/Tests/SelectWithJoinTests.vb
@@ -983,37 +983,6 @@ Namespace Tests
     End Sub
 
     <TestMethod()>
-    Public Overridable Sub SelectWithRelationshipNotDefinedInModel()
-      Dim linkedItem1 = Me.ModelFactory.CreateLinkedItem(1, Nothing)
-      Dim linkedItem2 = Me.ModelFactory.CreateLinkedItem(2, 1)
-
-      Dim linkedItem1Child1 = Me.ModelFactory.CreateLinkedItemChild(1, 1)
-      Dim linkedItem1Child2 = Me.ModelFactory.CreateLinkedItemChild(2, 1)
-      Dim linkedItem1Child3 = Me.ModelFactory.CreateLinkedItemChild(3, 1)
-
-      InsertItems(linkedItem1, linkedItem2)
-      InsertItems(linkedItem1Child1, linkedItem1Child2, linkedItem1Child3)
-
-      Using db = CreateDbContext()
-        Dim result = db.From(Of LinkedItem).
-                        Join(Of LinkedItem)(Function(j) j.T1.Id = j.T2.PreviousId.Value).As(Function(x) x.NextItem).
-                        Join(Of LinkedItemChild)(Function(j) j.T1.Id = j.T3.LinkedItemId).As(Function(j) j.T1.Children).
-                        SelectAll().ToList()
-
-        Assert.AreEqual(1, result.Count)
-
-        Dim linkedItem1Result = result.First()
-        Assert.AreEqual(linkedItem1, linkedItem1Result)
-        Assert.IsNotNull(linkedItem1Result.NextItem)
-        Assert.AreEqual(linkedItem2, linkedItem1Result.NextItem)
-        Assert.AreEqual(3, linkedItem1Result.Children.Count)
-        Assert.IsNotNull(linkedItem1Result.Children.SingleOrDefault(Function(x) x.Id = 1))
-        Assert.IsNotNull(linkedItem1Result.Children.SingleOrDefault(Function(x) x.Id = 2))
-        Assert.IsNotNull(linkedItem1Result.Children.SingleOrDefault(Function(x) x.Id = 3))
-      End Using
-    End Sub
-
-    <TestMethod()>
     Public Overridable Sub SelectWithMaximumAllowedRelationships()
       Dim linkedItem1 = Me.ModelFactory.CreateLinkedItem(1, Nothing)
       Dim linkedItem2 = Me.ModelFactory.CreateLinkedItem(2, 1)


### PR DESCRIPTION
This PR adds support for JOIN subqueries.

Join methods have now new overloads that accept table source factory functions of type `Func<SubqueryContext, ISubqueryableSelectSqlExpression<TJoined>>`.

`SubqueryContext` parameter allows you to build the subquery. Return value is an expression (result of `SelectAll`, `Select`, `Distinct`, ... methods).

Subquery cannot be materialized. That means `ToList` or `FirstOrDefault` methods should never be called on the subquery.

For example, here we join `Label` entity from a subquery:
```cs
using (var db = CreateContext())
{
    var list = db.From<Article>()
                 .Join(c =>
                 {
                     return c.From<Label>()
                             .Where(x => x.Language == "en")
                             .SelectAll();
                 })
                 .On(j => j.T1.Id == j.T2.Id)
                 .SelectAll().ToList();

    foreach (var article in list)
    {
        Console.WriteLine($"{article.Id}: {article.Label.Description}");
    }
}
```
If the subquery returns an entity from the model and there are defined relationships in the model, navigation properties will be filled just like with normal joins. However, **only main entity is materialized in the subquery**! If subquery contains joins, they are translated to the SQL, but no related objects are created and set to the navigation properties of the main subquery entity!

Although, the result of the subquery doesn't have to be an entity from the model. Also anonymous types, non-model ad hoc types and value tuples (only in VB.NET) are supported.

For example:
```cs
using (var db = CreateContext())
{
    // get all articles which have at least 2 categories

    // using anonymous type
    var list1 = db.From<Article>()
                  .Join(c =>
                  {
                      return c.From<ArticleCategory>()
                              .GroupBy(x => x.ArticleId)
                              .Select(x => new { ArticleId = x.ArticleId, CategoriesCount = Yamo.Sql.Aggregate.Count() });
                  })
                  .On(j => j.T1.Id == j.T2.ArticleId)
                  .Where(j => 2 < j.T2.CategoriesCount)
                  .SelectAll()
                  .ToList();

    // using non model entity (same result as above)
    var list2 = db.From<Article>()
                  .Join(c =>
                  {
                      return c.From<ArticleCategory>()
                              .GroupBy(x => x.ArticleId)
                              .Select(x => new Stats { ArticleId = x.ArticleId, CategoriesCount = Yamo.Sql.Aggregate.Count() });
                  })
                  .On(j => j.T1.Id == j.T2.ArticleId)
                  .Where(j => 2 < j.T2.CategoriesCount)
                  .SelectAll()
                  .ToList();
}
```
Value tuples only works in VB.NET:
```vbnet
Using db = CreateContext()
  ' using value tuple (same result as above)
  Dim list = db.From(Of Article).
                Join(Function(c)
                       Return c.From(Of ArticleCategory).
                                GroupBy(Function(x) x.ArticleId).
                                Select(Function(x) (ArticleId:=x.ArticleId, CategoriesCount:=Yamo.Sql.Aggregate.Count()))
                     End Function).
                On(Function(j) j.T1.Id = j.T2.ArticleId).
                Where(Function(j) 2 < j.T2.CategoriesCount).
                SelectAll().ToList()
End Using
```
You can use properties/fields of the subquery types in the methods like `On`, `Where`, etc. to build the SQL expression. For non-model ad hoc types, there is a(n obvious) limitation though. Only properties/fields explicitly used in member initializer syntax (in `Select` method of the subquery) are allowed. If you pass the value to the constructor and later access the same value with a property, it will fail. That's because there is no way for Yamo to know which constructor argument belongs to which property. We could try to match arguments and properties if they have the same name, but this is not implemented currently.

In the previous examples, anonymous types, non-model ad hoc types and value tuples were used purely to filter `Article` records. No subquery values were returned, because no relationships exist for them in the model. If you need to return subquery values of non model types, you still can of course. Just use `As` or `Include` methods, depending on your use case.

For example (assume `Stats` is non-model ad hoc type):
```cs
using (var db = CreateContext())
{
    // get all articles with Stats property filled
    var list1 = db.From<Article>()
                  .LeftJoin(c =>
                  {
                      return c.From<ArticleCategory>()
                              .GroupBy(x => x.ArticleId)
                              .Select(x => new Stats { ArticleId = x.ArticleId, CategoriesCount = Yamo.Sql.Aggregate.Count() });
                  })
                  .On(j => j.T1.Id == j.T2.ArticleId)
                  .As(x => x.Stats)
                  .SelectAll()
                  .ToList();

    // get all articles with CategoriesCount property filled
    var list2 = db.From<Article>()
                  .LeftJoin(c =>
                  {
                      return c.From<ArticleCategory>()
                              .GroupBy(x => x.ArticleId)
                              .Select(x => new Stats { ArticleId = x.ArticleId, CategoriesCount = Yamo.Sql.Aggregate.Count() });
                  })
                  .On(j => j.T1.Id == j.T2.ArticleId)
                  .SelectAll()
                  .Include(j => j.T1.CategoriesCount, j => j.T2.CategoriesCount)
                  .ToList();
}
```
For model entities, if there is a missing row in the `LEFT JOIN`, `null` is automatically set to the navigation property (assuming defined relationship). Yamo detects the presence by the primary key values. But for anonymous types, non-model ad hoc types or value tuples, there is no primary key definition in the model. Yamo doesn't know if `NULL` values in the resultset are caused by missing row in joined table/subquery or if `NULL`s are completely valid values.

This is solved in the following way: by default, if all related columns have `NULL` value, `null` will be returned for the whole record. Otherwise, an instance will be created. This behavior can be changed to always enforce instance creation, even if all columns contain `NULL`.

For example:
```cs
using (var db = CreateContext())
{
    // get all articles with Stats property filled

    // Using NonModelEntityCreationBehavior.NullIfAllColumnsAreNull, which is the default.
    // If article has no category, joined subquery won't have matching records present and both
    // columns will contain null values. Stats object won't be created and Stats property will be
    // set to null in this case.
    var list1 = db.From<Article>()
                  .LeftJoin(c =>
                  {
                      return c.From<ArticleCategory>()
                              .GroupBy(x => x.ArticleId)
                              .Select(x => new Stats { ArticleId = x.ArticleId, CategoriesCount = Yamo.Sql.Aggregate.Count() });
                  })
                  .On(j => j.T1.Id == j.T2.ArticleId)
                  .As(x => x.Stats)
                  .SelectAll()
                  .ToList();

    // Using NonModelEntityCreationBehavior.AlwaysCreateInstance.
    // If article has no category, joined subquery won't have matching records present and both
    // columns will contain null values. However, Stats object will still be created and therefore Stats
    // property will always contain Stats object instance. To fill Stats object properties, default value
    // will be used in case of null.
    // So in this case it will be:
    //    new Stats { ArticleId = 0, CategoriesCount = 0 }
    var list2 = db.From<Article>()
                  .LeftJoin(c =>
                  {
                      return c.From<ArticleCategory>()
                              .GroupBy(x => x.ArticleId)
                              .Select(x => new Stats { ArticleId = x.ArticleId, CategoriesCount = Yamo.Sql.Aggregate.Count() });
                  }, NonModelEntityCreationBehavior.AlwaysCreateInstance)
                  .On(j => j.T1.Id == j.T2.ArticleId)
                  .As(x => x.Stats)
                  .SelectAll()
                  .ToList();
}
```
This might be later improved to allow better control, e.g. ad hoc define columns that indicate record presence.

Additionally, calling `Exclude` and `Include` methods directly in the subquery is not supported at the moment.

This PR contains breaking changes on API that is public, but not intended to be called directly.