### PR TITLE
Added support for set operators

### DIFF
--- a/Source/Samples/Yamo.Playground.CS/Program.cs
+++ b/Source/Samples/Yamo.Playground.CS/Program.cs
@@ -83,7 +83,9 @@ namespace Yamo.Playground.CS
             //Test58();
             //Test59();
             //Test60();
-            Test61();
+            //Test61();
+            Test62();
+            Test63();
         }
 
         public static MyContext CreateContext()
@@ -1234,6 +1236,42 @@ namespace Yamo.Playground.CS
                                          .SelectAll();
                              })
                              .Where(x => 42 < x.Price)
+                             .SelectAll()
+                             .ToList();
+            }
+        }
+
+        public static void Test62()
+        {
+            using (var db = CreateContext())
+            {
+                var list = db.From<Article>()
+                             .Where(x => x.Price < 42)
+                             .SelectAll()
+                             .UnionAll(c =>
+                             {
+                                 return c.From<Article>()
+                                         .Where(x => 420 < x.Price)
+                                         .SelectAll();
+                             })
+                             .ToList();
+            }
+        }
+
+        public static void Test63()
+        {
+            using (var db = CreateContext())
+            {
+                var list = db.From(c =>
+                             {
+                                 return c.From<Article>()
+                                         .SelectAll()
+                                         .UnionAll(c2 =>
+                                         {
+                                             return c2.From<Article>("ArticleArchive")
+                                                      .SelectAll();
+                                         });
+                             })
                              .SelectAll()
                              .ToList();
             }

--- a/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.If.vb
+++ b/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.If.vb
@@ -140,6 +140,12 @@
           Case GeneratedClass.CustomDistinctSelectSqlExpression
             min = 1
             max = 1
+          Case GeneratedClass.SetSelectSqlExpression
+            min = 1
+            max = 1
+          Case GeneratedClass.CustomSetSelectSqlExpression
+            min = 1
+            max = 1
         End Select
 
         Dim className = GetClassName(generatedClass)

--- a/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.Set.vb
+++ b/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.Set.vb
@@ -1,0 +1,464 @@
+﻿Namespace Generator
+
+  Partial Public Class CodeGenerator
+
+    Protected Sub GenerateSet(builder As CodeBuilder, entityCount As Int32)
+      GenerateUnionWithSubquery(builder, entityCount)
+      builder.AppendLine()
+
+      GenerateUnionWithFormattableString(builder, entityCount)
+      builder.AppendLine()
+
+      GenerateUnionWithRawSqlString(builder, entityCount)
+      builder.AppendLine()
+
+      GenerateUnionAllWithSubquery(builder, entityCount)
+      builder.AppendLine()
+
+      GenerateUnionAllWithFormattableString(builder, entityCount)
+      builder.AppendLine()
+
+      GenerateUnionAllWithRawSqlString(builder, entityCount)
+      builder.AppendLine()
+
+      GenerateExceptWithSubquery(builder, entityCount)
+      builder.AppendLine()
+
+      GenerateExceptWithFormattableString(builder, entityCount)
+      builder.AppendLine()
+
+      GenerateExceptWithRawSqlString(builder, entityCount)
+      builder.AppendLine()
+
+      GenerateIntersectWithSubquery(builder, entityCount)
+      builder.AppendLine()
+
+      GenerateIntersectWithFormattableString(builder, entityCount)
+      builder.AppendLine()
+
+      GenerateIntersectWithRawSqlString(builder, entityCount)
+      builder.AppendLine()
+
+      GenerateInternalSetWithSubquery(builder, entityCount)
+      builder.AppendLine()
+
+      GenerateInternalSetWithFormattableString(builder, entityCount)
+      builder.AppendLine()
+
+      GenerateInternalSetWithRawSqlString(builder, entityCount)
+    End Sub
+
+    Protected Sub GenerateCustomSet(builder As CodeBuilder, entityCount As Int32)
+      GenerateCustomUnionWithSubquery(builder, entityCount)
+      builder.AppendLine()
+
+      GenerateCustomUnionWithFormattableString(builder, entityCount)
+      builder.AppendLine()
+
+      GenerateCustomUnionWithRawSqlString(builder, entityCount)
+      builder.AppendLine()
+
+      GenerateCustomUnionAllWithSubquery(builder, entityCount)
+      builder.AppendLine()
+
+      GenerateCustomUnionAllWithFormattableString(builder, entityCount)
+      builder.AppendLine()
+
+      GenerateCustomUnionAllWithRawSqlString(builder, entityCount)
+      builder.AppendLine()
+
+      GenerateCustomExceptWithSubquery(builder, entityCount)
+      builder.AppendLine()
+
+      GenerateCustomExceptWithFormattableString(builder, entityCount)
+      builder.AppendLine()
+
+      GenerateCustomExceptWithRawSqlString(builder, entityCount)
+      builder.AppendLine()
+
+      GenerateCustomIntersectWithSubquery(builder, entityCount)
+      builder.AppendLine()
+
+      GenerateCustomIntersectWithFormattableString(builder, entityCount)
+      builder.AppendLine()
+
+      GenerateCustomIntersectWithRawSqlString(builder, entityCount)
+      builder.AppendLine()
+
+      GenerateCustomInternalSetWithSubquery(builder, entityCount)
+      builder.AppendLine()
+
+      GenerateCustomInternalSetWithFormattableString(builder, entityCount)
+      builder.AppendLine()
+
+      GenerateCustomInternalSetWithRawSqlString(builder, entityCount)
+    End Sub
+
+    Protected Sub GenerateUnionWithSubquery(builder As CodeBuilder, entityCount As Int32)
+      Dim comment = "Adds UNION operator."
+      Dim params = {"queryExpressionFactory"}
+      AddComment(builder, comment, params:=params, returns:="")
+
+      Dim generic = GetGenericName(1, entityCount = 1)
+
+      builder.Indent().AppendLine($"Public Function Union(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of {generic}))) As SetSelectSqlExpression(Of {generic})").PushIndent()
+      builder.Indent().AppendLine("Return InternalSet(SetOperator.Union, queryExpressionFactory)").PopIndent()
+      builder.Indent().AppendLine("End Function")
+    End Sub
+
+    Protected Sub GenerateUnionWithFormattableString(builder As CodeBuilder, entityCount As Int32)
+      Dim comment = "Adds UNION operator."
+      Dim params = {"queryExpression"}
+      AddComment(builder, comment, params:=params, returns:="")
+
+      Dim generic = GetGenericName(1, entityCount = 1)
+
+      builder.Indent().AppendLine($"Public Function Union(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of {generic})").PushIndent()
+      builder.Indent().AppendLine("Return InternalSet(SetOperator.Union, queryExpression)").PopIndent()
+      builder.Indent().AppendLine("End Function")
+    End Sub
+
+    Protected Sub GenerateUnionWithRawSqlString(builder As CodeBuilder, entityCount As Int32)
+      Dim comment = "Adds UNION operator."
+      Dim params = {"queryExpression", "parameters"}
+      AddComment(builder, comment, params:=params, returns:="")
+
+      Dim generic = GetGenericName(1, entityCount = 1)
+
+      builder.Indent().AppendLine($"Public Function Union(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of {generic})").PushIndent()
+      builder.Indent().AppendLine("Return InternalSet(SetOperator.Union, queryExpression, parameters)").PopIndent()
+      builder.Indent().AppendLine("End Function")
+    End Sub
+
+    Protected Sub GenerateCustomUnionWithSubquery(builder As CodeBuilder, entityCount As Int32)
+      Dim comment = "Adds UNION operator."
+      Dim params = {"queryExpressionFactory"}
+      AddComment(builder, comment, params:=params, returns:="")
+
+      Dim generic = GetGenericName(1, entityCount = 1)
+
+      builder.Indent().AppendLine($"Public Function Union(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of {generic}))) As CustomSetSelectSqlExpression(Of {generic})").PushIndent()
+      builder.Indent().AppendLine("Return InternalSet(SetOperator.Union, queryExpressionFactory)").PopIndent()
+      builder.Indent().AppendLine("End Function")
+    End Sub
+
+    Protected Sub GenerateCustomUnionWithFormattableString(builder As CodeBuilder, entityCount As Int32)
+      Dim comment = "Adds UNION operator."
+      Dim params = {"queryExpression"}
+      AddComment(builder, comment, params:=params, returns:="")
+
+      Dim generic = GetGenericName(1, entityCount = 1)
+
+      builder.Indent().AppendLine($"Public Function Union(<DisallowNull> queryExpression As FormattableString) As CustomSetSelectSqlExpression(Of {generic})").PushIndent()
+      builder.Indent().AppendLine("Return InternalSet(SetOperator.Union, queryExpression)").PopIndent()
+      builder.Indent().AppendLine("End Function")
+    End Sub
+
+    Protected Sub GenerateCustomUnionWithRawSqlString(builder As CodeBuilder, entityCount As Int32)
+      Dim comment = "Adds UNION operator."
+      Dim params = {"queryExpression", "parameters"}
+      AddComment(builder, comment, params:=params, returns:="")
+
+      Dim generic = GetGenericName(1, entityCount = 1)
+
+      builder.Indent().AppendLine($"Public Function Union(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As CustomSetSelectSqlExpression(Of {generic})").PushIndent()
+      builder.Indent().AppendLine("Return InternalSet(SetOperator.Union, queryExpression, parameters)").PopIndent()
+      builder.Indent().AppendLine("End Function")
+    End Sub
+
+    Protected Sub GenerateUnionAllWithSubquery(builder As CodeBuilder, entityCount As Int32)
+      Dim comment = "Adds UNION ALL operator."
+      Dim params = {"queryExpressionFactory"}
+      AddComment(builder, comment, params:=params, returns:="")
+
+      Dim generic = GetGenericName(1, entityCount = 1)
+
+      builder.Indent().AppendLine($"Public Function UnionAll(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of {generic}))) As SetSelectSqlExpression(Of {generic})").PushIndent()
+      builder.Indent().AppendLine("Return InternalSet(SetOperator.UnionAll, queryExpressionFactory)").PopIndent()
+      builder.Indent().AppendLine("End Function")
+    End Sub
+
+    Protected Sub GenerateUnionAllWithFormattableString(builder As CodeBuilder, entityCount As Int32)
+      Dim comment = "Adds UNION ALL operator."
+      Dim params = {"queryExpression"}
+      AddComment(builder, comment, params:=params, returns:="")
+
+      Dim generic = GetGenericName(1, entityCount = 1)
+
+      builder.Indent().AppendLine($"Public Function UnionAll(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of {generic})").PushIndent()
+      builder.Indent().AppendLine("Return InternalSet(SetOperator.UnionAll, queryExpression)").PopIndent()
+      builder.Indent().AppendLine("End Function")
+    End Sub
+
+    Protected Sub GenerateUnionAllWithRawSqlString(builder As CodeBuilder, entityCount As Int32)
+      Dim comment = "Adds UNION ALL operator."
+      Dim params = {"queryExpression", "parameters"}
+      AddComment(builder, comment, params:=params, returns:="")
+
+      Dim generic = GetGenericName(1, entityCount = 1)
+
+      builder.Indent().AppendLine($"Public Function UnionAll(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of {generic})").PushIndent()
+      builder.Indent().AppendLine("Return InternalSet(SetOperator.UnionAll, queryExpression, parameters)").PopIndent()
+      builder.Indent().AppendLine("End Function")
+    End Sub
+
+    Protected Sub GenerateCustomUnionAllWithSubquery(builder As CodeBuilder, entityCount As Int32)
+      Dim comment = "Adds UNION ALL operator."
+      Dim params = {"queryExpressionFactory"}
+      AddComment(builder, comment, params:=params, returns:="")
+
+      Dim generic = GetGenericName(1, entityCount = 1)
+
+      builder.Indent().AppendLine($"Public Function UnionAll(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of {generic}))) As CustomSetSelectSqlExpression(Of {generic})").PushIndent()
+      builder.Indent().AppendLine("Return InternalSet(SetOperator.UnionAll, queryExpressionFactory)").PopIndent()
+      builder.Indent().AppendLine("End Function")
+    End Sub
+
+    Protected Sub GenerateCustomUnionAllWithFormattableString(builder As CodeBuilder, entityCount As Int32)
+      Dim comment = "Adds UNION ALL operator."
+      Dim params = {"queryExpression"}
+      AddComment(builder, comment, params:=params, returns:="")
+
+      Dim generic = GetGenericName(1, entityCount = 1)
+
+      builder.Indent().AppendLine($"Public Function UnionAll(<DisallowNull> queryExpression As FormattableString) As CustomSetSelectSqlExpression(Of {generic})").PushIndent()
+      builder.Indent().AppendLine("Return InternalSet(SetOperator.UnionAll, queryExpression)").PopIndent()
+      builder.Indent().AppendLine("End Function")
+    End Sub
+
+    Protected Sub GenerateCustomUnionAllWithRawSqlString(builder As CodeBuilder, entityCount As Int32)
+      Dim comment = "Adds UNION ALL operator."
+      Dim params = {"queryExpression", "parameters"}
+      AddComment(builder, comment, params:=params, returns:="")
+
+      Dim generic = GetGenericName(1, entityCount = 1)
+
+      builder.Indent().AppendLine($"Public Function UnionAll(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As CustomSetSelectSqlExpression(Of {generic})").PushIndent()
+      builder.Indent().AppendLine("Return InternalSet(SetOperator.UnionAll, queryExpression, parameters)").PopIndent()
+      builder.Indent().AppendLine("End Function")
+    End Sub
+
+    Protected Sub GenerateExceptWithSubquery(builder As CodeBuilder, entityCount As Int32)
+      Dim comment = "Adds EXCEPT operator."
+      Dim params = {"queryExpressionFactory"}
+      AddComment(builder, comment, params:=params, returns:="")
+
+      Dim generic = GetGenericName(1, entityCount = 1)
+
+      builder.Indent().AppendLine($"Public Function Except(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of {generic}))) As SetSelectSqlExpression(Of {generic})").PushIndent()
+      builder.Indent().AppendLine("Return InternalSet(SetOperator.Except, queryExpressionFactory)").PopIndent()
+      builder.Indent().AppendLine("End Function")
+    End Sub
+
+    Protected Sub GenerateExceptWithFormattableString(builder As CodeBuilder, entityCount As Int32)
+      Dim comment = "Adds EXCEPT operator."
+      Dim params = {"queryExpression"}
+      AddComment(builder, comment, params:=params, returns:="")
+
+      Dim generic = GetGenericName(1, entityCount = 1)
+
+      builder.Indent().AppendLine($"Public Function Except(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of {generic})").PushIndent()
+      builder.Indent().AppendLine("Return InternalSet(SetOperator.Except, queryExpression)").PopIndent()
+      builder.Indent().AppendLine("End Function")
+    End Sub
+
+    Protected Sub GenerateExceptWithRawSqlString(builder As CodeBuilder, entityCount As Int32)
+      Dim comment = "Adds EXCEPT operator."
+      Dim params = {"queryExpression", "parameters"}
+      AddComment(builder, comment, params:=params, returns:="")
+
+      Dim generic = GetGenericName(1, entityCount = 1)
+
+      builder.Indent().AppendLine($"Public Function Except(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of {generic})").PushIndent()
+      builder.Indent().AppendLine("Return InternalSet(SetOperator.Except, queryExpression, parameters)").PopIndent()
+      builder.Indent().AppendLine("End Function")
+    End Sub
+
+    Protected Sub GenerateCustomExceptWithSubquery(builder As CodeBuilder, entityCount As Int32)
+      Dim comment = "Adds EXCEPT operator."
+      Dim params = {"queryExpressionFactory"}
+      AddComment(builder, comment, params:=params, returns:="")
+
+      Dim generic = GetGenericName(1, entityCount = 1)
+
+      builder.Indent().AppendLine($"Public Function Except(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of {generic}))) As CustomSetSelectSqlExpression(Of {generic})").PushIndent()
+      builder.Indent().AppendLine("Return InternalSet(SetOperator.Except, queryExpressionFactory)").PopIndent()
+      builder.Indent().AppendLine("End Function")
+    End Sub
+
+    Protected Sub GenerateCustomExceptWithFormattableString(builder As CodeBuilder, entityCount As Int32)
+      Dim comment = "Adds EXCEPT operator."
+      Dim params = {"queryExpression"}
+      AddComment(builder, comment, params:=params, returns:="")
+
+      Dim generic = GetGenericName(1, entityCount = 1)
+
+      builder.Indent().AppendLine($"Public Function Except(<DisallowNull> queryExpression As FormattableString) As CustomSetSelectSqlExpression(Of {generic})").PushIndent()
+      builder.Indent().AppendLine("Return InternalSet(SetOperator.Except, queryExpression)").PopIndent()
+      builder.Indent().AppendLine("End Function")
+    End Sub
+
+    Protected Sub GenerateCustomExceptWithRawSqlString(builder As CodeBuilder, entityCount As Int32)
+      Dim comment = "Adds EXCEPT operator."
+      Dim params = {"queryExpression", "parameters"}
+      AddComment(builder, comment, params:=params, returns:="")
+
+      Dim generic = GetGenericName(1, entityCount = 1)
+
+      builder.Indent().AppendLine($"Public Function Except(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As CustomSetSelectSqlExpression(Of {generic})").PushIndent()
+      builder.Indent().AppendLine("Return InternalSet(SetOperator.Except, queryExpression, parameters)").PopIndent()
+      builder.Indent().AppendLine("End Function")
+    End Sub
+
+    Protected Sub GenerateIntersectWithSubquery(builder As CodeBuilder, entityCount As Int32)
+      Dim comment = "Adds INTERSECT operator."
+      Dim params = {"queryExpressionFactory"}
+      AddComment(builder, comment, params:=params, returns:="")
+
+      Dim generic = GetGenericName(1, entityCount = 1)
+
+      builder.Indent().AppendLine($"Public Function Intersect(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of {generic}))) As SetSelectSqlExpression(Of {generic})").PushIndent()
+      builder.Indent().AppendLine("Return InternalSet(SetOperator.Intersect, queryExpressionFactory)").PopIndent()
+      builder.Indent().AppendLine("End Function")
+    End Sub
+
+    Protected Sub GenerateIntersectWithFormattableString(builder As CodeBuilder, entityCount As Int32)
+      Dim comment = "Adds INTERSECT operator."
+      Dim params = {"queryExpression"}
+      AddComment(builder, comment, params:=params, returns:="")
+
+      Dim generic = GetGenericName(1, entityCount = 1)
+
+      builder.Indent().AppendLine($"Public Function Intersect(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of {generic})").PushIndent()
+      builder.Indent().AppendLine("Return InternalSet(SetOperator.Intersect, queryExpression)").PopIndent()
+      builder.Indent().AppendLine("End Function")
+    End Sub
+
+    Protected Sub GenerateIntersectWithRawSqlString(builder As CodeBuilder, entityCount As Int32)
+      Dim comment = "Adds INTERSECT operator."
+      Dim params = {"queryExpression", "parameters"}
+      AddComment(builder, comment, params:=params, returns:="")
+
+      Dim generic = GetGenericName(1, entityCount = 1)
+
+      builder.Indent().AppendLine($"Public Function Intersect(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of {generic})").PushIndent()
+      builder.Indent().AppendLine("Return InternalSet(SetOperator.Intersect, queryExpression, parameters)").PopIndent()
+      builder.Indent().AppendLine("End Function")
+    End Sub
+
+    Protected Sub GenerateCustomIntersectWithSubquery(builder As CodeBuilder, entityCount As Int32)
+      Dim comment = "Adds INTERSECT operator."
+      Dim params = {"queryExpressionFactory"}
+      AddComment(builder, comment, params:=params, returns:="")
+
+      Dim generic = GetGenericName(1, entityCount = 1)
+
+      builder.Indent().AppendLine($"Public Function Intersect(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of {generic}))) As CustomSetSelectSqlExpression(Of {generic})").PushIndent()
+      builder.Indent().AppendLine("Return InternalSet(SetOperator.Intersect, queryExpressionFactory)").PopIndent()
+      builder.Indent().AppendLine("End Function")
+    End Sub
+
+    Protected Sub GenerateCustomIntersectWithFormattableString(builder As CodeBuilder, entityCount As Int32)
+      Dim comment = "Adds INTERSECT operator."
+      Dim params = {"queryExpression"}
+      AddComment(builder, comment, params:=params, returns:="")
+
+      Dim generic = GetGenericName(1, entityCount = 1)
+
+      builder.Indent().AppendLine($"Public Function Intersect(<DisallowNull> queryExpression As FormattableString) As CustomSetSelectSqlExpression(Of {generic})").PushIndent()
+      builder.Indent().AppendLine("Return InternalSet(SetOperator.Intersect, queryExpression)").PopIndent()
+      builder.Indent().AppendLine("End Function")
+    End Sub
+
+    Protected Sub GenerateCustomIntersectWithRawSqlString(builder As CodeBuilder, entityCount As Int32)
+      Dim comment = "Adds INTERSECT operator."
+      Dim params = {"queryExpression", "parameters"}
+      AddComment(builder, comment, params:=params, returns:="")
+
+      Dim generic = GetGenericName(1, entityCount = 1)
+
+      builder.Indent().AppendLine($"Public Function Intersect(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As CustomSetSelectSqlExpression(Of {generic})").PushIndent()
+      builder.Indent().AppendLine("Return InternalSet(SetOperator.Intersect, queryExpression, parameters)").PopIndent()
+      builder.Indent().AppendLine("End Function")
+    End Sub
+
+    Protected Sub GenerateInternalSetWithSubquery(builder As CodeBuilder, entityCount As Int32)
+      Dim comment = "Adds set operator."
+      Dim params = {"setOperator", "queryExpressionFactory"}
+      AddComment(builder, comment, params:=params, returns:="")
+
+      Dim generic = GetGenericName(1, entityCount = 1)
+
+      builder.Indent().AppendLine($"Private Function InternalSet(setOperator As SetOperator, queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of {generic}))) As SetSelectSqlExpression(Of {generic})").PushIndent()
+      builder.Indent().AppendLine($"Me.Builder.AddSet(Of {generic})(Me.Executor, setOperator, queryExpressionFactory)")
+      builder.Indent().AppendLine($"Return New SetSelectSqlExpression(Of {generic})(Me.Builder, Me.Executor)").PopIndent()
+      builder.Indent().AppendLine("End Function")
+    End Sub
+
+    Protected Sub GenerateInternalSetWithFormattableString(builder As CodeBuilder, entityCount As Int32)
+      Dim comment = "Adds set operator."
+      Dim params = {"setOperator", "queryExpression"}
+      AddComment(builder, comment, params:=params, returns:="")
+
+      Dim generic = GetGenericName(1, entityCount = 1)
+
+      builder.Indent().AppendLine($"Private Function InternalSet(setOperator As SetOperator, queryExpression As FormattableString) As SetSelectSqlExpression(Of {generic})").PushIndent()
+      builder.Indent().AppendLine($"Me.Builder.AddSet(Of {generic})(setOperator, queryExpression)")
+      builder.Indent().AppendLine($"Return New SetSelectSqlExpression(Of {generic})(Me.Builder, Me.Executor)").PopIndent()
+      builder.Indent().AppendLine("End Function")
+    End Sub
+
+    Protected Sub GenerateInternalSetWithRawSqlString(builder As CodeBuilder, entityCount As Int32)
+      Dim comment = "Adds set operator."
+      Dim params = {"setOperator", "queryExpression", "parameters"}
+      AddComment(builder, comment, params:=params, returns:="")
+
+      Dim generic = GetGenericName(1, entityCount = 1)
+
+      builder.Indent().AppendLine($"Private Function InternalSet(setOperator As SetOperator, queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of {generic})").PushIndent()
+      builder.Indent().AppendLine($"Me.Builder.AddSet(Of {generic})(setOperator, queryExpression, parameters)")
+      builder.Indent().AppendLine($"Return New SetSelectSqlExpression(Of {generic})(Me.Builder, Me.Executor)").PopIndent()
+      builder.Indent().AppendLine("End Function")
+    End Sub
+
+    Protected Sub GenerateCustomInternalSetWithSubquery(builder As CodeBuilder, entityCount As Int32)
+      Dim comment = "Adds set operator."
+      Dim params = {"setOperator", "queryExpressionFactory"}
+      AddComment(builder, comment, params:=params, returns:="")
+
+      Dim generic = GetGenericName(1, entityCount = 1)
+
+      builder.Indent().AppendLine($"Private Function InternalSet(setOperator As SetOperator, queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of {generic}))) As CustomSetSelectSqlExpression(Of {generic})").PushIndent()
+      builder.Indent().AppendLine($"Me.Builder.AddSet(Of {generic})(Me.Executor, setOperator, queryExpressionFactory)")
+      builder.Indent().AppendLine($"Return New CustomSetSelectSqlExpression(Of {generic})(Me.Builder, Me.Executor)").PopIndent()
+      builder.Indent().AppendLine("End Function")
+    End Sub
+
+    Protected Sub GenerateCustomInternalSetWithFormattableString(builder As CodeBuilder, entityCount As Int32)
+      Dim comment = "Adds set operator."
+      Dim params = {"setOperator", "queryExpression"}
+      AddComment(builder, comment, params:=params, returns:="")
+
+      Dim generic = GetGenericName(1, entityCount = 1)
+
+      builder.Indent().AppendLine($"Private Function InternalSet(setOperator As SetOperator, queryExpression As FormattableString) As CustomSetSelectSqlExpression(Of {generic})").PushIndent()
+      builder.Indent().AppendLine($"Me.Builder.AddSet(Of {generic})(setOperator, queryExpression)")
+      builder.Indent().AppendLine($"Return New CustomSetSelectSqlExpression(Of {generic})(Me.Builder, Me.Executor)").PopIndent()
+      builder.Indent().AppendLine("End Function")
+    End Sub
+
+    Protected Sub GenerateCustomInternalSetWithRawSqlString(builder As CodeBuilder, entityCount As Int32)
+      Dim comment = "Adds set operator."
+      Dim params = {"setOperator", "queryExpression", "parameters"}
+      AddComment(builder, comment, params:=params, returns:="")
+
+      Dim generic = GetGenericName(1, entityCount = 1)
+
+      builder.Indent().AppendLine($"Private Function InternalSet(setOperator As SetOperator, queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As CustomSetSelectSqlExpression(Of {generic})").PushIndent()
+      builder.Indent().AppendLine($"Me.Builder.AddSet(Of {generic})(setOperator, queryExpression, parameters)")
+      builder.Indent().AppendLine($"Return New CustomSetSelectSqlExpression(Of {generic})(Me.Builder, Me.Executor)").PopIndent()
+      builder.Indent().AppendLine("End Function")
+    End Sub
+
+  End Class
+End Namespace

--- a/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.vb
+++ b/Source/Source/Yamo.CodeGenerator/Generator/CodeGenerator.vb
@@ -69,6 +69,10 @@ Namespace Generator
           Return "CustomSelectSqlExpression"
         Case GeneratedClass.CustomDistinctSelectSqlExpression
           Return "CustomDistinctSelectSqlExpression"
+        Case GeneratedClass.SetSelectSqlExpression
+          Return "SetSelectSqlExpression"
+        Case GeneratedClass.CustomSetSelectSqlExpression
+          Return "CustomSetSelectSqlExpression"
         Case GeneratedClass.Join
           Return "Join"
         Case Else

--- a/Source/Source/Yamo.CodeGenerator/Generator/CustomDistinctSelectSqlExpressionCodeGenerator.vb
+++ b/Source/Source/Yamo.CodeGenerator/Generator/CustomDistinctSelectSqlExpressionCodeGenerator.vb
@@ -16,6 +16,7 @@
       builder.Indent().AppendLine("Imports System.Linq.Expressions")
       builder.Indent().AppendLine("Imports Yamo.Expressions.Builders")
       builder.Indent().AppendLine("Imports Yamo.Internal.Query")
+      builder.Indent().AppendLine("Imports Yamo.Internal.Query.Metadata")
       builder.AppendLine()
       builder.Indent().AppendLine("Namespace Expressions").PushIndent()
       builder.AppendLine()
@@ -31,6 +32,12 @@
       builder.Indent().AppendLine($"Implements ISubqueryableSelectSqlExpression(Of {generic})")
       builder.AppendLine()
       GenerateConstructor(builder, entityCount)
+      builder.AppendLine()
+
+      GenerateCustomSet(builder, entityCount)
+      builder.AppendLine()
+
+      GenerateIf(builder, entityCount)
       builder.AppendLine()
 
       GenerateToSubquery(builder, entityCount)

--- a/Source/Source/Yamo.CodeGenerator/Generator/CustomSelectSqlExpressionCodeGenerator.vb
+++ b/Source/Source/Yamo.CodeGenerator/Generator/CustomSelectSqlExpressionCodeGenerator.vb
@@ -9,7 +9,8 @@
 
     Protected Overrides Function GetAllowedResultsForCondition() As GeneratedClass()
       Return {
-        GeneratedClass.CustomDistinctSelectSqlExpression
+        GeneratedClass.CustomDistinctSelectSqlExpression,
+        GeneratedClass.CustomSetSelectSqlExpression
       }
     End Function
 
@@ -18,6 +19,7 @@
       builder.Indent().AppendLine("Imports System.Linq.Expressions")
       builder.Indent().AppendLine("Imports Yamo.Expressions.Builders")
       builder.Indent().AppendLine("Imports Yamo.Internal.Query")
+      builder.Indent().AppendLine("Imports Yamo.Internal.Query.Metadata")
       builder.AppendLine()
       builder.Indent().AppendLine("Namespace Expressions").PushIndent()
       builder.AppendLine()
@@ -36,6 +38,12 @@
       builder.AppendLine()
 
       GenerateCustomDistinct(builder, entityCount)
+      builder.AppendLine()
+
+      GenerateCustomSet(builder, entityCount)
+      builder.AppendLine()
+
+      GenerateIf(builder, entityCount)
       builder.AppendLine()
 
       GenerateToSubquery(builder, entityCount)

--- a/Source/Source/Yamo.CodeGenerator/Generator/CustomSetSelectSqlExpressionCodeGenerator.vb
+++ b/Source/Source/Yamo.CodeGenerator/Generator/CustomSetSelectSqlExpressionCodeGenerator.vb
@@ -1,6 +1,6 @@
 ﻿Namespace Generator
 
-  Public Class SelectedSelectSqlExpressionCodeGenerator
+  Public Class CustomSetSelectSqlExpressionCodeGenerator
     Inherits CodeGenerator
 
     Public Sub New(indentation As String, outputFolder As String, definition As GeneratedClassDefinition, definitions As List(Of GeneratedClassDefinition))
@@ -9,9 +9,7 @@
 
     Protected Overrides Function GetAllowedResultsForCondition() As GeneratedClass()
       Return {
-        GeneratedClass.SelectedSelectSqlExpression,
-        GeneratedClass.DistinctSelectSqlExpression,
-        GeneratedClass.SetSelectSqlExpression
+        GeneratedClass.CustomSetSelectSqlExpression
       }
     End Function
 
@@ -25,7 +23,7 @@
       builder.Indent().AppendLine("Namespace Expressions").PushIndent()
       builder.AppendLine()
 
-      Dim comment = "Represents SELECT clause in SQL SELECT statement."
+      Dim comment = "Represents set operator in SQL SELECT statement."
       Dim typeParams = GetGenericNames(entityCount)
       AddComment(builder, comment, typeParams:=typeParams)
 
@@ -38,16 +36,7 @@
       GenerateConstructor(builder, entityCount)
       builder.AppendLine()
 
-      GenerateExclude(builder, entityCount)
-      builder.AppendLine()
-
-      GenerateInclude(builder, entityCount)
-      builder.AppendLine()
-
-      GenerateDistinct(builder, entityCount)
-      builder.AppendLine()
-
-      GenerateSet(builder, entityCount)
+      GenerateCustomSet(builder, entityCount)
       builder.AppendLine()
 
       GenerateIf(builder, entityCount)
@@ -56,10 +45,10 @@
       GenerateToSubquery(builder, entityCount)
       builder.AppendLine()
 
-      GenerateToList(builder, entityCount)
+      GenerateCustomToList(builder, entityCount)
       builder.AppendLine()
 
-      GenerateFirstOrDefault(builder, entityCount)
+      GenerateCustomFirstOrDefault(builder, entityCount)
       builder.AppendLine()
 
       builder.PopIndent()

--- a/Source/Source/Yamo.CodeGenerator/Generator/DistinctSelectSqlExpressionCodeGenerator.vb
+++ b/Source/Source/Yamo.CodeGenerator/Generator/DistinctSelectSqlExpressionCodeGenerator.vb
@@ -16,6 +16,7 @@
       builder.Indent().AppendLine("Imports System.Linq.Expressions")
       builder.Indent().AppendLine("Imports Yamo.Expressions.Builders")
       builder.Indent().AppendLine("Imports Yamo.Internal.Query")
+      builder.Indent().AppendLine("Imports Yamo.Internal.Query.Metadata")
       builder.AppendLine()
       builder.Indent().AppendLine("Namespace Expressions").PushIndent()
       builder.AppendLine()
@@ -31,6 +32,12 @@
       builder.Indent().AppendLine($"Implements ISubqueryableSelectSqlExpression(Of {generic})")
       builder.AppendLine()
       GenerateConstructor(builder, entityCount)
+      builder.AppendLine()
+
+      GenerateSet(builder, entityCount)
+      builder.AppendLine()
+
+      GenerateIf(builder, entityCount)
       builder.AppendLine()
 
       GenerateToSubquery(builder, entityCount)

--- a/Source/Source/Yamo.CodeGenerator/Generator/GeneratedClass.vb
+++ b/Source/Source/Yamo.CodeGenerator/Generator/GeneratedClass.vb
@@ -15,6 +15,8 @@
     DistinctSelectSqlExpression
     CustomSelectSqlExpression
     CustomDistinctSelectSqlExpression
+    SetSelectSqlExpression
+    CustomSetSelectSqlExpression
     Join
   End Enum
 End Namespace

--- a/Source/Source/Yamo.CodeGenerator/Generator/SetSelectSqlExpressionCodeGenerator.vb
+++ b/Source/Source/Yamo.CodeGenerator/Generator/SetSelectSqlExpressionCodeGenerator.vb
@@ -1,6 +1,6 @@
 ﻿Namespace Generator
 
-  Public Class SelectedSelectSqlExpressionCodeGenerator
+  Public Class SetSelectSqlExpressionCodeGenerator
     Inherits CodeGenerator
 
     Public Sub New(indentation As String, outputFolder As String, definition As GeneratedClassDefinition, definitions As List(Of GeneratedClassDefinition))
@@ -9,8 +9,6 @@
 
     Protected Overrides Function GetAllowedResultsForCondition() As GeneratedClass()
       Return {
-        GeneratedClass.SelectedSelectSqlExpression,
-        GeneratedClass.DistinctSelectSqlExpression,
         GeneratedClass.SetSelectSqlExpression
       }
     End Function
@@ -25,7 +23,7 @@
       builder.Indent().AppendLine("Namespace Expressions").PushIndent()
       builder.AppendLine()
 
-      Dim comment = "Represents SELECT clause in SQL SELECT statement."
+      Dim comment = "Represents set operator in SQL SELECT statement."
       Dim typeParams = GetGenericNames(entityCount)
       AddComment(builder, comment, typeParams:=typeParams)
 
@@ -36,15 +34,6 @@
       builder.Indent().AppendLine($"Implements ISubqueryableSelectSqlExpression(Of {generic})")
       builder.AppendLine()
       GenerateConstructor(builder, entityCount)
-      builder.AppendLine()
-
-      GenerateExclude(builder, entityCount)
-      builder.AppendLine()
-
-      GenerateInclude(builder, entityCount)
-      builder.AppendLine()
-
-      GenerateDistinct(builder, entityCount)
       builder.AppendLine()
 
       GenerateSet(builder, entityCount)

--- a/Source/Source/Yamo.CodeGenerator/Program.vb
+++ b/Source/Source/Yamo.CodeGenerator/Program.vb
@@ -25,6 +25,8 @@ Module Program
     Dim distinctSelectSqlExpressionDefinition = New GeneratedClassDefinition(GeneratedClass.DistinctSelectSqlExpression, 1)
     Dim customSelectSqlExpressionDefinition = New GeneratedClassDefinition(GeneratedClass.CustomSelectSqlExpression, 1)
     Dim customDistinctSelectSqlExpressionDefinition = New GeneratedClassDefinition(GeneratedClass.CustomDistinctSelectSqlExpression, 1)
+    Dim setSelectSqlExpressionDefinition = New GeneratedClassDefinition(GeneratedClass.SetSelectSqlExpression, 1)
+    Dim customSetSelectSqlExpressionDefinition = New GeneratedClassDefinition(GeneratedClass.CustomSetSelectSqlExpression, 1)
     Dim joinDefinition = New GeneratedClassDefinition(GeneratedClass.Join, 2, maxEntityCount)
 
     Dim definitions = New List(Of GeneratedClassDefinition) From {
@@ -42,6 +44,8 @@ Module Program
       distinctSelectSqlExpressionDefinition,
       customSelectSqlExpressionDefinition,
       customDistinctSelectSqlExpressionDefinition,
+      setSelectSqlExpressionDefinition,
+      customSetSelectSqlExpressionDefinition,
       joinDefinition
     }
 
@@ -52,6 +56,9 @@ Module Program
 
     Dim customSelectSqlExpressionCodeGenerator = New CustomSelectSqlExpressionCodeGenerator(indentation, expressionsFolder, customSelectSqlExpressionDefinition, definitions)
     customSelectSqlExpressionCodeGenerator.Generate()
+
+    Dim customSetSelectSqlExpressionCodeGenerator = New CustomSetSelectSqlExpressionCodeGenerator(indentation, expressionsFolder, customSetSelectSqlExpressionDefinition, definitions)
+    customSetSelectSqlExpressionCodeGenerator.Generate()
 
     Dim distinctSelectSqlExpressionCodeGenerator = New DistinctSelectSqlExpressionCodeGenerator(indentation, expressionsFolder, distinctSelectSqlExpressionDefinition, definitions)
     distinctSelectSqlExpressionCodeGenerator.Generate()
@@ -85,6 +92,9 @@ Module Program
 
     Dim selectSqlExpressionCodeGenerator = New SelectSqlExpressionCodeGenerator(indentation, expressionsFolder, selectSqlExpressionDefinition, definitions)
     selectSqlExpressionCodeGenerator.Generate()
+
+    Dim setSelectSqlExpressionCodeGenerator = New SetSelectSqlExpressionCodeGenerator(indentation, expressionsFolder, setSelectSqlExpressionDefinition, definitions)
+    setSelectSqlExpressionCodeGenerator.Generate()
 
     Dim withHintsSelectSqlExpressionCodeGenerator = New WithHintsSelectSqlExpressionCodeGenerator(indentation, expressionsFolder, withHintsSqlExpressionDefinition, definitions)
     withHintsSelectSqlExpressionCodeGenerator.Generate()

--- a/Source/Source/Yamo/Expressions/CustomDistinctSelectSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/CustomDistinctSelectSqlExpression.vb
@@ -2,6 +2,7 @@
 Imports System.Linq.Expressions
 Imports Yamo.Expressions.Builders
 Imports Yamo.Internal.Query
+Imports Yamo.Internal.Query.Metadata
 
 Namespace Expressions
 
@@ -21,6 +22,210 @@ Namespace Expressions
     Friend Sub New(builder As SelectSqlExpressionBuilder, executor As QueryExecutor)
       MyBase.New(builder, executor)
     End Sub
+
+    ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T))) As CustomSetSelectSqlExpression(Of T)
+      Return InternalSet(SetOperator.Union, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpression As FormattableString) As CustomSetSelectSqlExpression(Of T)
+      Return InternalSet(SetOperator.Union, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As CustomSetSelectSqlExpression(Of T)
+      Return InternalSet(SetOperator.Union, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T))) As CustomSetSelectSqlExpression(Of T)
+      Return InternalSet(SetOperator.UnionAll, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpression As FormattableString) As CustomSetSelectSqlExpression(Of T)
+      Return InternalSet(SetOperator.UnionAll, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As CustomSetSelectSqlExpression(Of T)
+      Return InternalSet(SetOperator.UnionAll, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T))) As CustomSetSelectSqlExpression(Of T)
+      Return InternalSet(SetOperator.Except, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpression As FormattableString) As CustomSetSelectSqlExpression(Of T)
+      Return InternalSet(SetOperator.Except, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As CustomSetSelectSqlExpression(Of T)
+      Return InternalSet(SetOperator.Except, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T))) As CustomSetSelectSqlExpression(Of T)
+      Return InternalSet(SetOperator.Intersect, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpression As FormattableString) As CustomSetSelectSqlExpression(Of T)
+      Return InternalSet(SetOperator.Intersect, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As CustomSetSelectSqlExpression(Of T)
+      Return InternalSet(SetOperator.Intersect, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T))) As CustomSetSelectSqlExpression(Of T)
+      Me.Builder.AddSet(Of T)(Me.Executor, setOperator, queryExpressionFactory)
+      Return New CustomSetSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpression As FormattableString) As CustomSetSelectSqlExpression(Of T)
+      Me.Builder.AddSet(Of T)(setOperator, queryExpression)
+      Return New CustomSetSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As CustomSetSelectSqlExpression(Of T)
+      Me.Builder.AddSet(Of T)(setOperator, queryExpression, parameters)
+      Return New CustomSetSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Conditionally builds the expression.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="condition"></param>
+    ''' <param name="[then]"></param>
+    ''' <param name="otherwise"></param>
+    ''' <returns></returns>
+    Public Function [If](Of TResult)(condition As Boolean, <DisallowNull> [then] As Func(Of CustomDistinctSelectSqlExpression(Of T), TResult), Optional otherwise As Func(Of CustomDistinctSelectSqlExpression(Of T), TResult) = Nothing) As TResult
+      If condition Then
+        Return [then].Invoke(Me)
+      ElseIf otherwise Is Nothing Then
+        Return CreateResultForCondition(Of TResult)()
+      Else
+        Return otherwise.Invoke(Me)
+      End If
+    End Function
+
+    ''' <summary>
+    ''' Creates result for condition if condition is not met.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <returns></returns>
+    Private Function CreateResultForCondition(Of TResult)() As TResult
+      Dim thisType = Me.GetType()
+      Dim resultType = GetType(TResult)
+
+      If thisType Is resultType Then
+        Return DirectCast(DirectCast(Me, Object), TResult)
+      End If
+
+      If Not CanCreateResultForCondition(resultType) Then
+        Throw New InvalidOperationException($"Parameter 'otherwise' in If() method is required for return type '{resultType}'.")
+      End If
+
+      Return DirectCast(Activator.CreateInstance(resultType, Reflection.BindingFlags.NonPublic Or Reflection.BindingFlags.Instance, Nothing, {Me.Builder, Me.Executor}, Nothing), TResult)
+    End Function
+
+    ''' <summary>
+    ''' Checks if result can be created if condition is not met.
+    ''' </summary>
+    ''' <param name="resultType"></param>
+    ''' <returns></returns>
+    Private Function CanCreateResultForCondition(resultType As Type) As Boolean
+      If Not GetType(SelectSqlExpressionBase).IsAssignableFrom(resultType) Then
+        Return False
+      End If
+
+      If Not resultType.IsGenericType Then
+        Return False
+      End If
+
+      Dim genericType = resultType.GetGenericTypeDefinition()
+
+
+      Return False
+    End Function
 
     ''' <summary>
     ''' Creates SQL subquery.

--- a/Source/Source/Yamo/Expressions/CustomSetSelectSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/CustomSetSelectSqlExpression.vb
@@ -7,30 +7,21 @@ Imports Yamo.Internal.Query.Metadata
 Namespace Expressions
 
   ''' <summary>
-  ''' Represents SELECT clause in SQL SELECT statement.
+  ''' Represents set operator in SQL SELECT statement.
   ''' </summary>
   ''' <typeparam name="T"></typeparam>
-  Public Class CustomSelectSqlExpression(Of T)
+  Public Class CustomSetSelectSqlExpression(Of T)
     Inherits SelectSqlExpressionBase
     Implements ISubqueryableSelectSqlExpression(Of T)
 
     ''' <summary>
-    ''' Creates new instance of <see cref="CustomSelectSqlExpression(Of T)"/>.
+    ''' Creates new instance of <see cref="CustomSetSelectSqlExpression(Of T)"/>.
     ''' </summary>
     ''' <param name="builder"></param>
     ''' <param name="executor"></param>
     Friend Sub New(builder As SelectSqlExpressionBuilder, executor As QueryExecutor)
       MyBase.New(builder, executor)
     End Sub
-
-    ''' <summary>
-    ''' Adds DISTINCT clause.
-    ''' </summary>
-    ''' <returns></returns>
-    Public Function Distinct() As CustomDistinctSelectSqlExpression(Of T)
-      Me.Builder.AddDistinct()
-      Return New CustomDistinctSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
-    End Function
 
     ''' <summary>
     ''' Adds UNION operator.
@@ -186,7 +177,7 @@ Namespace Expressions
     ''' <param name="[then]"></param>
     ''' <param name="otherwise"></param>
     ''' <returns></returns>
-    Public Function [If](Of TResult)(condition As Boolean, <DisallowNull> [then] As Func(Of CustomSelectSqlExpression(Of T), TResult), Optional otherwise As Func(Of CustomSelectSqlExpression(Of T), TResult) = Nothing) As TResult
+    Public Function [If](Of TResult)(condition As Boolean, <DisallowNull> [then] As Func(Of CustomSetSelectSqlExpression(Of T), TResult), Optional otherwise As Func(Of CustomSetSelectSqlExpression(Of T), TResult) = Nothing) As TResult
       If condition Then
         Return [then].Invoke(Me)
       ElseIf otherwise Is Nothing Then
@@ -232,7 +223,6 @@ Namespace Expressions
 
       Dim genericType = resultType.GetGenericTypeDefinition()
 
-      If genericType Is GetType(CustomDistinctSelectSqlExpression(Of )) Then Return True
       If genericType Is GetType(CustomSetSelectSqlExpression(Of )) Then Return True
 
       Return False

--- a/Source/Source/Yamo/Expressions/DistinctSelectSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/DistinctSelectSqlExpression.vb
@@ -2,6 +2,7 @@
 Imports System.Linq.Expressions
 Imports Yamo.Expressions.Builders
 Imports Yamo.Internal.Query
+Imports Yamo.Internal.Query.Metadata
 
 Namespace Expressions
 
@@ -21,6 +22,210 @@ Namespace Expressions
     Friend Sub New(builder As SelectSqlExpressionBuilder, executor As QueryExecutor)
       MyBase.New(builder, executor)
     End Sub
+
+    ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T))) As SetSelectSqlExpression(Of T)
+      Return InternalSet(SetOperator.Union, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T)
+      Return InternalSet(SetOperator.Union, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T)
+      Return InternalSet(SetOperator.Union, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T))) As SetSelectSqlExpression(Of T)
+      Return InternalSet(SetOperator.UnionAll, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T)
+      Return InternalSet(SetOperator.UnionAll, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T)
+      Return InternalSet(SetOperator.UnionAll, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T))) As SetSelectSqlExpression(Of T)
+      Return InternalSet(SetOperator.Except, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T)
+      Return InternalSet(SetOperator.Except, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T)
+      Return InternalSet(SetOperator.Except, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T))) As SetSelectSqlExpression(Of T)
+      Return InternalSet(SetOperator.Intersect, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T)
+      Return InternalSet(SetOperator.Intersect, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T)
+      Return InternalSet(SetOperator.Intersect, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T))) As SetSelectSqlExpression(Of T)
+      Me.Builder.AddSet(Of T)(Me.Executor, setOperator, queryExpressionFactory)
+      Return New SetSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpression As FormattableString) As SetSelectSqlExpression(Of T)
+      Me.Builder.AddSet(Of T)(setOperator, queryExpression)
+      Return New SetSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T)
+      Me.Builder.AddSet(Of T)(setOperator, queryExpression, parameters)
+      Return New SetSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Conditionally builds the expression.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <param name="condition"></param>
+    ''' <param name="[then]"></param>
+    ''' <param name="otherwise"></param>
+    ''' <returns></returns>
+    Public Function [If](Of TResult)(condition As Boolean, <DisallowNull> [then] As Func(Of DistinctSelectSqlExpression(Of T), TResult), Optional otherwise As Func(Of DistinctSelectSqlExpression(Of T), TResult) = Nothing) As TResult
+      If condition Then
+        Return [then].Invoke(Me)
+      ElseIf otherwise Is Nothing Then
+        Return CreateResultForCondition(Of TResult)()
+      Else
+        Return otherwise.Invoke(Me)
+      End If
+    End Function
+
+    ''' <summary>
+    ''' Creates result for condition if condition is not met.
+    ''' </summary>
+    ''' <typeparam name="TResult"></typeparam>
+    ''' <returns></returns>
+    Private Function CreateResultForCondition(Of TResult)() As TResult
+      Dim thisType = Me.GetType()
+      Dim resultType = GetType(TResult)
+
+      If thisType Is resultType Then
+        Return DirectCast(DirectCast(Me, Object), TResult)
+      End If
+
+      If Not CanCreateResultForCondition(resultType) Then
+        Throw New InvalidOperationException($"Parameter 'otherwise' in If() method is required for return type '{resultType}'.")
+      End If
+
+      Return DirectCast(Activator.CreateInstance(resultType, Reflection.BindingFlags.NonPublic Or Reflection.BindingFlags.Instance, Nothing, {Me.Builder, Me.Executor}, Nothing), TResult)
+    End Function
+
+    ''' <summary>
+    ''' Checks if result can be created if condition is not met.
+    ''' </summary>
+    ''' <param name="resultType"></param>
+    ''' <returns></returns>
+    Private Function CanCreateResultForCondition(resultType As Type) As Boolean
+      If Not GetType(SelectSqlExpressionBase).IsAssignableFrom(resultType) Then
+        Return False
+      End If
+
+      If Not resultType.IsGenericType Then
+        Return False
+      End If
+
+      Dim genericType = resultType.GetGenericTypeDefinition()
+
+
+      Return False
+    End Function
 
     ''' <summary>
     ''' Creates SQL subquery.

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpression.vb
@@ -2,6 +2,7 @@
 Imports System.Linq.Expressions
 Imports Yamo.Expressions.Builders
 Imports Yamo.Internal.Query
+Imports Yamo.Internal.Query.Metadata
 
 Namespace Expressions
 
@@ -96,6 +97,152 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T))) As SetSelectSqlExpression(Of T)
+      Return InternalSet(SetOperator.Union, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T)
+      Return InternalSet(SetOperator.Union, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T)
+      Return InternalSet(SetOperator.Union, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T))) As SetSelectSqlExpression(Of T)
+      Return InternalSet(SetOperator.UnionAll, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T)
+      Return InternalSet(SetOperator.UnionAll, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T)
+      Return InternalSet(SetOperator.UnionAll, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T))) As SetSelectSqlExpression(Of T)
+      Return InternalSet(SetOperator.Except, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T)
+      Return InternalSet(SetOperator.Except, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T)
+      Return InternalSet(SetOperator.Except, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T))) As SetSelectSqlExpression(Of T)
+      Return InternalSet(SetOperator.Intersect, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T)
+      Return InternalSet(SetOperator.Intersect, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T)
+      Return InternalSet(SetOperator.Intersect, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T))) As SetSelectSqlExpression(Of T)
+      Me.Builder.AddSet(Of T)(Me.Executor, setOperator, queryExpressionFactory)
+      Return New SetSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpression As FormattableString) As SetSelectSqlExpression(Of T)
+      Me.Builder.AddSet(Of T)(setOperator, queryExpression)
+      Return New SetSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T)
+      Me.Builder.AddSet(Of T)(setOperator, queryExpression, parameters)
+      Return New SetSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Conditionally builds the expression.
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
@@ -151,6 +298,7 @@ Namespace Expressions
 
       If genericType Is GetType(SelectedSelectSqlExpression(Of )) Then Return True
       If genericType Is GetType(DistinctSelectSqlExpression(Of )) Then Return True
+      If genericType Is GetType(SetSelectSqlExpression(Of )) Then Return True
 
       Return False
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2.vb
@@ -2,6 +2,7 @@
 Imports System.Linq.Expressions
 Imports Yamo.Expressions.Builders
 Imports Yamo.Internal.Query
+Imports Yamo.Internal.Query.Metadata
 
 Namespace Expressions
 
@@ -197,6 +198,152 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(Me.Executor, setOperator, queryExpressionFactory)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(setOperator, queryExpression)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(setOperator, queryExpression, parameters)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Conditionally builds the expression.
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
@@ -252,6 +399,7 @@ Namespace Expressions
 
       If genericType Is GetType(SelectedSelectSqlExpression(Of ,)) Then Return True
       If genericType Is GetType(DistinctSelectSqlExpression(Of )) Then Return True
+      If genericType Is GetType(SetSelectSqlExpression(Of )) Then Return True
 
       Return False
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3.vb
@@ -2,6 +2,7 @@
 Imports System.Linq.Expressions
 Imports Yamo.Expressions.Builders
 Imports Yamo.Internal.Query
+Imports Yamo.Internal.Query.Metadata
 
 Namespace Expressions
 
@@ -280,6 +281,152 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(Me.Executor, setOperator, queryExpressionFactory)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(setOperator, queryExpression)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(setOperator, queryExpression, parameters)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Conditionally builds the expression.
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
@@ -335,6 +482,7 @@ Namespace Expressions
 
       If genericType Is GetType(SelectedSelectSqlExpression(Of ,,)) Then Return True
       If genericType Is GetType(DistinctSelectSqlExpression(Of )) Then Return True
+      If genericType Is GetType(SetSelectSqlExpression(Of )) Then Return True
 
       Return False
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4.vb
@@ -2,6 +2,7 @@
 Imports System.Linq.Expressions
 Imports Yamo.Expressions.Builders
 Imports Yamo.Internal.Query
+Imports Yamo.Internal.Query.Metadata
 
 Namespace Expressions
 
@@ -385,6 +386,152 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(Me.Executor, setOperator, queryExpressionFactory)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(setOperator, queryExpression)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(setOperator, queryExpression, parameters)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Conditionally builds the expression.
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
@@ -440,6 +587,7 @@ Namespace Expressions
 
       If genericType Is GetType(SelectedSelectSqlExpression(Of ,,,)) Then Return True
       If genericType Is GetType(DistinctSelectSqlExpression(Of )) Then Return True
+      If genericType Is GetType(SetSelectSqlExpression(Of )) Then Return True
 
       Return False
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5.vb
@@ -2,6 +2,7 @@
 Imports System.Linq.Expressions
 Imports Yamo.Expressions.Builders
 Imports Yamo.Internal.Query
+Imports Yamo.Internal.Query.Metadata
 
 Namespace Expressions
 
@@ -512,6 +513,152 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(Me.Executor, setOperator, queryExpressionFactory)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(setOperator, queryExpression)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(setOperator, queryExpression, parameters)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Conditionally builds the expression.
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
@@ -567,6 +714,7 @@ Namespace Expressions
 
       If genericType Is GetType(SelectedSelectSqlExpression(Of ,,,,)) Then Return True
       If genericType Is GetType(DistinctSelectSqlExpression(Of )) Then Return True
+      If genericType Is GetType(SetSelectSqlExpression(Of )) Then Return True
 
       Return False
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6.vb
@@ -2,6 +2,7 @@
 Imports System.Linq.Expressions
 Imports Yamo.Expressions.Builders
 Imports Yamo.Internal.Query
+Imports Yamo.Internal.Query.Metadata
 
 Namespace Expressions
 
@@ -661,6 +662,152 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(Me.Executor, setOperator, queryExpressionFactory)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(setOperator, queryExpression)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(setOperator, queryExpression, parameters)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Conditionally builds the expression.
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
@@ -716,6 +863,7 @@ Namespace Expressions
 
       If genericType Is GetType(SelectedSelectSqlExpression(Of ,,,,,)) Then Return True
       If genericType Is GetType(DistinctSelectSqlExpression(Of )) Then Return True
+      If genericType Is GetType(SetSelectSqlExpression(Of )) Then Return True
 
       Return False
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7.vb
@@ -2,6 +2,7 @@
 Imports System.Linq.Expressions
 Imports Yamo.Expressions.Builders
 Imports Yamo.Internal.Query
+Imports Yamo.Internal.Query.Metadata
 
 Namespace Expressions
 
@@ -832,6 +833,152 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(Me.Executor, setOperator, queryExpressionFactory)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(setOperator, queryExpression)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(setOperator, queryExpression, parameters)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Conditionally builds the expression.
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
@@ -887,6 +1034,7 @@ Namespace Expressions
 
       If genericType Is GetType(SelectedSelectSqlExpression(Of ,,,,,,)) Then Return True
       If genericType Is GetType(DistinctSelectSqlExpression(Of )) Then Return True
+      If genericType Is GetType(SetSelectSqlExpression(Of )) Then Return True
 
       Return False
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8.vb
@@ -2,6 +2,7 @@
 Imports System.Linq.Expressions
 Imports Yamo.Expressions.Builders
 Imports Yamo.Internal.Query
+Imports Yamo.Internal.Query.Metadata
 
 Namespace Expressions
 
@@ -1025,6 +1026,152 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(Me.Executor, setOperator, queryExpressionFactory)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(setOperator, queryExpression)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(setOperator, queryExpression, parameters)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Conditionally builds the expression.
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
@@ -1080,6 +1227,7 @@ Namespace Expressions
 
       If genericType Is GetType(SelectedSelectSqlExpression(Of ,,,,,,,)) Then Return True
       If genericType Is GetType(DistinctSelectSqlExpression(Of )) Then Return True
+      If genericType Is GetType(SetSelectSqlExpression(Of )) Then Return True
 
       Return False
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9.vb
@@ -2,6 +2,7 @@
 Imports System.Linq.Expressions
 Imports Yamo.Expressions.Builders
 Imports Yamo.Internal.Query
+Imports Yamo.Internal.Query.Metadata
 
 Namespace Expressions
 
@@ -1240,6 +1241,152 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(Me.Executor, setOperator, queryExpressionFactory)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(setOperator, queryExpression)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(setOperator, queryExpression, parameters)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Conditionally builds the expression.
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
@@ -1295,6 +1442,7 @@ Namespace Expressions
 
       If genericType Is GetType(SelectedSelectSqlExpression(Of ,,,,,,,,)) Then Return True
       If genericType Is GetType(DistinctSelectSqlExpression(Of )) Then Return True
+      If genericType Is GetType(SetSelectSqlExpression(Of )) Then Return True
 
       Return False
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10.vb
@@ -2,6 +2,7 @@
 Imports System.Linq.Expressions
 Imports Yamo.Expressions.Builders
 Imports Yamo.Internal.Query
+Imports Yamo.Internal.Query.Metadata
 
 Namespace Expressions
 
@@ -1477,6 +1478,152 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(Me.Executor, setOperator, queryExpressionFactory)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(setOperator, queryExpression)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(setOperator, queryExpression, parameters)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Conditionally builds the expression.
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
@@ -1532,6 +1679,7 @@ Namespace Expressions
 
       If genericType Is GetType(SelectedSelectSqlExpression(Of ,,,,,,,,,)) Then Return True
       If genericType Is GetType(DistinctSelectSqlExpression(Of )) Then Return True
+      If genericType Is GetType(SetSelectSqlExpression(Of )) Then Return True
 
       Return False
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11.vb
@@ -2,6 +2,7 @@
 Imports System.Linq.Expressions
 Imports Yamo.Expressions.Builders
 Imports Yamo.Internal.Query
+Imports Yamo.Internal.Query.Metadata
 
 Namespace Expressions
 
@@ -1736,6 +1737,152 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(Me.Executor, setOperator, queryExpressionFactory)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(setOperator, queryExpression)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(setOperator, queryExpression, parameters)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Conditionally builds the expression.
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
@@ -1791,6 +1938,7 @@ Namespace Expressions
 
       If genericType Is GetType(SelectedSelectSqlExpression(Of ,,,,,,,,,,)) Then Return True
       If genericType Is GetType(DistinctSelectSqlExpression(Of )) Then Return True
+      If genericType Is GetType(SetSelectSqlExpression(Of )) Then Return True
 
       Return False
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12.vb
@@ -2,6 +2,7 @@
 Imports System.Linq.Expressions
 Imports Yamo.Expressions.Builders
 Imports Yamo.Internal.Query
+Imports Yamo.Internal.Query.Metadata
 
 Namespace Expressions
 
@@ -2017,6 +2018,152 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(Me.Executor, setOperator, queryExpressionFactory)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(setOperator, queryExpression)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(setOperator, queryExpression, parameters)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Conditionally builds the expression.
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
@@ -2072,6 +2219,7 @@ Namespace Expressions
 
       If genericType Is GetType(SelectedSelectSqlExpression(Of ,,,,,,,,,,,)) Then Return True
       If genericType Is GetType(DistinctSelectSqlExpression(Of )) Then Return True
+      If genericType Is GetType(SetSelectSqlExpression(Of )) Then Return True
 
       Return False
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13.vb
@@ -2,6 +2,7 @@
 Imports System.Linq.Expressions
 Imports Yamo.Expressions.Builders
 Imports Yamo.Internal.Query
+Imports Yamo.Internal.Query.Metadata
 
 Namespace Expressions
 
@@ -2320,6 +2321,152 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(Me.Executor, setOperator, queryExpressionFactory)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(setOperator, queryExpression)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(setOperator, queryExpression, parameters)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Conditionally builds the expression.
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
@@ -2375,6 +2522,7 @@ Namespace Expressions
 
       If genericType Is GetType(SelectedSelectSqlExpression(Of ,,,,,,,,,,,,)) Then Return True
       If genericType Is GetType(DistinctSelectSqlExpression(Of )) Then Return True
+      If genericType Is GetType(SetSelectSqlExpression(Of )) Then Return True
 
       Return False
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14.vb
@@ -2,6 +2,7 @@
 Imports System.Linq.Expressions
 Imports Yamo.Expressions.Builders
 Imports Yamo.Internal.Query
+Imports Yamo.Internal.Query.Metadata
 
 Namespace Expressions
 
@@ -2645,6 +2646,152 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(Me.Executor, setOperator, queryExpressionFactory)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(setOperator, queryExpression)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(setOperator, queryExpression, parameters)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Conditionally builds the expression.
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
@@ -2700,6 +2847,7 @@ Namespace Expressions
 
       If genericType Is GetType(SelectedSelectSqlExpression(Of ,,,,,,,,,,,,,)) Then Return True
       If genericType Is GetType(DistinctSelectSqlExpression(Of )) Then Return True
+      If genericType Is GetType(SetSelectSqlExpression(Of )) Then Return True
 
       Return False
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15.vb
@@ -2,6 +2,7 @@
 Imports System.Linq.Expressions
 Imports Yamo.Expressions.Builders
 Imports Yamo.Internal.Query
+Imports Yamo.Internal.Query.Metadata
 
 Namespace Expressions
 
@@ -2992,6 +2993,152 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(Me.Executor, setOperator, queryExpressionFactory)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(setOperator, queryExpression)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(setOperator, queryExpression, parameters)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Conditionally builds the expression.
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
@@ -3047,6 +3194,7 @@ Namespace Expressions
 
       If genericType Is GetType(SelectedSelectSqlExpression(Of ,,,,,,,,,,,,,,)) Then Return True
       If genericType Is GetType(DistinctSelectSqlExpression(Of )) Then Return True
+      If genericType Is GetType(SetSelectSqlExpression(Of )) Then Return True
 
       Return False
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16.vb
@@ -2,6 +2,7 @@
 Imports System.Linq.Expressions
 Imports Yamo.Expressions.Builders
 Imports Yamo.Internal.Query
+Imports Yamo.Internal.Query.Metadata
 
 Namespace Expressions
 
@@ -3361,6 +3362,152 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(Me.Executor, setOperator, queryExpressionFactory)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(setOperator, queryExpression)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(setOperator, queryExpression, parameters)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Conditionally builds the expression.
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
@@ -3416,6 +3563,7 @@ Namespace Expressions
 
       If genericType Is GetType(SelectedSelectSqlExpression(Of ,,,,,,,,,,,,,,,)) Then Return True
       If genericType Is GetType(DistinctSelectSqlExpression(Of )) Then Return True
+      If genericType Is GetType(SetSelectSqlExpression(Of )) Then Return True
 
       Return False
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17.vb
@@ -2,6 +2,7 @@
 Imports System.Linq.Expressions
 Imports Yamo.Expressions.Builders
 Imports Yamo.Internal.Query
+Imports Yamo.Internal.Query.Metadata
 
 Namespace Expressions
 
@@ -3752,6 +3753,152 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(Me.Executor, setOperator, queryExpressionFactory)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(setOperator, queryExpression)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(setOperator, queryExpression, parameters)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Conditionally builds the expression.
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
@@ -3807,6 +3954,7 @@ Namespace Expressions
 
       If genericType Is GetType(SelectedSelectSqlExpression(Of ,,,,,,,,,,,,,,,,)) Then Return True
       If genericType Is GetType(DistinctSelectSqlExpression(Of )) Then Return True
+      If genericType Is GetType(SetSelectSqlExpression(Of )) Then Return True
 
       Return False
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18.vb
@@ -2,6 +2,7 @@
 Imports System.Linq.Expressions
 Imports Yamo.Expressions.Builders
 Imports Yamo.Internal.Query
+Imports Yamo.Internal.Query.Metadata
 
 Namespace Expressions
 
@@ -4165,6 +4166,152 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(Me.Executor, setOperator, queryExpressionFactory)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(setOperator, queryExpression)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(setOperator, queryExpression, parameters)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Conditionally builds the expression.
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
@@ -4220,6 +4367,7 @@ Namespace Expressions
 
       If genericType Is GetType(SelectedSelectSqlExpression(Of ,,,,,,,,,,,,,,,,,)) Then Return True
       If genericType Is GetType(DistinctSelectSqlExpression(Of )) Then Return True
+      If genericType Is GetType(SetSelectSqlExpression(Of )) Then Return True
 
       Return False
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19.vb
@@ -2,6 +2,7 @@
 Imports System.Linq.Expressions
 Imports Yamo.Expressions.Builders
 Imports Yamo.Internal.Query
+Imports Yamo.Internal.Query.Metadata
 
 Namespace Expressions
 
@@ -4600,6 +4601,152 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(Me.Executor, setOperator, queryExpressionFactory)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(setOperator, queryExpression)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(setOperator, queryExpression, parameters)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Conditionally builds the expression.
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
@@ -4655,6 +4802,7 @@ Namespace Expressions
 
       If genericType Is GetType(SelectedSelectSqlExpression(Of ,,,,,,,,,,,,,,,,,,)) Then Return True
       If genericType Is GetType(DistinctSelectSqlExpression(Of )) Then Return True
+      If genericType Is GetType(SetSelectSqlExpression(Of )) Then Return True
 
       Return False
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20.vb
@@ -2,6 +2,7 @@
 Imports System.Linq.Expressions
 Imports Yamo.Expressions.Builders
 Imports Yamo.Internal.Query
+Imports Yamo.Internal.Query.Metadata
 
 Namespace Expressions
 
@@ -5057,6 +5058,152 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(Me.Executor, setOperator, queryExpressionFactory)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(setOperator, queryExpression)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(setOperator, queryExpression, parameters)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Conditionally builds the expression.
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
@@ -5112,6 +5259,7 @@ Namespace Expressions
 
       If genericType Is GetType(SelectedSelectSqlExpression(Of ,,,,,,,,,,,,,,,,,,,)) Then Return True
       If genericType Is GetType(DistinctSelectSqlExpression(Of )) Then Return True
+      If genericType Is GetType(SetSelectSqlExpression(Of )) Then Return True
 
       Return False
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21.vb
@@ -2,6 +2,7 @@
 Imports System.Linq.Expressions
 Imports Yamo.Expressions.Builders
 Imports Yamo.Internal.Query
+Imports Yamo.Internal.Query.Metadata
 
 Namespace Expressions
 
@@ -5536,6 +5537,152 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(Me.Executor, setOperator, queryExpressionFactory)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(setOperator, queryExpression)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(setOperator, queryExpression, parameters)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Conditionally builds the expression.
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
@@ -5591,6 +5738,7 @@ Namespace Expressions
 
       If genericType Is GetType(SelectedSelectSqlExpression(Of ,,,,,,,,,,,,,,,,,,,,)) Then Return True
       If genericType Is GetType(DistinctSelectSqlExpression(Of )) Then Return True
+      If genericType Is GetType(SetSelectSqlExpression(Of )) Then Return True
 
       Return False
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22.vb
@@ -2,6 +2,7 @@
 Imports System.Linq.Expressions
 Imports Yamo.Expressions.Builders
 Imports Yamo.Internal.Query
+Imports Yamo.Internal.Query.Metadata
 
 Namespace Expressions
 
@@ -6037,6 +6038,152 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(Me.Executor, setOperator, queryExpressionFactory)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(setOperator, queryExpression)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(setOperator, queryExpression, parameters)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Conditionally builds the expression.
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
@@ -6092,6 +6239,7 @@ Namespace Expressions
 
       If genericType Is GetType(SelectedSelectSqlExpression(Of ,,,,,,,,,,,,,,,,,,,,,)) Then Return True
       If genericType Is GetType(DistinctSelectSqlExpression(Of )) Then Return True
+      If genericType Is GetType(SetSelectSqlExpression(Of )) Then Return True
 
       Return False
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23.vb
@@ -2,6 +2,7 @@
 Imports System.Linq.Expressions
 Imports Yamo.Expressions.Builders
 Imports Yamo.Internal.Query
+Imports Yamo.Internal.Query.Metadata
 
 Namespace Expressions
 
@@ -6560,6 +6561,152 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(Me.Executor, setOperator, queryExpressionFactory)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(setOperator, queryExpression)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(setOperator, queryExpression, parameters)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Conditionally builds the expression.
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
@@ -6615,6 +6762,7 @@ Namespace Expressions
 
       If genericType Is GetType(SelectedSelectSqlExpression(Of ,,,,,,,,,,,,,,,,,,,,,,)) Then Return True
       If genericType Is GetType(DistinctSelectSqlExpression(Of )) Then Return True
+      If genericType Is GetType(SetSelectSqlExpression(Of )) Then Return True
 
       Return False
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24.vb
@@ -2,6 +2,7 @@
 Imports System.Linq.Expressions
 Imports Yamo.Expressions.Builders
 Imports Yamo.Internal.Query
+Imports Yamo.Internal.Query.Metadata
 
 Namespace Expressions
 
@@ -7105,6 +7106,152 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(Me.Executor, setOperator, queryExpressionFactory)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(setOperator, queryExpression)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(setOperator, queryExpression, parameters)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Conditionally builds the expression.
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
@@ -7160,6 +7307,7 @@ Namespace Expressions
 
       If genericType Is GetType(SelectedSelectSqlExpression(Of ,,,,,,,,,,,,,,,,,,,,,,,)) Then Return True
       If genericType Is GetType(DistinctSelectSqlExpression(Of )) Then Return True
+      If genericType Is GetType(SetSelectSqlExpression(Of )) Then Return True
 
       Return False
     End Function

--- a/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
+++ b/Source/Source/Yamo/Expressions/SelectedSelectSqlExpressionOfT1T2T3T4T5T6T7T8T9T10T11T12T13T14T15T16T17T18T19T20T21T22T23T24T25.vb
@@ -2,6 +2,7 @@
 Imports System.Linq.Expressions
 Imports Yamo.Expressions.Builders
 Imports Yamo.Internal.Query
+Imports Yamo.Internal.Query.Metadata
 
 Namespace Expressions
 
@@ -7672,6 +7673,152 @@ Namespace Expressions
     End Function
 
     ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Union(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Union, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds UNION ALL operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function UnionAll(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.UnionAll, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds EXCEPT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Except(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Except, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpressionFactory)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpression)
+    End Function
+
+    ''' <summary>
+    ''' Adds INTERSECT operator.
+    ''' </summary>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Public Function Intersect(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Return InternalSet(SetOperator.Intersect, queryExpression, parameters)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpressionFactory"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T1))) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(Me.Executor, setOperator, queryExpressionFactory)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpression"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpression As FormattableString) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(setOperator, queryExpression)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
+    ''' Adds set operator.
+    ''' </summary>
+    ''' <param name="setOperator"></param>
+    ''' <param name="queryExpression"></param>
+    ''' <param name="parameters"></param>
+    ''' <returns></returns>
+    Private Function InternalSet(setOperator As SetOperator, queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T1)
+      Me.Builder.AddSet(Of T1)(setOperator, queryExpression, parameters)
+      Return New SetSelectSqlExpression(Of T1)(Me.Builder, Me.Executor)
+    End Function
+
+    ''' <summary>
     ''' Conditionally builds the expression.
     ''' </summary>
     ''' <typeparam name="TResult"></typeparam>
@@ -7727,6 +7874,7 @@ Namespace Expressions
 
       If genericType Is GetType(SelectedSelectSqlExpression(Of ,,,,,,,,,,,,,,,,,,,,,,,,)) Then Return True
       If genericType Is GetType(DistinctSelectSqlExpression(Of )) Then Return True
+      If genericType Is GetType(SetSelectSqlExpression(Of )) Then Return True
 
       Return False
     End Function

--- a/Source/Source/Yamo/Expressions/SetSelectSqlExpression.vb
+++ b/Source/Source/Yamo/Expressions/SetSelectSqlExpression.vb
@@ -7,15 +7,15 @@ Imports Yamo.Internal.Query.Metadata
 Namespace Expressions
 
   ''' <summary>
-  ''' Represents SELECT clause in SQL SELECT statement.
+  ''' Represents set operator in SQL SELECT statement.
   ''' </summary>
   ''' <typeparam name="T"></typeparam>
-  Public Class CustomSelectSqlExpression(Of T)
+  Public Class SetSelectSqlExpression(Of T)
     Inherits SelectSqlExpressionBase
     Implements ISubqueryableSelectSqlExpression(Of T)
 
     ''' <summary>
-    ''' Creates new instance of <see cref="CustomSelectSqlExpression(Of T)"/>.
+    ''' Creates new instance of <see cref="SetSelectSqlExpression(Of T)"/>.
     ''' </summary>
     ''' <param name="builder"></param>
     ''' <param name="executor"></param>
@@ -24,20 +24,11 @@ Namespace Expressions
     End Sub
 
     ''' <summary>
-    ''' Adds DISTINCT clause.
-    ''' </summary>
-    ''' <returns></returns>
-    Public Function Distinct() As CustomDistinctSelectSqlExpression(Of T)
-      Me.Builder.AddDistinct()
-      Return New CustomDistinctSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
-    End Function
-
-    ''' <summary>
     ''' Adds UNION operator.
     ''' </summary>
     ''' <param name="queryExpressionFactory"></param>
     ''' <returns></returns>
-    Public Function Union(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T))) As CustomSetSelectSqlExpression(Of T)
+    Public Function Union(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T))) As SetSelectSqlExpression(Of T)
       Return InternalSet(SetOperator.Union, queryExpressionFactory)
     End Function
 
@@ -46,7 +37,7 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="queryExpression"></param>
     ''' <returns></returns>
-    Public Function Union(<DisallowNull> queryExpression As FormattableString) As CustomSetSelectSqlExpression(Of T)
+    Public Function Union(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T)
       Return InternalSet(SetOperator.Union, queryExpression)
     End Function
 
@@ -56,7 +47,7 @@ Namespace Expressions
     ''' <param name="queryExpression"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function Union(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As CustomSetSelectSqlExpression(Of T)
+    Public Function Union(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T)
       Return InternalSet(SetOperator.Union, queryExpression, parameters)
     End Function
 
@@ -65,7 +56,7 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="queryExpressionFactory"></param>
     ''' <returns></returns>
-    Public Function UnionAll(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T))) As CustomSetSelectSqlExpression(Of T)
+    Public Function UnionAll(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T))) As SetSelectSqlExpression(Of T)
       Return InternalSet(SetOperator.UnionAll, queryExpressionFactory)
     End Function
 
@@ -74,7 +65,7 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="queryExpression"></param>
     ''' <returns></returns>
-    Public Function UnionAll(<DisallowNull> queryExpression As FormattableString) As CustomSetSelectSqlExpression(Of T)
+    Public Function UnionAll(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T)
       Return InternalSet(SetOperator.UnionAll, queryExpression)
     End Function
 
@@ -84,7 +75,7 @@ Namespace Expressions
     ''' <param name="queryExpression"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function UnionAll(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As CustomSetSelectSqlExpression(Of T)
+    Public Function UnionAll(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T)
       Return InternalSet(SetOperator.UnionAll, queryExpression, parameters)
     End Function
 
@@ -93,7 +84,7 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="queryExpressionFactory"></param>
     ''' <returns></returns>
-    Public Function Except(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T))) As CustomSetSelectSqlExpression(Of T)
+    Public Function Except(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T))) As SetSelectSqlExpression(Of T)
       Return InternalSet(SetOperator.Except, queryExpressionFactory)
     End Function
 
@@ -102,7 +93,7 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="queryExpression"></param>
     ''' <returns></returns>
-    Public Function Except(<DisallowNull> queryExpression As FormattableString) As CustomSetSelectSqlExpression(Of T)
+    Public Function Except(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T)
       Return InternalSet(SetOperator.Except, queryExpression)
     End Function
 
@@ -112,7 +103,7 @@ Namespace Expressions
     ''' <param name="queryExpression"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function Except(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As CustomSetSelectSqlExpression(Of T)
+    Public Function Except(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T)
       Return InternalSet(SetOperator.Except, queryExpression, parameters)
     End Function
 
@@ -121,7 +112,7 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="queryExpressionFactory"></param>
     ''' <returns></returns>
-    Public Function Intersect(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T))) As CustomSetSelectSqlExpression(Of T)
+    Public Function Intersect(<DisallowNull> queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T))) As SetSelectSqlExpression(Of T)
       Return InternalSet(SetOperator.Intersect, queryExpressionFactory)
     End Function
 
@@ -130,7 +121,7 @@ Namespace Expressions
     ''' </summary>
     ''' <param name="queryExpression"></param>
     ''' <returns></returns>
-    Public Function Intersect(<DisallowNull> queryExpression As FormattableString) As CustomSetSelectSqlExpression(Of T)
+    Public Function Intersect(<DisallowNull> queryExpression As FormattableString) As SetSelectSqlExpression(Of T)
       Return InternalSet(SetOperator.Intersect, queryExpression)
     End Function
 
@@ -140,7 +131,7 @@ Namespace Expressions
     ''' <param name="queryExpression"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Public Function Intersect(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As CustomSetSelectSqlExpression(Of T)
+    Public Function Intersect(<DisallowNull> queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T)
       Return InternalSet(SetOperator.Intersect, queryExpression, parameters)
     End Function
 
@@ -150,9 +141,9 @@ Namespace Expressions
     ''' <param name="setOperator"></param>
     ''' <param name="queryExpressionFactory"></param>
     ''' <returns></returns>
-    Private Function InternalSet(setOperator As SetOperator, queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T))) As CustomSetSelectSqlExpression(Of T)
+    Private Function InternalSet(setOperator As SetOperator, queryExpressionFactory As Func(Of SubqueryContext, ISubqueryableSelectSqlExpression(Of T))) As SetSelectSqlExpression(Of T)
       Me.Builder.AddSet(Of T)(Me.Executor, setOperator, queryExpressionFactory)
-      Return New CustomSetSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
+      Return New SetSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>
@@ -161,9 +152,9 @@ Namespace Expressions
     ''' <param name="setOperator"></param>
     ''' <param name="queryExpression"></param>
     ''' <returns></returns>
-    Private Function InternalSet(setOperator As SetOperator, queryExpression As FormattableString) As CustomSetSelectSqlExpression(Of T)
+    Private Function InternalSet(setOperator As SetOperator, queryExpression As FormattableString) As SetSelectSqlExpression(Of T)
       Me.Builder.AddSet(Of T)(setOperator, queryExpression)
-      Return New CustomSetSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
+      Return New SetSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>
@@ -173,9 +164,9 @@ Namespace Expressions
     ''' <param name="queryExpression"></param>
     ''' <param name="parameters"></param>
     ''' <returns></returns>
-    Private Function InternalSet(setOperator As SetOperator, queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As CustomSetSelectSqlExpression(Of T)
+    Private Function InternalSet(setOperator As SetOperator, queryExpression As RawSqlString, <DisallowNull> ParamArray parameters() As Object) As SetSelectSqlExpression(Of T)
       Me.Builder.AddSet(Of T)(setOperator, queryExpression, parameters)
-      Return New CustomSetSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
+      Return New SetSelectSqlExpression(Of T)(Me.Builder, Me.Executor)
     End Function
 
     ''' <summary>
@@ -186,7 +177,7 @@ Namespace Expressions
     ''' <param name="[then]"></param>
     ''' <param name="otherwise"></param>
     ''' <returns></returns>
-    Public Function [If](Of TResult)(condition As Boolean, <DisallowNull> [then] As Func(Of CustomSelectSqlExpression(Of T), TResult), Optional otherwise As Func(Of CustomSelectSqlExpression(Of T), TResult) = Nothing) As TResult
+    Public Function [If](Of TResult)(condition As Boolean, <DisallowNull> [then] As Func(Of SetSelectSqlExpression(Of T), TResult), Optional otherwise As Func(Of SetSelectSqlExpression(Of T), TResult) = Nothing) As TResult
       If condition Then
         Return [then].Invoke(Me)
       ElseIf otherwise Is Nothing Then
@@ -232,8 +223,7 @@ Namespace Expressions
 
       Dim genericType = resultType.GetGenericTypeDefinition()
 
-      If genericType Is GetType(CustomDistinctSelectSqlExpression(Of )) Then Return True
-      If genericType Is GetType(CustomSetSelectSqlExpression(Of )) Then Return True
+      If genericType Is GetType(SetSelectSqlExpression(Of )) Then Return True
 
       Return False
     End Function
@@ -252,16 +242,17 @@ Namespace Expressions
     ''' <returns></returns>
     Public Function ToList() As List(Of T)
       Dim query = Me.Builder.CreateQuery()
-      Return Me.Executor.ReadCustomList(Of T)(query)
+      Return Me.Executor.ReadList(Of T)(query)
     End Function
 
     ''' <summary>
     ''' Executes SQL query and returns first record or a default value.
     ''' </summary>
+    ''' <param name="behavior">Defines how collection navigation properties are filled. This setting has no effect if no collection navigation properties are used.</param>
     ''' <returns></returns>
-    Public Function FirstOrDefault() As <MaybeNull> T
+    Public Function FirstOrDefault(Optional behavior As CollectionNavigationFillBehavior = CollectionNavigationFillBehavior.ProcessOnlyFirstRow) As <MaybeNull> T
       Dim query = Me.Builder.CreateQuery()
-      Return Me.Executor.ReadCustomFirstOrDefault(Of T)(query)
+      Return Me.Executor.ReadFirstOrDefault(Of T)(query, behavior)
     End Function
 
   End Class

--- a/Source/Source/Yamo/Internal/Query/Metadata/SetOperator.vb
+++ b/Source/Source/Yamo/Internal/Query/Metadata/SetOperator.vb
@@ -1,0 +1,14 @@
+﻿Namespace Internal.Query.Metadata
+
+  ''' <summary>
+  ''' Set operator.<br/>
+  ''' This API supports Yamo infrastructure and is not intended to be used directly from your code.
+  ''' </summary>
+  Public Enum SetOperator
+    Union = 0
+    UnionAll = 1
+    Except = 2
+    Intersect = 3
+  End Enum
+
+End Namespace

--- a/Source/Test/Yamo.Test.SQLite/Tests/SelectWithSetTests.vb
+++ b/Source/Test/Yamo.Test.SQLite/Tests/SelectWithSetTests.vb
@@ -1,0 +1,14 @@
+﻿Imports Yamo.Test
+
+Namespace Tests
+
+  <TestClass()>
+  Public Class SelectWithSetTests
+    Inherits Yamo.Test.Tests.SelectWithSetTests
+
+    Protected Overrides Function CreateTestEnvironment() As ITestEnvironment
+      Return SQLiteTestEnvironment.Create()
+    End Function
+
+  End Class
+End Namespace

--- a/Source/Test/Yamo.Test.SqlServer/Tests/SelectWithSetTests.vb
+++ b/Source/Test/Yamo.Test.SqlServer/Tests/SelectWithSetTests.vb
@@ -1,0 +1,14 @@
+﻿Imports Yamo.Test
+
+Namespace Tests
+
+  <TestClass()>
+  Public Class SelectWithSetTests
+    Inherits Yamo.Test.Tests.SelectWithSetTests
+
+    Protected Overrides Function CreateTestEnvironment() As ITestEnvironment
+      Return SqlServerTestEnvironment.Create()
+    End Function
+
+  End Class
+End Namespace

--- a/Source/Test/Yamo.Test/Tests/SelectWithConditionTests.vb
+++ b/Source/Test/Yamo.Test/Tests/SelectWithConditionTests.vb
@@ -2788,6 +2788,109 @@ Namespace Tests
     End Sub
 
     <TestMethod()>
+    Public Overridable Sub SelectWithConditionalSet()
+      Dim items = CreateItems()
+
+      items(0).IntColumn = 1
+      items(1).IntColumn = 2
+      items(2).IntColumn = 3
+      items(3).IntColumn = 4
+      items(4).IntColumn = 5
+
+      InsertItems(items)
+
+      ' condition is true, apply true part
+      Using db = CreateDbContext()
+        Dim result = db.From(Of ItemWithAllSupportedValues).
+                        Where(Function(x) x.IntColumn <= 2).
+                        SelectAll().
+                        If(True,
+                        [then]:=Function(exp)
+                                  Return exp.Union(Function(c)
+                                                     Return c.From(Of ItemWithAllSupportedValues).
+                                                              Where(Function(x) 2 <= x.IntColumn AndAlso x.IntColumn <= 3).
+                                                              SelectAll()
+                                                   End Function)
+                                End Function
+                        ).
+                        ToList()
+
+        CollectionAssert.AreEquivalent({items(0), items(1), items(2)}, result)
+      End Using
+
+      ' condition is false, apply nothing
+      Using db = CreateDbContext()
+        Dim result = db.From(Of ItemWithAllSupportedValues).
+                        Where(Function(x) x.IntColumn <= 2).
+                        SelectAll().
+                        If(False,
+                        [then]:=Function(exp)
+                                  Return exp.Union(Function(c)
+                                                     Return c.From(Of ItemWithAllSupportedValues).
+                                                              Where(Function(x) 2 <= x.IntColumn AndAlso x.IntColumn <= 3).
+                                                              SelectAll()
+                                                   End Function)
+                                End Function
+                        ).
+                        ToList()
+
+        CollectionAssert.AreEquivalent({items(0), items(1)}, result)
+      End Using
+
+      ' condition is true, apply true part
+      Using db = CreateDbContext()
+        Dim result = db.From(Of ItemWithAllSupportedValues).
+                        Where(Function(x) x.IntColumn <= 2).
+                        SelectAll().
+                        If(True,
+                        [then]:=Function(exp)
+                                  Return exp.Union(Function(c)
+                                                     Return c.From(Of ItemWithAllSupportedValues).
+                                                              Where(Function(x) 2 <= x.IntColumn AndAlso x.IntColumn <= 3).
+                                                              SelectAll()
+                                                   End Function)
+                                End Function,
+                        otherwise:=Function(exp)
+                                     Return exp.Union(Function(c)
+                                                        Return c.From(Of ItemWithAllSupportedValues).
+                                                                 Where(Function(x) 4 <= x.IntColumn AndAlso x.IntColumn <= 5).
+                                                                 SelectAll()
+                                                      End Function)
+                                   End Function
+                        ).
+                        ToList()
+
+        CollectionAssert.AreEquivalent({items(0), items(1), items(2)}, result)
+      End Using
+
+      ' condition is false, apply false part
+      Using db = CreateDbContext()
+        Dim result = db.From(Of ItemWithAllSupportedValues).
+                        Where(Function(x) x.IntColumn <= 2).
+                        SelectAll().
+                        If(False,
+                        [then]:=Function(exp)
+                                  Return exp.Union(Function(c)
+                                                     Return c.From(Of ItemWithAllSupportedValues).
+                                                              Where(Function(x) 2 <= x.IntColumn AndAlso x.IntColumn <= 3).
+                                                              SelectAll()
+                                                   End Function)
+                                End Function,
+                        otherwise:=Function(exp)
+                                     Return exp.Union(Function(c)
+                                                        Return c.From(Of ItemWithAllSupportedValues).
+                                                                 Where(Function(x) 4 <= x.IntColumn AndAlso x.IntColumn <= 5).
+                                                                 SelectAll()
+                                                      End Function)
+                                   End Function
+                        ).
+                        ToList()
+
+        CollectionAssert.AreEquivalent({items(0), items(1), items(3), items(4)}, result)
+      End Using
+    End Sub
+
+    <TestMethod()>
     Public Overridable Sub SelectWithConditionalToList()
       Dim items = CreateItems()
 

--- a/Source/Test/Yamo.Test/Tests/SelectWithSetTests.vb
+++ b/Source/Test/Yamo.Test/Tests/SelectWithSetTests.vb
@@ -1,0 +1,294 @@
+﻿Imports Yamo.Test.Model
+
+Namespace Tests
+
+  Public MustInherit Class SelectWithSetTests
+    Inherits BaseIntegrationTests
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithUnionUsingSubquery()
+      Dim articles = CreateArticles()
+
+      InsertItems(articles)
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        Where(Function(x) x.Id <= 2).
+                        SelectAll().
+                        Union(Function(c)
+                                Return c.From(Of Article).
+                                         Where(Function(x) 2 <= x.Id AndAlso x.Id <= 3).
+                                         OrderBy(Function(x) x.Id).
+                                         SelectAll()
+                              End Function).
+                        ToList()
+
+        CollectionAssert.AreEqual({articles(0), articles(1), articles(2)}, result)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithUnionUsingFormattableString()
+      Dim articles = CreateArticles()
+
+      InsertItems(articles)
+
+      Dim filterFrom = 2
+      Dim filterTo = 3
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        Where(Function(x) x.Id <= 2).
+                        SelectAll().
+                        Union($"SELECT {Sql.Model.Columns(Of Article)} FROM Article WHERE {filterFrom} <= Id AND Id <= {filterTo} ORDER BY Id").
+                        ToList()
+
+        CollectionAssert.AreEqual({articles(0), articles(1), articles(2)}, result)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithUnionUsingRawSqlString()
+      Dim articles = CreateArticles()
+
+      InsertItems(articles)
+
+      Dim filterFrom = 2
+      Dim filterTo = 3
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        Where(Function(x) x.Id <= 2).
+                        SelectAll().
+                        Union("SELECT {0} FROM Article WHERE {1} <= Id AND Id <= {2} ORDER BY Id", Sql.Model.Columns(Of Article), filterFrom, filterTo).
+                        ToList()
+
+        CollectionAssert.AreEqual({articles(0), articles(1), articles(2)}, result)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithUnionAllUsingSubquery()
+      Dim articles = CreateArticles()
+
+      InsertItems(articles)
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        Where(Function(x) x.Id <= 2).
+                        SelectAll().
+                        UnionAll(Function(c)
+                                   Return c.From(Of Article).
+                                            Where(Function(x) 2 <= x.Id AndAlso x.Id <= 3).
+                                            OrderBy(Function(x) x.Id).
+                                            SelectAll()
+                                 End Function).
+                        ToList()
+
+        CollectionAssert.AreEqual({articles(0), articles(1), articles(1), articles(2)}, result)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithUnionAllUsingFormattableString()
+      Dim articles = CreateArticles()
+
+      InsertItems(articles)
+
+      Dim filterFrom = 2
+      Dim filterTo = 3
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        Where(Function(x) x.Id <= 2).
+                        SelectAll().
+                        UnionAll($"SELECT {Sql.Model.Columns(Of Article)} FROM Article WHERE {filterFrom} <= Id AND Id <= {filterTo} ORDER BY Id").
+                        ToList()
+
+        CollectionAssert.AreEqual({articles(0), articles(1), articles(1), articles(2)}, result)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithUnionAllUsingRawSqlString()
+      Dim articles = CreateArticles()
+
+      InsertItems(articles)
+
+      Dim filterFrom = 2
+      Dim filterTo = 3
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        Where(Function(x) x.Id <= 2).
+                        SelectAll().
+                        UnionAll("SELECT {0} FROM Article WHERE {1} <= Id AND Id <= {2} ORDER BY Id", Sql.Model.Columns(Of Article), filterFrom, filterTo).
+                        ToList()
+
+        CollectionAssert.AreEqual({articles(0), articles(1), articles(1), articles(2)}, result)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithExceptUsingSubquery()
+      Dim articles = CreateArticles()
+
+      InsertItems(articles)
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        Where(Function(x) x.Id <= 5).
+                        SelectAll().
+                        Except(Function(c)
+                                 Return c.From(Of Article).
+                                          Where(Function(x) 2 <= x.Id AndAlso x.Id <= 4).
+                                          OrderBy(Function(x) x.Id).
+                                          SelectAll()
+                               End Function).
+                        ToList()
+
+        CollectionAssert.AreEqual({articles(0), articles(4)}, result)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithExceptUsingFormattableString()
+      Dim articles = CreateArticles()
+
+      InsertItems(articles)
+
+      Dim filterFrom = 2
+      Dim filterTo = 4
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        Where(Function(x) x.Id <= 5).
+                        SelectAll().
+                        Except($"SELECT {Sql.Model.Columns(Of Article)} FROM Article WHERE {filterFrom} <= Id AND Id <= {filterTo} ORDER BY Id").
+                        ToList()
+
+        CollectionAssert.AreEqual({articles(0), articles(4)}, result)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithExceptUsingRawSqlString()
+      Dim articles = CreateArticles()
+
+      InsertItems(articles)
+
+      Dim filterFrom = 2
+      Dim filterTo = 4
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        Where(Function(x) x.Id <= 5).
+                        SelectAll().
+                        Except("SELECT {0} FROM Article WHERE {1} <= Id AND Id <= {2} ORDER BY Id", Sql.Model.Columns(Of Article), filterFrom, filterTo).
+                        ToList()
+
+        CollectionAssert.AreEqual({articles(0), articles(4)}, result)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithIntersectUsingSubquery()
+      Dim articles = CreateArticles()
+
+      InsertItems(articles)
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        Where(Function(x) x.Id <= 5).
+                        SelectAll().
+                        Intersect(Function(c)
+                                    Return c.From(Of Article).
+                                             Where(Function(x) 2 <= x.Id AndAlso x.Id <= 4).
+                                             OrderBy(Function(x) x.Id).
+                                             SelectAll()
+                                  End Function).
+                        ToList()
+
+        CollectionAssert.AreEqual({articles(1), articles(2), articles(3)}, result)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithIntersectUsingFormattableString()
+      Dim articles = CreateArticles()
+
+      InsertItems(articles)
+
+      Dim filterFrom = 2
+      Dim filterTo = 4
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        Where(Function(x) x.Id <= 5).
+                        SelectAll().
+                        Intersect($"SELECT {Sql.Model.Columns(Of Article)} FROM Article WHERE {filterFrom} <= Id AND Id <= {filterTo} ORDER BY Id").
+                        ToList()
+
+        CollectionAssert.AreEqual({articles(1), articles(2), articles(3)}, result)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithIntersectUsingRawSqlString()
+      Dim articles = CreateArticles()
+
+      InsertItems(articles)
+
+      Dim filterFrom = 2
+      Dim filterTo = 4
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        Where(Function(x) x.Id <= 5).
+                        SelectAll().
+                        Intersect("SELECT {0} FROM Article WHERE {1} <= Id AND Id <= {2} ORDER BY Id", Sql.Model.Columns(Of Article), filterFrom, filterTo).
+                        ToList()
+
+        CollectionAssert.AreEqual({articles(1), articles(2), articles(3)}, result)
+      End Using
+    End Sub
+
+    <TestMethod()>
+    Public Overridable Sub SelectWithMultipleSetOperators()
+      Dim articles = CreateArticles()
+
+      InsertItems(articles)
+
+      Using db = CreateDbContext()
+        Dim result = db.From(Of Article).
+                        Where(Function(x) x.Id = 3).
+                        SelectAll().
+                        UnionAll(Function(c)
+                                   Return c.From(Of Article).
+                                            Where(Function(x) x.Id = 2).
+                                            SelectAll()
+                                 End Function).
+                        UnionAll(Function(c)
+                                   Return c.From(Of Article).
+                                            Where(Function(x) x.Id = 1).
+                                            OrderBy(Function(x) x.Id).
+                                            SelectAll()
+                                 End Function).
+                        ToList()
+
+        CollectionAssert.AreEqual({articles(0), articles(1), articles(2)}, result)
+      End Using
+    End Sub
+
+    Protected Overridable Function CreateArticles() As List(Of Article)
+      Return New List(Of Article) From {
+        Me.ModelFactory.CreateArticle(1, 10),
+        Me.ModelFactory.CreateArticle(2, 20),
+        Me.ModelFactory.CreateArticle(3, 30),
+        Me.ModelFactory.CreateArticle(4, 40),
+        Me.ModelFactory.CreateArticle(5, 50)
+      }
+    End Function
+
+  End Class
+End Namespace


### PR DESCRIPTION
This PR adds support for `UNION`, `UNION ALL`, `EXCEPT` and `INTERSECT` set operators.

For each operator, there is a corresponding method available: `Union`, `UnionAll`, `Except` and `Intersect`. Methods accept query expression factory as their parameter. Similarly to other methods, there are also overloads that allow to use raw SQL in the form of `FormattableString` or `RawSqlString` (with optional parameters).

Here are the examples (where query expression factory is used):
```cs
using (var db = CreateContext())
{
    var list = db.From<Article>()
                 .Where(x => x.Price < 42)
                 .SelectAll()
                 .UnionAll(c =>
                 {
                     return c.From<Article>()
                             .Where(x => 420 < x.Price)
                             .SelectAll();
                 })
                 .ToList();
}
```

```cs
using (var db = CreateContext())
{
    var list = db.From(c =>
                 {
                     return c.From<Article>()
                             .SelectAll()
                             .UnionAll(c2 =>
                             {
                                 return c2.From<Article>("ArticleArchive")
                                          .SelectAll();
                             });
                 })
                 .SelectAll()
                 .ToList();
}
```
It is expected that each query expression will produce the same/compatible set of columns. To allow more use cases, it is not enforced to use the same join entities in each query expression. Only the result type must be the same. Therefore, be careful how you use `SelectAll` and `Select` methods.

The definition of the result (how the columns from the resultset are processed) is always taken from the main query expression.

In case you want to limit the rows in the resultset (`LIMIT` or `OFFSET`) or use the `ORDER BY` clause, do so the the last query expression. Just like you would write it in the normal SQL query.