### PR TITLE
Added support for FROM subqueries

### DIFF
--- a/Source/Samples/Yamo.Playground.CS/Program.cs
+++ b/Source/Samples/Yamo.Playground.CS/Program.cs
@@ -82,7 +82,8 @@ namespace Yamo.Playground.CS
             //Test57();
             //Test58();
             //Test59();
-            Test60();
+            //Test60();
+            Test61();
         }
 
         public static MyContext CreateContext()
@@ -1219,6 +1220,22 @@ namespace Yamo.Playground.CS
                               .As(x => x.Stats)
                               .SelectAll()
                               .ToList();
+            }
+        }
+
+        public static void Test61()
+        {
+            using (var db = CreateContext())
+            {
+                var list = db.From(c =>
+                             {
+                                 return c.From<Article>()
+                                         .Where(x => x.InStock)
+                                         .SelectAll();
+                             })
+                             .Where(x => 42 < x.Price)
+                             .SelectAll()
+                             .ToList();
             }
         }
 

--- a/Source/Source/Yamo.CodeGenerator/Generator/SelectSqlExpressionCodeGenerator.vb
+++ b/Source/Source/Yamo.CodeGenerator/Generator/SelectSqlExpressionCodeGenerator.vb
@@ -106,12 +106,34 @@
         builder.AppendLine()
 
         comment = $"Creates new instance of <see cref=""{GetFullClassName(entityCount)}""/>."
+        params = {"context", "tableSourceFactory", "behavior"}
+        AddComment(builder, comment, params:=params)
+
+        builder.Indent().AppendLine("Friend Sub New(context As DbContext, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T)), behavior As NonModelEntityCreationBehavior)").PushIndent()
+        builder.Indent().AppendLine("MyBase.New(New SelectSqlExpressionBuilder(context), New QueryExecutor(context))")
+        builder.Indent().AppendLine("Me.Builder.SetMainTableSource(Me.Executor, tableSourceFactory, behavior)").PopIndent()
+        builder.Indent().AppendLine("End Sub")
+
+        builder.AppendLine()
+
+        comment = $"Creates new instance of <see cref=""{GetFullClassName(entityCount)}""/>."
         params = {"context", "tableSource"}
         AddComment(builder, comment, params:=params)
 
         builder.Indent().AppendLine("Friend Sub New(context As DbContext, tableSource As FormattableString)").PushIndent()
         builder.Indent().AppendLine("MyBase.New(New SelectSqlExpressionBuilder(context, GetType(T)), New QueryExecutor(context))")
         builder.Indent().AppendLine("Me.Builder.SetMainTableSource(tableSource)").PopIndent()
+        builder.Indent().AppendLine("End Sub")
+
+        builder.AppendLine()
+
+        comment = $"Creates new instance of <see cref=""{GetFullClassName(entityCount)}""/>."
+        params = {"context", "tableSourceFactory", "behavior"}
+        AddComment(builder, comment, params:=params)
+
+        builder.Indent().AppendLine("Friend Sub New(context As SubqueryContext, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T)), behavior As NonModelEntityCreationBehavior)").PushIndent()
+        builder.Indent().AppendLine("MyBase.New(New SelectSqlExpressionBuilder(context), context.Executor)")
+        builder.Indent().AppendLine("Me.Builder.SetMainTableSource(Me.Executor, tableSourceFactory, behavior)").PopIndent()
         builder.Indent().AppendLine("End Sub")
 
         builder.AppendLine()

--- a/Source/Source/Yamo/DbContext.vb
+++ b/Source/Source/Yamo/DbContext.vb
@@ -197,6 +197,17 @@ Public Class DbContext
   ''' Starts building SQL SELECT statement.
   ''' </summary>
   ''' <typeparam name="T"></typeparam>
+  ''' <param name="tableSourceFactory"></param>
+  ''' <param name="behavior"></param>
+  ''' <returns></returns>
+  Public Function From(Of T)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As SelectSqlExpression(Of T)
+    Return New SelectSqlExpression(Of T)(Me, tableSourceFactory, behavior)
+  End Function
+
+  ''' <summary>
+  ''' Starts building SQL SELECT statement.
+  ''' </summary>
+  ''' <typeparam name="T"></typeparam>
   ''' <param name="tableSource"></param>
   ''' <returns></returns>
   Public Function From(Of T)(<DisallowNull> tableSource As FormattableString) As SelectSqlExpression(Of T)

--- a/Source/Source/Yamo/Expressions/SelectSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/SelectSqlExpression.vb
@@ -33,10 +33,32 @@ Namespace Expressions
     ''' Creates new instance of <see cref="SelectSqlExpression(Of T)"/>.
     ''' </summary>
     ''' <param name="context"></param>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    Friend Sub New(context As DbContext, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T)), behavior As NonModelEntityCreationBehavior)
+      MyBase.New(New SelectSqlExpressionBuilder(context), New QueryExecutor(context))
+      Me.Builder.SetMainTableSource(Me.Executor, tableSourceFactory, behavior)
+    End Sub
+
+    ''' <summary>
+    ''' Creates new instance of <see cref="SelectSqlExpression(Of T)"/>.
+    ''' </summary>
+    ''' <param name="context"></param>
     ''' <param name="tableSource"></param>
     Friend Sub New(context As DbContext, tableSource As FormattableString)
       MyBase.New(New SelectSqlExpressionBuilder(context, GetType(T)), New QueryExecutor(context))
       Me.Builder.SetMainTableSource(tableSource)
+    End Sub
+
+    ''' <summary>
+    ''' Creates new instance of <see cref="SelectSqlExpression(Of T)"/>.
+    ''' </summary>
+    ''' <param name="context"></param>
+    ''' <param name="tableSourceFactory"></param>
+    ''' <param name="behavior"></param>
+    Friend Sub New(context As SubqueryContext, tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T)), behavior As NonModelEntityCreationBehavior)
+      MyBase.New(New SelectSqlExpressionBuilder(context), context.Executor)
+      Me.Builder.SetMainTableSource(Me.Executor, tableSourceFactory, behavior)
     End Sub
 
     ''' <summary>

--- a/Source/Source/Yamo/Internal/Query/Metadata/DeleteSqlModel.vb
+++ b/Source/Source/Yamo/Internal/Query/Metadata/DeleteSqlModel.vb
@@ -11,12 +11,29 @@ Namespace Internal.Query.Metadata
     Inherits SqlModelBase
 
     ''' <summary>
+    ''' Gets main SQL entity.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <returns></returns>
+    Public Overloads ReadOnly Property MainEntity As EntityBasedSqlEntity
+      Get
+        Return m_MainEntity
+      End Get
+    End Property
+
+    ''' <summary>
+    ''' Stores main SQL entity.
+    ''' </summary>
+    Private m_MainEntity As EntityBasedSqlEntity
+
+    ''' <summary>
     ''' Creates new instance of <see cref="DeleteSqlModel"/>.<br/>
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
     ''' <param name="mainEntity"></param>
     Public Sub New(<DisallowNull> mainEntity As Entity)
-      MyBase.New(mainEntity)
+      MyBase.New()
+      m_MainEntity = SetMainEntity(mainEntity, False)
     End Sub
 
   End Class

--- a/Source/Source/Yamo/Internal/Query/Metadata/EntityBasedSqlEntity.vb
+++ b/Source/Source/Yamo/Internal/Query/Metadata/EntityBasedSqlEntity.vb
@@ -30,7 +30,7 @@ Namespace Internal.Query.Metadata
     ''' </summary>
     ''' <param name="entity"></param>
     Sub New(<DisallowNull> entity As Entity)
-      Me.New(entity, "", -1)
+      Me.New(entity, False, "", -1)
     End Sub
 
     ''' <summary>
@@ -38,10 +38,11 @@ Namespace Internal.Query.Metadata
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
     ''' <param name="entity"></param>
+    ''' <param name="tableSourceIsSubquery"></param>
     ''' <param name="tableAlias"></param>
     ''' <param name="index"></param>
-    Sub New(<DisallowNull> entity As Entity, <DisallowNull> tableAlias As String, index As Int32)
-      MyBase.New(entity.EntityType, tableAlias, index, entity.GetPropertiesCount())
+    Sub New(<DisallowNull> entity As Entity, tableSourceIsSubquery As Boolean, <DisallowNull> tableAlias As String, index As Int32)
+      MyBase.New(entity.EntityType, tableSourceIsSubquery, tableAlias, index, entity.GetPropertiesCount())
       Me.Entity = entity
     End Sub
 
@@ -50,12 +51,13 @@ Namespace Internal.Query.Metadata
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
     ''' <param name="entity"></param>
+    ''' <param name="tableSourceIsSubquery"></param>
     ''' <param name="tableAlias"></param>
     ''' <param name="index"></param>
     ''' <param name="relationship"></param>
     ''' <param name="isIgnored"></param>
-    Sub New(<DisallowNull> entity As Entity, <DisallowNull> tableAlias As String, index As Int32, relationship As SqlEntityRelationship, isIgnored As Boolean)
-      MyBase.New(entity.EntityType, tableAlias, index, entity.GetPropertiesCount(), relationship, isIgnored)
+    Sub New(<DisallowNull> entity As Entity, tableSourceIsSubquery As Boolean, <DisallowNull> tableAlias As String, index As Int32, relationship As SqlEntityRelationship, isIgnored As Boolean)
+      MyBase.New(entity.EntityType, tableSourceIsSubquery, tableAlias, index, entity.GetPropertiesCount(), relationship, isIgnored)
       Me.Entity = entity
     End Sub
 

--- a/Source/Source/Yamo/Internal/Query/Metadata/NonModelEntityBasedSqlEntity.vb
+++ b/Source/Source/Yamo/Internal/Query/Metadata/NonModelEntityBasedSqlEntity.vb
@@ -18,13 +18,6 @@ Namespace Internal.Query.Metadata
     Public ReadOnly Property Entity As NonModelEntity
 
     ''' <summary>
-    ''' Gets entity creation behavior.<br/>
-    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
-    ''' </summary>
-    ''' <returns></returns>
-    Public ReadOnly Property CreationBehavior As NonModelEntityCreationBehavior
-
-    ''' <summary>
     ''' Creates new instance of <see cref="EntityBasedSqlEntity"/>.<br/>
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
@@ -33,11 +26,9 @@ Namespace Internal.Query.Metadata
     ''' <param name="index"></param>
     ''' <param name="relationship"></param>
     ''' <param name="isIgnored"></param>
-    ''' <param name="creationBehavior"></param>
-    Sub New(<DisallowNull> entity As NonModelEntity, <DisallowNull> tableAlias As String, index As Int32, relationship As SqlEntityRelationship, isIgnored As Boolean, creationBehavior As NonModelEntityCreationBehavior)
-      MyBase.New(entity.EntityType, tableAlias, index, entity.GetColumnsCount(), relationship, isIgnored)
+    Sub New(<DisallowNull> entity As NonModelEntity, <DisallowNull> tableAlias As String, index As Int32, relationship As SqlEntityRelationship, isIgnored As Boolean)
+      MyBase.New(entity.EntityType, True, tableAlias, index, entity.GetColumnsCount(), relationship, isIgnored)
       Me.Entity = entity
-      Me.CreationBehavior = creationBehavior
     End Sub
 
     ''' <summary>

--- a/Source/Source/Yamo/Internal/Query/Metadata/SelectSqlModel.vb
+++ b/Source/Source/Yamo/Internal/Query/Metadata/SelectSqlModel.vb
@@ -44,9 +44,8 @@ Namespace Internal.Query.Metadata
     ''' Creates new instance of <see cref="SelectSqlModel"/>.<br/>
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
-    ''' <param name="mainEntity"></param>
-    Public Sub New(<DisallowNull> mainEntity As Entity)
-      MyBase.New(mainEntity)
+    Public Sub New()
+      MyBase.New()
     End Sub
 
     ''' <summary>
@@ -54,10 +53,11 @@ Namespace Internal.Query.Metadata
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
     ''' <param name="entity"></param>
+    ''' <param name="tableSourceIsSubquery"></param>
     ''' <param name="relationship"></param>
     ''' <returns></returns>
-    Public Function AddJoin(<DisallowNull> entity As Entity, relationship As SqlEntityRelationship) As EntityBasedSqlEntity
-      Return AddEntity(entity, relationship, False)
+    Public Function AddJoin(<DisallowNull> entity As Entity, tableSourceIsSubquery As Boolean, relationship As SqlEntityRelationship) As EntityBasedSqlEntity
+      Return AddEntity(entity, tableSourceIsSubquery, relationship, False)
     End Function
 
     ''' <summary>
@@ -66,10 +66,9 @@ Namespace Internal.Query.Metadata
     ''' </summary>
     ''' <param name="entity"></param>
     ''' <param name="relationship"></param>
-    ''' <param name="creationBehavior"></param>
     ''' <returns></returns>
-    Public Function AddJoin(<DisallowNull> entity As NonModelEntity, relationship As SqlEntityRelationship, creationBehavior As NonModelEntityCreationBehavior) As NonModelEntityBasedSqlEntity
-      Return AddEntity(entity, relationship, False, creationBehavior)
+    Public Function AddJoin(<DisallowNull> entity As NonModelEntity, relationship As SqlEntityRelationship) As NonModelEntityBasedSqlEntity
+      Return AddEntity(entity, relationship, False)
     End Function
 
     ''' <summary>
@@ -79,7 +78,7 @@ Namespace Internal.Query.Metadata
     ''' <param name="entity"></param>
     ''' <returns></returns>
     Public Function AddIgnoredJoin(<DisallowNull> entity As Entity) As EntityBasedSqlEntity
-      Return AddEntity(entity, Nothing, True)
+      Return AddEntity(entity, False, Nothing, True)
     End Function
 
     ''' <summary>
@@ -89,7 +88,7 @@ Namespace Internal.Query.Metadata
     ''' <param name="entity"></param>
     ''' <returns></returns>
     Public Function AddIgnoredJoin(<DisallowNull> entity As NonModelEntity) As NonModelEntityBasedSqlEntity
-      Return AddEntity(entity, Nothing, True, NonModelEntityCreationBehavior.NullIfAllColumnsAreNull)
+      Return AddEntity(entity, Nothing, True)
     End Function
 
     ''' <summary>

--- a/Source/Source/Yamo/Internal/Query/Metadata/SqlEntityBase.vb
+++ b/Source/Source/Yamo/Internal/Query/Metadata/SqlEntityBase.vb
@@ -16,6 +16,13 @@ Namespace Internal.Query.Metadata
     Public ReadOnly Property EntityType As Type
 
     ''' <summary>
+    ''' Gets whether table source of this entity is a subquery.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <returns></returns>
+    Public ReadOnly Property TableSourceIsSubquery As Boolean
+
+    ''' <summary>
     ''' Gets table alias.<br/>
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
@@ -77,11 +84,13 @@ Namespace Internal.Query.Metadata
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
     ''' <param name="entityType"></param>
+    ''' <param name="tableSourceIsSubquery"></param>
     ''' <param name="tableAlias"></param>
     ''' <param name="index"></param>
     ''' <param name="columnsCount"></param>
-    Sub New(<DisallowNull> entityType As Type, <DisallowNull> tableAlias As String, index As Int32, columnsCount As Int32)
+    Sub New(<DisallowNull> entityType As Type, tableSourceIsSubquery As Boolean, <DisallowNull> tableAlias As String, index As Int32, columnsCount As Int32)
       Me.EntityType = entityType
+      Me.TableSourceIsSubquery = tableSourceIsSubquery
       Me.TableAlias = tableAlias
       Me.Index = index
       Me.Relationship = Nothing
@@ -104,13 +113,14 @@ Namespace Internal.Query.Metadata
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
     ''' <param name="entityType"></param>
+    ''' <param name="tableSourceIsSubquery"></param>
     ''' <param name="tableAlias"></param>
     ''' <param name="index"></param>
     ''' <param name="columnsCount"></param>
     ''' <param name="relationship"></param>
     ''' <param name="isIgnored"></param>
-    Sub New(<DisallowNull> entityType As Type, <DisallowNull> tableAlias As String, index As Int32, columnsCount As Int32, relationship As SqlEntityRelationship, isIgnored As Boolean)
-      Me.New(entityType, tableAlias, index, columnsCount)
+    Sub New(<DisallowNull> entityType As Type, tableSourceIsSubquery As Boolean, <DisallowNull> tableAlias As String, index As Int32, columnsCount As Int32, relationship As SqlEntityRelationship, isIgnored As Boolean)
+      Me.New(entityType, tableSourceIsSubquery, tableAlias, index, columnsCount)
       Me.Relationship = relationship
       Me.IsIgnored = isIgnored
     End Sub

--- a/Source/Source/Yamo/Internal/Query/Metadata/SqlModelBase.vb
+++ b/Source/Source/Yamo/Internal/Query/Metadata/SqlModelBase.vb
@@ -14,7 +14,7 @@ Namespace Internal.Query.Metadata
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
     ''' <returns></returns>
-    Public ReadOnly Property MainEntity As EntityBasedSqlEntity
+    Public ReadOnly Property MainEntity As <MaybeNull> SqlEntityBase
 
     ''' <summary>
     ''' Gets SQL entities.<br/>
@@ -27,27 +27,65 @@ Namespace Internal.Query.Metadata
     ''' Creates new instance of <see cref="SqlModelBase"/>.<br/>
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
-    ''' <param name="mainEntity"></param>
-    Public Sub New(<DisallowNull> mainEntity As Entity)
+    Sub New()
+      Me.MainEntity = Nothing
       Me.Entities = New List(Of SqlEntityBase)
-
-      Dim tableAlias = "T0"
-
-      Me.MainEntity = New EntityBasedSqlEntity(mainEntity, tableAlias, 0)
-      Me.Entities.Add(Me.MainEntity)
     End Sub
 
     ''' <summary>
-    ''' Adds SQL entity used in the query.
+    ''' Sets main SQL entity.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <param name="mainEntity"></param>
+    ''' <param name="tableSourceIsSubquery"></param>
+    ''' <returns></returns>
+    Public Function SetMainEntity(<DisallowNull> mainEntity As Entity, tableSourceIsSubquery As Boolean) As EntityBasedSqlEntity
+      If Me.MainEntity IsNot Nothing Then
+        Throw New InvalidOperationException("Main entity is already set.")
+      End If
+
+      Dim tableAlias = "T0"
+      Dim sqlEntity = New EntityBasedSqlEntity(mainEntity, tableSourceIsSubquery, tableAlias, 0)
+
+      _MainEntity = sqlEntity
+      Me.Entities.Add(Me.MainEntity)
+
+      Return sqlEntity
+    End Function
+
+    ''' <summary>
+    ''' Sets main SQL entity.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <param name="mainEntity"></param>
+    ''' <returns></returns>
+    Public Function SetMainEntity(<DisallowNull> mainEntity As NonModelEntity) As NonModelEntityBasedSqlEntity
+      If Me.MainEntity IsNot Nothing Then
+        Throw New InvalidOperationException("Main entity is already set.")
+      End If
+
+      Dim tableAlias = "T0"
+      Dim sqlEntity = New NonModelEntityBasedSqlEntity(mainEntity, tableAlias, 0, Nothing, False)
+
+      _MainEntity = sqlEntity
+      Me.Entities.Add(Me.MainEntity)
+
+      Return sqlEntity
+    End Function
+
+    ''' <summary>
+    ''' Adds SQL entity used in the query.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
     ''' <param name="entity"></param>
+    ''' <param name="tableSourceIsSubquery"></param>
     ''' <param name="relationship"></param>
     ''' <param name="isIgnored"></param>
     ''' <returns></returns>
-    Protected Function AddEntity(<DisallowNull> entity As Entity, relationship As SqlEntityRelationship, isIgnored As Boolean) As EntityBasedSqlEntity
+    Protected Function AddEntity(<DisallowNull> entity As Entity, tableSourceIsSubquery As Boolean, relationship As SqlEntityRelationship, isIgnored As Boolean) As EntityBasedSqlEntity
       Dim index = Me.Entities.Count
       Dim tableAlias = "T" & index.ToString(Globalization.CultureInfo.InvariantCulture)
-      Dim sqlEntity = New EntityBasedSqlEntity(entity, tableAlias, index, relationship, isIgnored)
+      Dim sqlEntity = New EntityBasedSqlEntity(entity, tableSourceIsSubquery, tableAlias, index, relationship, isIgnored)
 
       Me.Entities.Add(sqlEntity)
 
@@ -55,17 +93,17 @@ Namespace Internal.Query.Metadata
     End Function
 
     ''' <summary>
-    ''' Adds SQL entity used in the query.
+    ''' Adds SQL entity used in the query.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
     ''' <param name="entity"></param>
     ''' <param name="relationship"></param>
     ''' <param name="isIgnored"></param>
-    ''' <param name="creationBehavior"></param>
     ''' <returns></returns>
-    Protected Function AddEntity(<DisallowNull> entity As NonModelEntity, relationship As SqlEntityRelationship, isIgnored As Boolean, creationBehavior As NonModelEntityCreationBehavior) As NonModelEntityBasedSqlEntity
+    Protected Function AddEntity(<DisallowNull> entity As NonModelEntity, relationship As SqlEntityRelationship, isIgnored As Boolean) As NonModelEntityBasedSqlEntity
       Dim index = Me.Entities.Count
       Dim tableAlias = "T" & index.ToString(Globalization.CultureInfo.InvariantCulture)
-      Dim sqlEntity = New NonModelEntityBasedSqlEntity(entity, tableAlias, index, relationship, isIgnored, creationBehavior)
+      Dim sqlEntity = New NonModelEntityBasedSqlEntity(entity, tableAlias, index, relationship, isIgnored)
 
       Me.Entities.Add(sqlEntity)
 

--- a/Source/Source/Yamo/Internal/Query/Metadata/SqlResultBase.vb
+++ b/Source/Source/Yamo/Internal/Query/Metadata/SqlResultBase.vb
@@ -16,12 +16,22 @@ Namespace Internal.Query.Metadata
     Public ReadOnly Property ResultType As Type
 
     ''' <summary>
+    ''' Gets entity creation behavior.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <returns></returns>
+    Public Property CreationBehavior As NonModelEntityCreationBehavior
+
+    ''' <summary>
     ''' Creates new instance of <see cref="SqlResultBase"/>.<br/>
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
     ''' <param name="resultType"></param>
     Public Sub New(<DisallowNull> resultType As Type)
       Me.ResultType = resultType
+      ' NOTE: probably better would be to set the default to NullIfAllColumnsAreNull.
+      ' It's like this for backward compatibility (to avoid breaking change in the behavior, since we won't be able to manage it for Include results at the moment).
+      Me.CreationBehavior = NonModelEntityCreationBehavior.AlwaysCreateInstance
     End Sub
 
     ''' <summary>

--- a/Source/Source/Yamo/Internal/Query/Metadata/UpdateSqlModel.vb
+++ b/Source/Source/Yamo/Internal/Query/Metadata/UpdateSqlModel.vb
@@ -11,12 +11,29 @@ Namespace Internal.Query.Metadata
     Inherits SqlModelBase
 
     ''' <summary>
+    ''' Gets main SQL entity.<br/>
+    ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+    ''' </summary>
+    ''' <returns></returns>
+    Public Overloads ReadOnly Property MainEntity As EntityBasedSqlEntity
+      Get
+        Return m_MainEntity
+      End Get
+    End Property
+
+    ''' <summary>
+    ''' Stores main SQL entity.
+    ''' </summary>
+    Private m_MainEntity As EntityBasedSqlEntity
+
+    ''' <summary>
     ''' Creates new instance of <see cref="UpdateSqlModel"/>.<br/>
     ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
     ''' </summary>
     ''' <param name="mainEntity"></param>
     Public Sub New(<DisallowNull> mainEntity As Entity)
-      MyBase.New(mainEntity)
+      MyBase.New()
+      m_MainEntity = SetMainEntity(mainEntity, False)
     End Sub
 
   End Class

--- a/Source/Source/Yamo/Internal/Query/ReaderDataFactory.vb
+++ b/Source/Source/Yamo/Internal/Query/ReaderDataFactory.vb
@@ -143,8 +143,18 @@ Namespace Internal.Query
       Dim readerData As ReaderDataBase
 
       If TypeOf entity Is EntityBasedSqlEntity Then
+        Dim ebEntity = DirectCast(entity, EntityBasedSqlEntity)
+
         Dim entityReader = EntityReaderCache.GetReader(dataReaderType, dialectProvider, model, entityType)
-        readerData = New EntitySqlResultReaderData(DirectCast(sqlResult, EntitySqlResult), entityReaderIndex, entityReader)
+
+        If ebEntity.TableSourceIsSubquery Then
+          Dim containsPKReader = EntityReaderCache.GetContainsPKReader(dataReaderType, dialectProvider, model, entityType)
+          Dim pkOffsets = GetPKOffsets(ebEntity)
+          readerData = New EntitySqlResultReaderData(DirectCast(sqlResult, EntitySqlResult), entityReaderIndex, entityReader, containsPKReader, pkOffsets)
+        Else
+          readerData = New EntitySqlResultReaderData(DirectCast(sqlResult, EntitySqlResult), entityReaderIndex, entityReader)
+        End If
+
       Else
         Dim nmEntity = DirectCast(entity, NonModelEntityBasedSqlEntity)
         readerData = Create(dataReaderType, dialectProvider, model, nmEntity.Entity.SqlResult, entityReaderIndex)

--- a/Source/Source/Yamo/SubqueryContext.vb
+++ b/Source/Source/Yamo/SubqueryContext.vb
@@ -50,6 +50,17 @@ Public Class SubqueryContext
   ''' Starts building SQL SELECT statement.
   ''' </summary>
   ''' <typeparam name="T"></typeparam>
+  ''' <param name="tableSourceFactory"></param>
+  ''' <param name="behavior"></param>
+  ''' <returns></returns>
+  Public Function From(Of T)(<DisallowNull> tableSourceFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T)), Optional behavior As NonModelEntityCreationBehavior = NonModelEntityCreationBehavior.NullIfAllColumnsAreNull) As SelectSqlExpression(Of T)
+    Return New SelectSqlExpression(Of T)(Me, tableSourceFactory, behavior)
+  End Function
+
+  ''' <summary>
+  ''' Starts building SQL SELECT statement.
+  ''' </summary>
+  ''' <typeparam name="T"></typeparam>
   ''' <param name="tableSource"></param>
   ''' <returns></returns>
   Public Function From(Of T)(<DisallowNull> tableSource As FormattableString) As SelectSqlExpression(Of T)

--- a/Source/Test/Yamo.Test.SQLite/Tests/SelectWithFromSubqueryTests.vb
+++ b/Source/Test/Yamo.Test.SQLite/Tests/SelectWithFromSubqueryTests.vb
@@ -1,0 +1,14 @@
+﻿Imports Yamo.Test
+
+Namespace Tests
+
+  <TestClass()>
+  Public Class SelectWithFromSubqueryTests
+    Inherits Yamo.Test.Tests.SelectWithFromSubqueryTests
+
+    Protected Overrides Function CreateTestEnvironment() As ITestEnvironment
+      Return SQLiteTestEnvironment.Create()
+    End Function
+
+  End Class
+End Namespace

--- a/Source/Test/Yamo.Test.SqlServer/Tests/SelectWithFromSubqueryTests.vb
+++ b/Source/Test/Yamo.Test.SqlServer/Tests/SelectWithFromSubqueryTests.vb
@@ -1,0 +1,14 @@
+﻿Imports Yamo.Test
+
+Namespace Tests
+
+  <TestClass()>
+  Public Class SelectWithFromSubqueryTests
+    Inherits Yamo.Test.Tests.SelectWithFromSubqueryTests
+
+    Protected Overrides Function CreateTestEnvironment() As ITestEnvironment
+      Return SqlServerTestEnvironment.Create()
+    End Function
+
+  End Class
+End Namespace

--- a/Source/Test/Yamo.Test/Infrastructure/AliasedEntityColumnData.vb
+++ b/Source/Test/Yamo.Test/Infrastructure/AliasedEntityColumnData.vb
@@ -1,0 +1,26 @@
+﻿Imports Yamo.Metadata
+
+Namespace Infrastructure
+
+  Public Class AliasedEntityColumnData
+    Inherits ColumnDataBase
+
+    Private m_Entity As Entity
+
+    Sub New(entity As Entity)
+      m_Entity = entity
+    End Sub
+
+    Public Overrides Function GetColumnCount() As Int32
+      Return m_Entity.GetPropertiesCount()
+    End Function
+
+    Public Overrides Function GetExpectedColumnNames() As String()
+      Return {}
+    End Function
+
+    Public Overrides Function GetNotExpectedColumnNames() As String()
+      Return m_Entity.GetProperties().Select(Function(x) x.ColumnName).ToArray()
+    End Function
+  End Class
+End Namespace

--- a/Source/Test/Yamo.Test/Infrastructure/ColumnDataBase.vb
+++ b/Source/Test/Yamo.Test/Infrastructure/ColumnDataBase.vb
@@ -1,0 +1,12 @@
+﻿Namespace Infrastructure
+
+  Public MustInherit Class ColumnDataBase
+
+    Public MustOverride Function GetColumnCount() As Int32
+
+    Public MustOverride Function GetExpectedColumnNames() As String()
+
+    Public MustOverride Function GetNotExpectedColumnNames() As String()
+
+  End Class
+End Namespace

--- a/Source/Test/Yamo.Test/Infrastructure/EntityColumnData.vb
+++ b/Source/Test/Yamo.Test/Infrastructure/EntityColumnData.vb
@@ -1,0 +1,26 @@
+﻿Imports Yamo.Metadata
+
+Namespace Infrastructure
+
+  Public Class EntityColumnData
+    Inherits ColumnDataBase
+
+    Private m_Entity As Entity
+
+    Sub New(entity As Entity)
+      m_Entity = entity
+    End Sub
+
+    Public Overrides Function GetColumnCount() As Int32
+      Return m_Entity.GetPropertiesCount()
+    End Function
+
+    Public Overrides Function GetExpectedColumnNames() As String()
+      Return m_Entity.GetProperties().Select(Function(x) x.ColumnName).ToArray()
+    End Function
+
+    Public Overrides Function GetNotExpectedColumnNames() As String()
+      Return {}
+    End Function
+  End Class
+End Namespace

--- a/Source/Test/Yamo.Test/Infrastructure/NonModelEntityColumnData.vb
+++ b/Source/Test/Yamo.Test/Infrastructure/NonModelEntityColumnData.vb
@@ -1,0 +1,24 @@
+﻿Namespace Infrastructure
+
+  Public Class NonModelEntityColumnData
+    Inherits ColumnDataBase
+
+    Private m_ColumnCount As Int32
+
+    Sub New(columnCount As Int32)
+      m_ColumnCount = columnCount
+    End Sub
+
+    Public Overrides Function GetColumnCount() As Int32
+      Return m_ColumnCount
+    End Function
+
+    Public Overrides Function GetExpectedColumnNames() As String()
+      Return {}
+    End Function
+
+    Public Overrides Function GetNotExpectedColumnNames() As String()
+      Return {}
+    End Function
+  End Class
+End Namespace

--- a/Source/Test/Yamo.Test/Model/NonModelObject.vb
+++ b/Source/Test/Yamo.Test/Model/NonModelObject.vb
@@ -12,6 +12,8 @@
 
     Public Property IntValue As Int32
 
+    Public Property DecimalValue As Decimal
+
     Public Property NullableDecimalValue As Decimal?
 
     Public Property ItemWithAllSupportedValues As ItemWithAllSupportedValues
@@ -54,6 +56,16 @@
       Me.StringValue2 = stringValue2
     End Sub
 
+    Public Sub New(intValue As Int32, decimalValue As Decimal)
+      Me.IntValue = intValue
+      Me.DecimalValue = decimalValue
+    End Sub
+
+    Public Sub New(intValue As Int32, stringValue1 As String)
+      Me.IntValue = intValue
+      Me.StringValue1 = stringValue1
+    End Sub
+
     Public Overrides Function Equals(obj As Object) As Boolean
       If obj Is Nothing OrElse TypeOf obj IsNot NonModelObject Then
         Return False
@@ -65,6 +77,7 @@
         If Not Object.Equals(Me.StringValue1, o.StringValue1) Then Return False
         If Not Object.Equals(Me.StringValue2, o.StringValue2) Then Return False
         If Not Object.Equals(Me.IntValue, o.IntValue) Then Return False
+        If Not Object.Equals(Me.DecimalValue, o.DecimalValue) Then Return False
         If Not Object.Equals(Me.NullableDecimalValue, o.NullableDecimalValue) Then Return False
 
         Return True
@@ -72,7 +85,7 @@
     End Function
 
     Public Overrides Function GetHashCode() As Int32
-      Return HashCode.Combine(Me.GuidValue, Me.BooleanValue, Me.StringValue1, Me.StringValue2, Me.IntValue, Me.NullableDecimalValue)
+      Return HashCode.Combine(Me.GuidValue, Me.BooleanValue, Me.StringValue1, Me.StringValue2, Me.IntValue, Me.DecimalValue, Me.NullableDecimalValue)
     End Function
 
   End Class

--- a/Source/Test/Yamo.Test/Tests/PropertyModifiedTrackingTests.vb
+++ b/Source/Test/Yamo.Test/Tests/PropertyModifiedTrackingTests.vb
@@ -245,7 +245,47 @@ Namespace Tests
     End Sub
 
     <TestMethod()>
-    Public Overridable Sub SelectModelEntityRecordWithPropertyModifiedTrackingFromJoinedSubquery()
+    Public Overridable Sub SelectModelEntityRecordWithPropertyModifiedTrackingFromFromSubquery()
+      Dim item1 = Me.ModelFactory.CreateItemWithPropertyModifiedTracking()
+      Dim item2 = Me.ModelFactory.CreateItemWithPropertyModifiedTracking()
+      Dim item3 = Me.ModelFactory.CreateItemWithPropertyModifiedTracking()
+
+      InsertItems(item1, item2, item3)
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Function(c)
+                               Return c.From(Of ItemWithPropertyModifiedTracking).
+                                        SelectAll()
+                             End Function).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(3, result.Count)
+        Assert.IsTrue(result.All(Function(x) Not x.IsAnyDbPropertyModified()))
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectNonModelAdHocTypeRecordWithPropertyModifiedTrackingFromFromSubquery()
+      Dim item1 = Me.ModelFactory.CreateItemWithPropertyModifiedTracking()
+      Dim item2 = Me.ModelFactory.CreateItemWithPropertyModifiedTracking()
+      Dim item3 = Me.ModelFactory.CreateItemWithPropertyModifiedTracking()
+
+      InsertItems(item1, item2, item3)
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Function(c)
+                               Return c.From(Of ItemWithPropertyModifiedTracking).
+                                        Select(Function(x) New NonModelObjectWithPropertyModifiedTracking With {.IntValue = x.Id, .StringValue = x.Description})
+                             End Function).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(3, result.Count)
+        Assert.IsTrue(result.All(Function(x) Not x.IsAnyDbPropertyModified()))
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectModelEntityRecordWithPropertyModifiedTrackingFromJoinSubquery()
       Dim linkedItem1 = Me.ModelFactory.CreateLinkedItem(1, Nothing)
       Dim linkedItem2 = Me.ModelFactory.CreateLinkedItem(2, Nothing)
       Dim linkedItem3 = Me.ModelFactory.CreateLinkedItem(3, Nothing)
@@ -273,13 +313,14 @@ Namespace Tests
                              End Function).
                         On(Function(j) j.T1.Id = j.T2.Id).As(Function(x) x.RelatedItem).
                         SelectAll().ToList()
+
         Assert.AreEqual(3, result.Count)
         Assert.IsTrue(result.All(Function(x) Not DirectCast(x.RelatedItem, ItemWithPropertyModifiedTracking).IsAnyDbPropertyModified()))
       End Using
     End Sub
 
     <TestMethod()>
-    Public Overridable Sub SelectNonModelAdHocTypeRecordWithPropertyModifiedTrackingFromJoinedSubquery()
+    Public Overridable Sub SelectNonModelAdHocTypeRecordWithPropertyModifiedTrackingFromJoinSubquery()
       Dim linkedItem1 = Me.ModelFactory.CreateLinkedItem(1, Nothing)
       Dim linkedItem2 = Me.ModelFactory.CreateLinkedItem(2, Nothing)
       Dim linkedItem3 = Me.ModelFactory.CreateLinkedItem(3, Nothing)
@@ -307,6 +348,7 @@ Namespace Tests
                              End Function).
                         On(Function(j) j.T1.Id = j.T2.IntValue).As(Function(x) x.RelatedItem).
                         SelectAll().ToList()
+
         Assert.AreEqual(3, result.Count)
         Assert.IsTrue(result.All(Function(x) Not DirectCast(x.RelatedItem, NonModelObjectWithPropertyModifiedTracking).IsAnyDbPropertyModified()))
       End Using

--- a/Source/Test/Yamo.Test/Tests/SelectWithFromSubqueryTests.vb
+++ b/Source/Test/Yamo.Test/Tests/SelectWithFromSubqueryTests.vb
@@ -1,0 +1,603 @@
+﻿Imports Yamo.Test.Model
+
+Namespace Tests
+
+  Public MustInherit Class SelectWithFromSubqueryTests
+    Inherits BaseIntegrationTests
+
+    Protected Const English As String = "en"
+
+    Protected Const German As String = "de"
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithSubqueryOfTypeEntity()
+      Dim article1 = Me.ModelFactory.CreateArticle(1, 100D)
+      Dim article2 = Me.ModelFactory.CreateArticle(2, 90D)
+      Dim article3 = Me.ModelFactory.CreateArticle(3, 80D)
+      Dim article4 = Me.ModelFactory.CreateArticle(4, 70D)
+
+      Dim label1En = Me.ModelFactory.CreateLabel("", 1, English)
+      Dim label3En = Me.ModelFactory.CreateLabel("", 3, English)
+      Dim label4En = Me.ModelFactory.CreateLabel("", 4, English)
+
+      InsertItems(article1, article2, article3, article4, label1En, label3En, label4En)
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Function(c)
+                               Return c.From(Of Article).
+                                        Where(Function(x) x.Id < 4).
+                                        SelectAll()
+                             End Function).
+                        Join(Of Label)(Function(a, l) a.Id = l.Id AndAlso l.Language = English).
+                        OrderBy(Function(l) l.Price).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(2, result.Count)
+        Assert.AreEqual(article3, result(0))
+        Assert.AreEqual(label3En, result(0).Label)
+        Assert.AreEqual(article1, result(1))
+        Assert.AreEqual(label1En, result(1).Label)
+      End Using
+
+      ' same as above, but use IJoin
+      Using db = CreateDbContext()
+        Dim result = db.From(Function(c)
+                               Return c.From(Of Article).
+                                        Where(Function(x) x.Id < 4).
+                                        SelectAll()
+                             End Function).
+                        Join(Of Label)(Function(j) j.T1.Id = j.T2.Id AndAlso j.T2.Language = English).
+                        OrderBy(Function(j) j.T1.Price).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(2, result.Count)
+        Assert.AreEqual(article3, result(0))
+        Assert.AreEqual(label3En, result(0).Label)
+        Assert.AreEqual(article1, result(1))
+        Assert.AreEqual(label1En, result(1).Label)
+      End Using
+
+      ' use custom select
+      Using db = CreateDbContext()
+        Dim result = db.From(Function(c)
+                               Return c.From(Of Article).
+                                        Where(Function(x) x.Id < 4).
+                                        Select(Function(x) x)
+                             End Function).
+                        Join(Of Label)(Function(j) j.T1.Id = j.T2.Id AndAlso j.T2.Language = English).
+                        OrderBy(Function(j) j.T1.Price).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(2, result.Count)
+        Assert.AreEqual(article3, result(0))
+        Assert.AreEqual(label3En, result(0).Label)
+        Assert.AreEqual(article1, result(1))
+        Assert.AreEqual(label1En, result(1).Label)
+      End Using
+
+      ' use custom select, but specify properties
+      Using db = CreateDbContext()
+        Dim result = db.From(Function(c)
+                               Return c.From(Of Article).
+                                        Where(Function(x) x.Id < 4).
+                                        Select(Function(x) New Article With {.Id = x.Id, .Price = x.Price})
+                             End Function).
+                        Join(Of Label)(Function(j) j.T1.Id = j.T2.Id AndAlso j.T2.Language = English).
+                        OrderBy(Function(j) j.T1.Price).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(2, result.Count)
+        Assert.AreEqual(New Article With {.Id = article3.Id, .Price = article3.Price}, result(0))
+        ' NOTE: Label instances won't be set, because in this case, Article will be
+        ' represented by NonModelEntity and hence relationship won't be found.
+        ' Should this be changed in the future?
+        'Assert.AreEqual(label3En, result(0).Label)
+        Assert.IsNull(result(0).Label)
+        Assert.AreEqual(New Article With {.Id = article1.Id, .Price = article1.Price}, result(1))
+        'Assert.AreEqual(label1En, result(1).Label)
+        Assert.IsNull(result(1).Label)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithSubqueryOfTypeAnonymousType()
+      Dim article1 = Me.ModelFactory.CreateArticle(1, 100D)
+      Dim article2 = Me.ModelFactory.CreateArticle(2, 90D)
+      Dim article3 = Me.ModelFactory.CreateArticle(3, 80D)
+      Dim article4 = Me.ModelFactory.CreateArticle(4, 70D)
+
+      Dim label1En = Me.ModelFactory.CreateLabel("", 1, English)
+      Dim label3En = Me.ModelFactory.CreateLabel("", 3, English)
+      Dim label4En = Me.ModelFactory.CreateLabel("", 4, English)
+
+      InsertItems(article1, article2, article3, article4, label1En, label3En, label4En)
+
+      Dim item1 = New With {Key .Id = article1.Id, Key .Price = article1.Price}
+      Dim item3 = New With {Key .Id = article3.Id, Key .Price = article3.Price}
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Function(c)
+                               Return c.From(Of Article).
+                                        Where(Function(x) x.Id < 4).
+                                        Select(Function(x) New With {Key .Id = x.Id, Key .Price = x.Price})
+                             End Function).
+                        Join(Of Label)(Function(a, l) a.Id = l.Id AndAlso l.Language = English).
+                        OrderBy(Function(l) l.Price).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(2, result.Count)
+        Assert.AreEqual(item3, result(0))
+        Assert.AreEqual(item1, result(1))
+      End Using
+
+      ' same as above, but use IJoin
+      Using db = CreateDbContext()
+        Dim result = db.From(Function(c)
+                               Return c.From(Of Article).
+                                        Where(Function(x) x.Id < 4).
+                                        Select(Function(x) New With {Key .Id = x.Id, Key .Price = x.Price})
+                             End Function).
+                        Join(Of Label)(Function(j) j.T1.Id = j.T2.Id AndAlso j.T2.Language = English).
+                        OrderBy(Function(j) j.T1.Price).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(2, result.Count)
+        Assert.AreEqual(item3, result(0))
+        Assert.AreEqual(item1, result(1))
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithSubqueryOfTypeValueTuple()
+      Dim article1 = Me.ModelFactory.CreateArticle(1, 100D)
+      Dim article2 = Me.ModelFactory.CreateArticle(2, 90D)
+      Dim article3 = Me.ModelFactory.CreateArticle(3, 80D)
+      Dim article4 = Me.ModelFactory.CreateArticle(4, 70D)
+
+      Dim label1En = Me.ModelFactory.CreateLabel("", 1, English)
+      Dim label3En = Me.ModelFactory.CreateLabel("", 3, English)
+      Dim label4En = Me.ModelFactory.CreateLabel("", 4, English)
+
+      InsertItems(article1, article2, article3, article4, label1En, label3En, label4En)
+
+      Dim item1 = (Id:=article1.Id, Price:=article1.Price)
+      Dim item3 = (Id:=article3.Id, Price:=article3.Price)
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Function(c)
+                               Return c.From(Of Article).
+                                        Where(Function(x) x.Id < 4).
+                                        Select(Function(x) (Id:=x.Id, Price:=x.Price))
+                             End Function).
+                        Join(Of Label)(Function(a, l) a.Id = l.Id AndAlso l.Language = English).
+                        OrderBy(Function(l) l.Price).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(2, result.Count)
+        Assert.AreEqual(item3, result(0))
+        Assert.AreEqual(item1, result(1))
+      End Using
+
+      ' same as above, but use IJoin
+      Using db = CreateDbContext()
+        Dim result = db.From(Function(c)
+                               Return c.From(Of Article).
+                                        Where(Function(x) x.Id < 4).
+                                        Select(Function(x) (Id:=x.Id, Price:=x.Price))
+                             End Function).
+                        Join(Of Label)(Function(j) j.T1.Id = j.T2.Id AndAlso j.T2.Language = English).
+                        OrderBy(Function(j) j.T1.Price).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(2, result.Count)
+        Assert.AreEqual(item3, result(0))
+        Assert.AreEqual(item1, result(1))
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithSubqueryOfTypeAdHocType()
+      Dim article1 = Me.ModelFactory.CreateArticle(1, 100D)
+      Dim article2 = Me.ModelFactory.CreateArticle(2, 90D)
+      Dim article3 = Me.ModelFactory.CreateArticle(3, 80D)
+      Dim article4 = Me.ModelFactory.CreateArticle(4, 70D)
+
+      Dim label1En = Me.ModelFactory.CreateLabel("", 1, English)
+      Dim label3En = Me.ModelFactory.CreateLabel("", 3, English)
+      Dim label4En = Me.ModelFactory.CreateLabel("", 4, English)
+
+      InsertItems(article1, article2, article3, article4, label1En, label3En, label4En)
+
+      Dim item1 = New NonModelObject(article1.Id, article1.Price)
+      Dim item3 = New NonModelObject(article3.Id, article3.Price)
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Function(c)
+                               Return c.From(Of Article).
+                                        Where(Function(x) x.Id < 4).
+                                        Select(Function(x) New NonModelObject With {.IntValue = x.Id, .DecimalValue = x.Price})
+                             End Function).
+                        Join(Of Label)(Function(a, l) a.IntValue = l.Id AndAlso l.Language = English).
+                        OrderBy(Function(l) l.DecimalValue).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(2, result.Count)
+        Assert.AreEqual(item3, result(0))
+        Assert.AreEqual(item1, result(1))
+      End Using
+
+      ' same as above, but use IJoin
+      Using db = CreateDbContext()
+        Dim result = db.From(Function(c)
+                               Return c.From(Of Article).
+                                        Where(Function(x) x.Id < 4).
+                                        Select(Function(x) New NonModelObject With {.IntValue = x.Id, .DecimalValue = x.Price})
+                             End Function).
+                        Join(Of Label)(Function(j) j.T1.IntValue = j.T2.Id AndAlso j.T2.Language = English).
+                        OrderBy(Function(j) j.T1.DecimalValue).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(2, result.Count)
+        Assert.AreEqual(item3, result(0))
+        Assert.AreEqual(item1, result(1))
+      End Using
+
+      ' use property with unknown column mapping
+      Try
+        Using db = CreateDbContext()
+          Dim result = db.From(Function(c)
+                                 Return c.From(Of Article).
+                                        Where(Function(x) x.Id < 4).
+                                        Select(Function(x) New NonModelObject(x.Id, x.Price))
+                               End Function).
+                        Join(Of Label)(Function(a, l) a.IntValue = l.Id AndAlso l.Language = English).
+                        OrderBy(Function(l) l.DecimalValue).
+                        SelectAll().ToList()
+        End Using
+        Assert.Fail()
+      Catch ex As Exception
+      End Try
+
+      ' same as above, but use IJoin
+      Try
+        Using db = CreateDbContext()
+          Dim result = db.From(Function(c)
+                                 Return c.From(Of Article).
+                                        Where(Function(x) x.Id < 4).
+                                        Select(Function(x) New NonModelObject(x.Id, x.Price))
+                               End Function).
+                        Join(Of Label)(Function(j) j.T1.IntValue = j.T2.Id AndAlso j.T2.Language = English).
+                        OrderBy(Function(j) j.T1.DecimalValue).
+                        SelectAll().ToList()
+        End Using
+        Assert.Fail()
+      Catch ex As Exception
+      End Try
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithSubqueryOfTypeEntityUsingNullIfAllColumnsAreNullBehavior()
+      Dim article1 = Me.ModelFactory.CreateArticle(1, 100D)
+      Dim article2 = Me.ModelFactory.CreateArticle(2, 90D)
+      Dim article3 = Me.ModelFactory.CreateArticle(3, 80D)
+
+      Dim label1En = Me.ModelFactory.CreateLabel("", 1, English)
+      Dim label3En = Me.ModelFactory.CreateLabel("", 3, English)
+
+      InsertItems(article1, article2, article3, label1En, label3En)
+
+      ' NonModelEntityCreationBehavior should not have any effect here
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Function(c)
+                               Return c.From(Of Article).
+                                        LeftJoin(Of Label)(Function(j) j.T1.Id = j.T2.Id AndAlso j.T2.Language = English).
+                                        Select(Function(x) x.T2)
+                             End Function, NonModelEntityCreationBehavior.NullIfAllColumnsAreNull).
+                        OrderBy(Function(x) x.Id).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(2, result.Count)
+        Assert.AreEqual(label1En, result(0))
+        Assert.AreEqual(label3En, result(1))
+      End Using
+
+      ' same as above, but assume behavior is not explicitly set
+      Using db = CreateDbContext()
+        Dim result = db.From(Function(c)
+                               Return c.From(Of Article).
+                                        LeftJoin(Of Label)(Function(j) j.T1.Id = j.T2.Id AndAlso j.T2.Language = English).
+                                        Select(Function(x) x.T2)
+                             End Function).
+                        OrderBy(Function(x) x.Id).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(2, result.Count)
+        Assert.AreEqual(label1En, result(0))
+        Assert.AreEqual(label3En, result(1))
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithSubqueryOfTypeEntityUsingAlwaysCreateInstanceBehavior()
+      Dim article1 = Me.ModelFactory.CreateArticle(1, 100D)
+      Dim article2 = Me.ModelFactory.CreateArticle(2, 90D)
+      Dim article3 = Me.ModelFactory.CreateArticle(3, 80D)
+
+      Dim label1En = Me.ModelFactory.CreateLabel("", 1, English)
+      Dim label3En = Me.ModelFactory.CreateLabel("", 3, English)
+
+      InsertItems(article1, article2, article3, label1En, label3En)
+
+      ' NonModelEntityCreationBehavior should not have any effect here
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Function(c)
+                               Return c.From(Of Article).
+                                        LeftJoin(Of Label)(Function(j) j.T1.Id = j.T2.Id AndAlso j.T2.Language = English).
+                                        Select(Function(x) x.T2)
+                             End Function, NonModelEntityCreationBehavior.AlwaysCreateInstance).
+                        OrderBy(Function(x) x.Id).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(2, result.Count)
+        Assert.AreEqual(label1En, result(0))
+        Assert.AreEqual(label3En, result(1))
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithSubqueryOfTypeAnonymousTypeUsingNullIfAllColumnsAreNullBehavior()
+      Dim article1 = Me.ModelFactory.CreateArticle(1, 100D)
+      Dim article2 = Me.ModelFactory.CreateArticle(2, 90D)
+      Dim article3 = Me.ModelFactory.CreateArticle(3, 80D)
+
+      Dim label1En = Me.ModelFactory.CreateLabel("", 1, English)
+      Dim label3En = Me.ModelFactory.CreateLabel("", 3, English)
+
+      InsertItems(article1, article2, article3, label1En, label3En)
+
+      Dim item1 = New With {Key .Id = label1En.Id, Key .Description = label1En.Description}
+      Dim item3 = New With {Key .Id = label3En.Id, Key .Description = label3En.Description}
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Function(c)
+                               Return c.From(Of Article).
+                                        LeftJoin(Of Label)(Function(j) j.T1.Id = j.T2.Id AndAlso j.T2.Language = English).
+                                        Select(Function(j) New With {Key .Id = j.T2.Id, Key .Description = j.T2.Description})
+                             End Function, NonModelEntityCreationBehavior.NullIfAllColumnsAreNull).
+                        OrderBy(Function(x) x.Id).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(2, result.Count)
+        Assert.AreEqual(item1, result(0))
+        Assert.AreEqual(item3, result(1))
+      End Using
+
+      ' same as above, but assume behavior is not explicitly set
+      Using db = CreateDbContext()
+        Dim result = db.From(Function(c)
+                               Return c.From(Of Article).
+                                        LeftJoin(Of Label)(Function(j) j.T1.Id = j.T2.Id AndAlso j.T2.Language = English).
+                                        Select(Function(j) New With {Key .Id = j.T2.Id, Key .Description = j.T2.Description})
+                             End Function).
+                        OrderBy(Function(x) x.Id).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(2, result.Count)
+        Assert.AreEqual(item1, result(0))
+        Assert.AreEqual(item3, result(1))
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithSubqueryOfTypeAnonymousTypeUsingAlwaysCreateInstanceBehavior()
+      Dim article1 = Me.ModelFactory.CreateArticle(1, 100D)
+      Dim article2 = Me.ModelFactory.CreateArticle(2, 90D)
+      Dim article3 = Me.ModelFactory.CreateArticle(3, 80D)
+
+      Dim label1En = Me.ModelFactory.CreateLabel("", 1, English)
+      Dim label3En = Me.ModelFactory.CreateLabel("", 3, English)
+
+      InsertItems(article1, article2, article3, label1En, label3En)
+
+      Dim item1 = New With {Key .Id = label1En.Id, Key .Description = label1En.Description}
+      Dim item3 = New With {Key .Id = label3En.Id, Key .Description = label3En.Description}
+      Dim itemEmpty = New With {Key .Id = 0, Key .Description = CType(Nothing, String)}
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Function(c)
+                               Return c.From(Of Article).
+                                        LeftJoin(Of Label)(Function(j) j.T1.Id = j.T2.Id AndAlso j.T2.Language = English).
+                                        Select(Function(j) New With {Key .Id = j.T2.Id, Key .Description = j.T2.Description})
+                             End Function, NonModelEntityCreationBehavior.AlwaysCreateInstance).
+                        OrderBy(Function(x) x.Id).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(3, result.Count)
+        Assert.AreEqual(itemEmpty, result(0))
+        Assert.AreEqual(item1, result(1))
+        Assert.AreEqual(item3, result(2))
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithSubqueryOfTypeValueTupleUsingNullIfAllColumnsAreNullBehavior()
+      Dim article1 = Me.ModelFactory.CreateArticle(1, 100D)
+      Dim article2 = Me.ModelFactory.CreateArticle(2, 90D)
+      Dim article3 = Me.ModelFactory.CreateArticle(3, 80D)
+
+      Dim label1En = Me.ModelFactory.CreateLabel("", 1, English)
+      Dim label3En = Me.ModelFactory.CreateLabel("", 3, English)
+
+      InsertItems(article1, article2, article3, label1En, label3En)
+
+      Dim item1 = (Id:=label1En.Id, Description:=label1En.Description)
+      Dim item3 = (Id:=label3En.Id, Description:=label3En.Description)
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Function(c)
+                               Return c.From(Of Article).
+                                        LeftJoin(Of Label)(Function(j) j.T1.Id = j.T2.Id AndAlso j.T2.Language = English).
+                                        Select(Function(j) (Id:=j.T2.Id, Description:=j.T2.Description))
+                             End Function, NonModelEntityCreationBehavior.NullIfAllColumnsAreNull).
+                        OrderBy(Function(x) x.Id).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(2, result.Count)
+        Assert.AreEqual(item1, result(0))
+        Assert.AreEqual(item3, result(1))
+      End Using
+
+      ' same as above, but assume behavior is not explicitly set
+      Using db = CreateDbContext()
+        Dim result = db.From(Function(c)
+                               Return c.From(Of Article).
+                                        LeftJoin(Of Label)(Function(j) j.T1.Id = j.T2.Id AndAlso j.T2.Language = English).
+                                        Select(Function(j) (Id:=j.T2.Id, Description:=j.T2.Description))
+                             End Function).
+                        OrderBy(Function(x) x.Id).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(2, result.Count)
+        Assert.AreEqual(item1, result(0))
+        Assert.AreEqual(item3, result(1))
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithSubqueryOfTypeValueTupleUsingAlwaysCreateInstanceBehavior()
+      Dim article1 = Me.ModelFactory.CreateArticle(1, 100D)
+      Dim article2 = Me.ModelFactory.CreateArticle(2, 90D)
+      Dim article3 = Me.ModelFactory.CreateArticle(3, 80D)
+
+      Dim label1En = Me.ModelFactory.CreateLabel("", 1, English)
+      Dim label3En = Me.ModelFactory.CreateLabel("", 3, English)
+
+      InsertItems(article1, article2, article3, label1En, label3En)
+
+      Dim item1 = (Id:=label1En.Id, Description:=label1En.Description)
+      Dim item3 = (Id:=label3En.Id, Description:=label3En.Description)
+      Dim itemEmpty = (Id:=0, Description:=CType(Nothing, String))
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Function(c)
+                               Return c.From(Of Article).
+                                        LeftJoin(Of Label)(Function(j) j.T1.Id = j.T2.Id AndAlso j.T2.Language = English).
+                                        Select(Function(j) (Id:=j.T2.Id, Description:=j.T2.Description))
+                             End Function, NonModelEntityCreationBehavior.AlwaysCreateInstance).
+                        OrderBy(Function(x) x.Id).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(3, result.Count)
+        Assert.AreEqual(itemEmpty, result(0))
+        Assert.AreEqual(item1, result(1))
+        Assert.AreEqual(item3, result(2))
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithSubqueryOfTypeAdHocTypeUsingNullIfAllColumnsAreNullBehavior()
+      Dim article1 = Me.ModelFactory.CreateArticle(1, 100D)
+      Dim article2 = Me.ModelFactory.CreateArticle(2, 90D)
+      Dim article3 = Me.ModelFactory.CreateArticle(3, 80D)
+
+      Dim label1En = Me.ModelFactory.CreateLabel("", 1, English)
+      Dim label3En = Me.ModelFactory.CreateLabel("", 3, English)
+
+      InsertItems(article1, article2, article3, label1En, label3En)
+
+      Dim item1 = New NonModelObject(label1En.Id, label1En.Description)
+      Dim item3 = New NonModelObject(label3En.Id, label3En.Description)
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Function(c)
+                               Return c.From(Of Article).
+                                        LeftJoin(Of Label)(Function(j) j.T1.Id = j.T2.Id AndAlso j.T2.Language = English).
+                                        Select(Function(j) New NonModelObject With {.IntValue = j.T2.Id, .StringValue1 = j.T2.Description})
+                             End Function, NonModelEntityCreationBehavior.NullIfAllColumnsAreNull).
+                        OrderBy(Function(x) x.IntValue).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(2, result.Count)
+        Assert.AreEqual(item1, result(0))
+        Assert.AreEqual(item3, result(1))
+      End Using
+
+      ' same as above, but assume behavior is not explicitly set
+      Using db = CreateDbContext()
+        Dim result = db.From(Function(c)
+                               Return c.From(Of Article).
+                                        LeftJoin(Of Label)(Function(j) j.T1.Id = j.T2.Id AndAlso j.T2.Language = English).
+                                        Select(Function(j) New NonModelObject With {.IntValue = j.T2.Id, .StringValue1 = j.T2.Description})
+                             End Function).
+                        OrderBy(Function(x) x.IntValue).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(2, result.Count)
+        Assert.AreEqual(item1, result(0))
+        Assert.AreEqual(item3, result(1))
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithSubqueryOfTypeAdHocTypeUsingAlwaysCreateInstanceBehavior()
+      Dim article1 = Me.ModelFactory.CreateArticle(1, 100D)
+      Dim article2 = Me.ModelFactory.CreateArticle(2, 90D)
+      Dim article3 = Me.ModelFactory.CreateArticle(3, 80D)
+
+      Dim label1En = Me.ModelFactory.CreateLabel("", 1, English)
+      Dim label3En = Me.ModelFactory.CreateLabel("", 3, English)
+
+      InsertItems(article1, article2, article3, label1En, label3En)
+
+      Dim item1 = New NonModelObject(label1En.Id, label1En.Description)
+      Dim item3 = New NonModelObject(label3En.Id, label3En.Description)
+      Dim itemEmpty = New NonModelObject(0, CType(Nothing, String))
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Function(c)
+                               Return c.From(Of Article).
+                                        LeftJoin(Of Label)(Function(j) j.T1.Id = j.T2.Id AndAlso j.T2.Language = English).
+                                        Select(Function(j) New NonModelObject With {.IntValue = j.T2.Id, .StringValue1 = j.T2.Description})
+                             End Function, NonModelEntityCreationBehavior.AlwaysCreateInstance).
+                        OrderBy(Function(x) x.IntValue).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(3, result.Count)
+        Assert.AreEqual(itemEmpty, result(0))
+        Assert.AreEqual(item1, result(1))
+        Assert.AreEqual(item3, result(2))
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithNestedSubquery()
+      Dim article1 = Me.ModelFactory.CreateArticle(1, 100D)
+      Dim article2 = Me.ModelFactory.CreateArticle(2, 90D)
+      Dim article3 = Me.ModelFactory.CreateArticle(3, 80D)
+      Dim article4 = Me.ModelFactory.CreateArticle(4, 70D)
+
+      InsertItems(article1, article2, article3, article4)
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Function(c)
+                               Return c.From(Function(c2)
+                                               Return c2.From(Of Article).
+                                                         Where(Function(x) 1 < x.Id).
+                                                         SelectAll()
+                                             End Function).
+                                        Where(Function(x) x.Id < 4).
+                                        SelectAll()
+                             End Function).
+                        OrderBy(Function(x) x.Id).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(2, result.Count)
+        Assert.AreEqual(article2, result(0))
+        Assert.AreEqual(article3, result(1))
+      End Using
+    End Sub
+
+  End Class
+End Namespace

--- a/Source/Test/Yamo.Test/Tests/SelectWithJoinSubqueryTests.vb
+++ b/Source/Test/Yamo.Test/Tests/SelectWithJoinSubqueryTests.vb
@@ -58,6 +58,44 @@ Namespace Tests
         Assert.AreEqual(article1, result(1))
         Assert.AreEqual(label1En, result(1).Label)
       End Using
+
+      ' use custom select
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        Join(Of Label)(Function(c)
+                                         Return c.From(Of Label).
+                                                  Where(Function(x) x.Language = English).
+                                                  Select(Function(x) x)
+                                       End Function).
+                        On(Function(j) j.T1.Id = j.T2.Id).
+                        OrderBy(Function(j) j.T2.Description).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(2, result.Count)
+        Assert.AreEqual(article3, result(0))
+        Assert.AreEqual(label3En, result(0).Label)
+        Assert.AreEqual(article1, result(1))
+        Assert.AreEqual(label1En, result(1).Label)
+      End Using
+
+      ' use custom select, but specify properties
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        Join(Of Label)(Function(c)
+                                         Return c.From(Of Label).
+                                                  Where(Function(x) x.Language = English).
+                                                  Select(Function(x) New Label With {.Id = x.Id, .Description = x.Description})
+                                       End Function).
+                        On(Function(j) j.T1.Id = j.T2.Id).
+                        OrderBy(Function(j) j.T2.Description).
+                        SelectAll().ToList()
+
+        Assert.AreEqual(2, result.Count)
+        Assert.AreEqual(article3, result(0))
+        Assert.AreEqual(New Label With {.Id = label3En.Id, .Description = label3En.Description}, result(0).Label)
+        Assert.AreEqual(article1, result(1))
+        Assert.AreEqual(New Label With {.Id = label1En.Id, .Description = label1En.Description}, result(1).Label)
+      End Using
     End Sub
 
     <TestMethod()>


### PR DESCRIPTION
This PR adds support for `FROM` subqueries.

API is basically the same as in #97 (with all the limitations, etc.).

Example:
```cs
using (var db = CreateContext())
{
    var list = db.From(c =>
                 {
                     return c.From<Article>()
                             .Where(x => x.InStock)
                             .SelectAll();
                 })
                 .Where(x => 42 < x.Price)
                 .SelectAll()
                 .ToList();
}
```

This PR contains breaking changes on API that is public, but not intended to be called directly.